### PR TITLE
Always canonicalize input paths

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,7 +145,11 @@ where
     };
 
     let cmd: Vec<String> = values_t!(args.values_of("command"), String)?;
-    let paths = values_t!(args.values_of("path"), PathBuf).unwrap_or(vec![".".into()]);
+    let paths = values_t!(args.values_of("path"), String)
+        .unwrap_or(vec![".".into()])
+        .iter()
+        .map(|string_path| string_path.into())
+        .collect();
 
     // Treat --kill as --signal SIGKILL (for compatibility with older syntax)
     let signal = if args.is_present("kill") {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,6 @@ use clap::{App, Arg, Error};
 use error;
 use std::{
     ffi::OsString,
-    fs::canonicalize,
     path::{PathBuf, MAIN_SEPARATOR},
     process::Command,
 };
@@ -146,11 +145,7 @@ where
     };
 
     let cmd: Vec<String> = values_t!(args.values_of("command"), String)?;
-    let str_paths = values_t!(args.values_of("path"), String).unwrap_or(vec![".".into()]);
-    let mut paths = vec![];
-    for path in str_paths {
-        paths.push(canonicalize(&path).map_err(|e| error::Error::Canonicalization(path, e))?);
-    }
+    let paths = values_t!(args.values_of("path"), PathBuf).unwrap_or(vec![".".into()]);
 
     // Treat --kill as --signal SIGKILL (for compatibility with older syntax)
     let signal = if args.is_present("kill") {


### PR DESCRIPTION
In some situations cargo-watch passes non-canonicalized paths into `watch`, and these aren't matched against the regex correctly. Because of this, it calls a Handler's `on_update` method even when an ignored file is changed.

I ran into this when using `cargo watch` with a `build.rs` script that edited a file in a git ignored folder. This caused an infinite loop because the build would update an ignored file, which would cause the build again. 

Here's a minimal repro repo: https://github.com/SpiralP/rust-cargo-watch-test


This used to be part of `watch` but was moved out in aae5a216b0b7d381b7c8af2d032f0b959757efbf.

https://github.com/watchexec/watchexec/commit/aae5a216b0b7d381b7c8af2d032f0b959757efbf#diff-8643ebb587e63cc619cd28e00be6a7e5L58 to https://github.com/watchexec/watchexec/commit/aae5a216b0b7d381b7c8af2d032f0b959757efbf#diff-dba02791b4baf8a328939029ac920005R140

