### PR TITLE
Update options in man page

### DIFF
--- a/doc/watchexec.1
+++ b/doc/watchexec.1
@@ -1,13 +1,13 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "WATCHEXEC" "1" "August 2018" "" ""
+.TH "WATCHEXEC" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBwatchexec\fR \- execute commands when watched files change
 .
 .SH "SYNOPSIS"
-watchexec [\fB\-\-exts\fR | \fB\-e\fR \fIextensions\fR]\.\.\. [\fB\-\-filter\fR | \fB\-f\fR \fIpattern\fR]\.\.\. [\fB\-\-ignore\fR | \fB\-i\fR \fIpattern\fR]\.\.\. [\fB\-\-watch\fR | \fB\-w\fR \fIpath\fR]\.\.\. [\fB\-\-restart\fR | \fB\-r\fR] [\fB\-\-clear\fR | \fB\-c\fR] [\fB\-\-postpone\fR | \fB\-p\fR] [\fB\-\-force\-poll\fR \fIinterval\fR] [\fB\-\-debug\fR | \fB\-d\fR] [\fB\-\-no\-vcs\-ignore\fR] [\fB\-\-no\-default\-ignore\fR] \fIcommand\fR [\fIargument\fR\.\.\.]
+watchexec [\fB\-\-exts\fR | \fB\-e\fR \fIextensions\fR]\.\.\. [\fB\-\-filter\fR | \fB\-f\fR \fIpattern\fR]\.\.\. [\fB\-\-ignore\fR | \fB\-i\fR \fIpattern\fR]\.\.\. [\fB\-\-watch\fR | \fB\-w\fR \fIpath\fR]\.\.\. [\fB\-\-restart\fR | \fB\-r\fR] [\fB\-\-clear\fR | \fB\-c\fR] [\fB\-\-postpone\fR | \fB\-p\fR] [\fB\-\-force\-poll\fR \fIinterval\fR] [\fB\-\-debounce\fR | \fB\-d\fR \fIinterval\fR] [\fB\-\-no\-vcs\-ignore\fR] [\fB\-\-no\-default\-ignore\fR] [\fB\-\-verbose\fR | \fB\-v\fR] [\fB\-\-version\fR | \fB\-V\fR] [\-\-] \fIcommand\fR [\fIargument\fR\.\.\.]
 .
 .SH "DESCRIPTION"
 Recursively monitors the current directory for changes, executing the command when a filesystem change is detected\. By default, watchexec uses efficient kernel\-level mechanisms to watch for changes\.
@@ -19,7 +19,7 @@ At startup, the specified \fIcommand\fR (passing any supplied \fIargument\fRs) i
 .
 .TP
 \fIcommand\fR
-Command to run when watched files are modified, and at startup, unless \fB\-\-postpone\fR is specified\. All \fIargument\fRs are passed to \fIcommand\fR\.
+Command to run when watched files are modified, and at startup, unless \fB\-\-postpone\fR is specified\. All \fIargument\fRs are passed to \fIcommand\fR\. If you pass flags to the command, you should separate it with \fB\-\-\fR, for example: \fBwatchexec \-w src \-\- rsync \-a src dest\fR\.
 .
 .TP
 \fB\-e\fR, \fB\-\-exts\fR \fIextensions\fR
@@ -58,12 +58,12 @@ Clears the screen before executing \fIcommand\fR\.
 Postpone execution of \fIcommand\fR until the first file modification is detected\.
 .
 .TP
-\fB\-d\fR, \fB\-\-debug\fR
-Prints diagnostic messages to STDERR
-.
-.TP
 \fB\-\-force\-poll\fR \fIinterval\fR
 Poll for changes every \fIinterval\fR ms instead of using system\-specific notification mechanisms (such as inotify)\. This is useful when you are monitoring NFS shares\.
+.
+.TP
+\fB\-d\fR, \fB\-\-debounce\fR
+Set the timeout between detected change and command execution, to avoid restarting too frequently when there are many events; defaults to 500ms\.
 .
 .TP
 \fB\-\-no\-vcs\-ignore\fR
@@ -72,6 +72,18 @@ Skip loading of version control system (VCS) ignore files\. By default, watchexe
 .TP
 \fB\-\-no\-default\-ignore\fR
 Skip default ignore statements\. By default, watchexec ignores common temporary files for you, for example \fB*\.swp\fR, \fB*\.pyc\fR, and \fB\.DS_Store\fR\.
