### PR TITLE
Update the environment variable documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,21 @@ Example use cases:
 * Simple invocation and use
 * Runs on OS X, Linux and Windows
 * Monitors current directory and all subdirectories for changes
-	* Uses most efficient event polling mechanism for your platform (except for [BSD](https://github.com/passcod/rsnotify#todo))
+    * Uses most efficient event polling mechanism for your platform (except for [BSD](https://github.com/passcod/rsnotify#todo))
 * Coalesces multiple filesystem events into one, for editors that use swap/backup files during saving
 * By default, uses `.gitignore` to determine which files to ignore notifications for
 * Support for watching files with a specific extension
 * Support for filtering/ignoring events based on glob patterns
 * Launches child processes in a new process group
 * Sets the following environment variables in the child process:
-    * `$WATCHEXEC_UPDATED_PATH` the path of the first file that triggered a change
-    * `$WATCHEXEC_COMMON_PATH` the longest common path of all of the files that triggered a change
+    * If a single file changed (depending on the event type):
+        * `$WATCHEXEC_CREATED_PATH`, the path of the file that was created
+        * `$WATCHEXEC_REMOVED_PATH`, the path of the file that was removed
+        * `$WATCHEXEC_RENAMED_PATH`, the path of the file that was renamed
+        * `$WATCHEXEC_WRITTEN_PATH`, the path of the file that was modified
+        * `$WATCHEXEC_META_CHANGED_PATH`, the path of the file whose metadata changed
+    * If multiple files changed:
+        * `$WATCHEXEC_COMMON_PATH`, the longest common path of all of the files that triggered a change
 * Optionally clears screen between executions
 * Optionally restarts the command with every modification (good for servers)
 * Does not require a language runtime
@@ -40,7 +46,7 @@ Example use cases:
 
 Watch all JavaScript, CSS and HTML files in the current directory and all subdirectories for changes, running `make` when a change is detected:
 
-	$ watchexec --exts js,css,html make
+    $ watchexec --exts js,css,html make
 
 Call `make test` when any file changes in this directory/subdirectory, except for everything below `target`:
 


### PR DESCRIPTION
This makes the documentation reflect changes from commit 8bd9bb3.
This also converts indentation to spaces in the README (there was mixed indentation).

Closes https://github.com/mattgreen/watchexec/issues/86 and https://github.com/mattgreen/watchexec/issues/81.