### PR TITLE
Use --locked to ensure reproducibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ debug:	src/* Cargo.toml
 	@cargo build
 
 release: src/* Cargo.toml
-	@cargo build --release
+	@cargo build --release --locked
 
 clean:
 	@cargo clean

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ test_script:
 
 before_deploy:
   # Generate artifacts for release
-  - cargo build --release
+  - cargo build --release --locked
   - mkdir staging
   - copy target\release\watchexec.exe staging
   - copy LICENSE staging\LICENSE.txt

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -2,7 +2,7 @@
 
 # Build script shamelessly stolen from ripgrep :)
 
-cargo build --target $TARGET --release
+cargo build --target $TARGET --release --locked
 
 build_dir=$(mktemp -d 2>/dev/null || mktemp -d -t tmp)
 out_dir=$(pwd)


### PR DESCRIPTION
This is to ensure that binaries built in this way are built reproducibly.

This way you'll also know if you messed up a release by not running `cargo update` before tagging.