+.
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Prints diagnostic messages to STDERR
+.
+.TP
+\fB\-V\fR, \fB\-\-version\fR
+Print the version of watchexec\.
+.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print a help message\.
 .
 .SH "ENVIRONMENT"
 Processes started by watchexec have environment variables set describing the modification(s) observed\. Which variable is set depends on how many modifications were observed and/or what type they were\.

--- a/doc/watchexec.1.html
+++ b/doc/watchexec.1.html
@@ -74,7 +74,7 @@
 
 <h2 id="SYNOPSIS">SYNOPSIS</h2>
 
-<p>watchexec [<code>--exts</code> | <code>-e</code> <var>extensions</var>]... [<code>--filter</code> | <code>-f</code> <var>pattern</var>]... [<code>--ignore</code> | <code>-i</code> <var>pattern</var>]... [<code>--watch</code> | <code>-w</code> <var>path</var>]... [<code>--restart</code> | <code>-r</code>] [<code>--clear</code> | <code>-c</code>] [<code>--postpone</code> | <code>-p</code>] [<code>--force-poll</code> <var>interval</var>] [<code>--debug</code> | <code>-d</code>] [<code>--no-vcs-ignore</code>] [<code>--no-default-ignore</code>] <var>command</var> [<var>argument</var>...]</p>
+<p>watchexec [<code>--exts</code> | <code>-e</code> <var>extensions</var>]... [<code>--filter</code> | <code>-f</code> <var>pattern</var>]... [<code>--ignore</code> | <code>-i</code> <var>pattern</var>]... [<code>--watch</code> | <code>-w</code> <var>path</var>]... [<code>--restart</code> | <code>-r</code>] [<code>--clear</code> | <code>-c</code>] [<code>--postpone</code> | <code>-p</code>] [<code>--force-poll</code> <var>interval</var>] [<code>--debounce</code> | <code>-d</code> <var>interval</var>] [<code>--no-vcs-ignore</code>] [<code>--no-default-ignore</code>] [<code>--verbose</code> | <code>-v</code>] [<code>--version</code> | <code>-V</code>] [--] <var>command</var> [<var>argument</var>...]</p>
 
 <h2 id="DESCRIPTION">DESCRIPTION</h2>
 
@@ -85,7 +85,7 @@
 <h2 id="OPTIONS">OPTIONS</h2>
 
 <dl>
-<dt class="flush"><var>command</var></dt><dd><p>Command to run when watched files are modified, and at startup, unless <code>--postpone</code> is specified. All <var>argument</var>s are passed to <var>command</var>.</p></dd>
+<dt class="flush"><var>command</var></dt><dd><p>Command to run when watched files are modified, and at startup, unless <code>--postpone</code> is specified. All <var>argument</var>s are passed to <var>command</var>. If you pass flags to the command, you should separate it with <code>--</code>, for example: <code>watchexec -w src -- rsync -a src dest</code>.</p></dd>
 <dt><code>-e</code>, <code>--exts</code> <var>extensions</var></dt><dd><p>Comma-separated list of file extensions to filter by. Leading dots are allowed (.rs) are allowed. (This is a shorthand for <code>-f</code>).</p></dd>
 <dt><code>-f</code>, <code>--filter</code> <var>pattern</var></dt><dd><p>Ignores modifications from paths that do not match <var>pattern</var>. This option can be specified multiple times, where a match on any given pattern causes the path to trigger <var>command</var>.</p></dd>
 <dt><code>-s</code>, <code>--signal</code></dt><dd><p>Sends the specified signal (e.g. <code>SIGKILL</code>) to the child process. Defaults to <code>SIGTERM</code>.</p></dd>
@@ -95,10 +95,13 @@
 <dt><code>-r</code>, <code>--restart</code></dt><dd><p>Terminates the child process group if it is still running when subsequent file modifications are detected. By default, sends <code>SIGTERM</code>; use <code>--kill</code> to send <code>SIGKILL</code>.</p></dd>
 <dt><code>-c</code>, <code>--clear</code></dt><dd><p>Clears the screen before executing <var>command</var>.</p></dd>
 <dt><code>-p</code>, <code>--postpone</code></dt><dd><p>Postpone execution of <var>command</var> until the first file modification is detected.</p></dd>
-<dt><code>-d</code>, <code>--debug</code></dt><dd><p>Prints diagnostic messages to STDERR</p></dd>
 <dt><code>--force-poll</code> <var>interval</var></dt><dd><p>Poll for changes every <var>interval</var> ms instead of using system-specific notification mechanisms (such as inotify). This is useful when you are monitoring NFS shares.</p></dd>
+<dt><code>-d</code>, <code>--debounce</code></dt><dd><p>Set the timeout between detected change and command execution, to avoid restarting too frequently when there are many events; defaults to 500ms.</p></dd>
 <dt><code>--no-vcs-ignore</code></dt><dd><p>Skip loading of version control system (VCS) ignore files. By default, watchexec loads .gitignore files in the current directory (or parent directories) and uses them to populate the ignore list.</p></dd>
 <dt><code>--no-default-ignore</code></dt><dd><p>Skip default ignore statements. By default, watchexec ignores common temporary files for you, for example <code>*.swp</code>, <code>*.pyc</code>, and <code>.DS_Store</code>.</p></dd>
+<dt><code>-v</code>, <code>--verbose</code></dt><dd><p>Prints diagnostic messages to STDERR</p></dd>
+<dt><code>-V</code>, <code>--version</code></dt><dd><p>Print the version of watchexec.</p></dd>
+<dt><code>-h</code>, <code>--help</code></dt><dd><p>Print a help message.</p></dd>
 </dl>
 
 
@@ -154,7 +157,7 @@
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>August 2018</li>
+    <li class='tc'>July 2019</li>
     <li class='tr'>watchexec(1)</li>
   </ol>
 

--- a/doc/watchexec.1.ronn
+++ b/doc/watchexec.1.ronn
@@ -3,7 +3,7 @@ watchexec(1) -- execute commands when watched files change
 
 ## SYNOPSIS
 
-watchexec [`--exts` | `-e` <extensions>]... [`--filter` | `-f` <pattern>]... [`--ignore` | `-i` <pattern>]... [`--watch` | `-w` <path>]... [`--restart` | `-r`] [`--clear` | `-c`] [`--postpone` | `-p`] [`--force-poll` <interval>] [`--debug` | `-d`] [`--no-vcs-ignore`] [`--no-default-ignore`] <command> [<argument>...]
+watchexec [`--exts` | `-e` <extensions>]... [`--filter` | `-f` <pattern>]... [`--ignore` | `-i` <pattern>]... [`--watch` | `-w` <path>]... [`--restart` | `-r`] [`--clear` | `-c`] [`--postpone` | `-p`] [`--force-poll` <interval>] [`--debounce` | `-d` <interval>] [`--no-vcs-ignore`] [`--no-default-ignore`] [`--verbose` | `-v`] [`--version` | `-V`] [--] <command> [<argument>...]
 
 ## DESCRIPTION
 
@@ -14,7 +14,7 @@ At startup, the specified <command> (passing any supplied <argument>s) is run on
 ## OPTIONS
 
 * <command>:
-Command to run when watched files are modified, and at startup, unless `--postpone` is specified. All <argument>s are passed to <command>.
+Command to run when watched files are modified, and at startup, unless `--postpone` is specified. All <argument>s are passed to <command>. If you pass flags to the command, you should separate it with `--`, for example: `watchexec -w src -- rsync -a src dest`.
 
 * `-e`, `--exts` <extensions>:
 Comma-separated list of file extensions to filter by. Leading dots are allowed (.rs) are allowed. (This is a shorthand for `-f`).
@@ -43,17 +43,26 @@ Clears the screen before executing <command>.
 * `-p`, `--postpone`:
 Postpone execution of <command> until the first file modification is detected.
 
-* `-d`, `--debug`:
-Prints diagnostic messages to STDERR
-
 * `--force-poll` <interval>:
 Poll for changes every <interval> ms instead of using system-specific notification mechanisms (such as inotify). This is useful when you are monitoring NFS shares.
+
+* `-d`, `--debounce`:
+Set the timeout between detected change and command execution, to avoid restarting too frequently when there are many events; defaults to 500ms.
 
 * `--no-vcs-ignore`:
 Skip loading of version control system (VCS) ignore files. By default, watchexec loads .gitignore files in the current directory (or parent directories) and uses them to populate the ignore list.
 
 * `--no-default-ignore`:
 Skip default ignore statements. By default, watchexec ignores common temporary files for you, for example `*.swp`, `*.pyc`, and `.DS_Store`.
+
+* `-v`, `--verbose`:
+Prints diagnostic messages to STDERR
+
+* `-V`, `--version`:
+Print the version of watchexec.
+
+* `-h`, `--help`:
+Print a help message.
 
 ## ENVIRONMENT
 


### PR DESCRIPTION
The options were out of date (e.g. `-d` was debug). This updates them to
match the help text.

This also adds some documentation about separating the command with --
so that clap doesn't eat the flags intended for the command.