### PR TITLE
#123 --watch-idle flag implementation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,8 @@ pub struct Args {
     /// Interval for polling. (seconds)
     #[builder(default = "2")]
     pub poll_interval: u32,
+    #[builder(default)]
+    pub watch_idle: bool,
 }
 
 impl ArgsBuilder {
@@ -205,7 +207,11 @@ where
                  .help("Do not wrap command in 'sh -c' resp. 'cmd.exe /C'")
                  .short("n")
                  .long("no-shell"))
-        .arg(Arg::with_name("once").short("1").hidden(true));
+        .arg(Arg::with_name("once").short("1").hidden(true))
+        .arg(Arg::with_name("watch-idle")
+                 .help("Ignores commands while the process is still running")
+                 .short("W")
+                 .long("watch-idle"));
 
     let args = match from {
         None => app.get_matches(),
@@ -300,5 +306,6 @@ where
         once: args.is_present("once"),
         poll: args.occurrences_of("poll") > 0,
         poll_interval,
+        watch_idle: args.is_present("watch-idle"),
     })
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -209,7 +209,7 @@ where
                  .long("no-shell"))
         .arg(Arg::with_name("once").short("1").hidden(true))
         .arg(Arg::with_name("watch-when-idle")
-                 .help("Ignores commands while the process is still running")
+                 .help("Ignore events while the process is still running")
                  .short("W")
                  .long("watch-when-idle"));
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,7 +75,7 @@ pub struct Args {
     #[builder(default = "2")]
     pub poll_interval: u32,
     #[builder(default)]
-    pub watch_idle: bool,
+    pub watch_when_idle: bool,
 }
 
 impl ArgsBuilder {
@@ -208,10 +208,10 @@ where
                  .short("n")
                  .long("no-shell"))
         .arg(Arg::with_name("once").short("1").hidden(true))
-        .arg(Arg::with_name("watch-idle")
+        .arg(Arg::with_name("watch-when-idle")
                  .help("Ignores commands while the process is still running")
                  .short("W")
-                 .long("watch-idle"));
+                 .long("watch-when-idle"));
 
     let args = match from {
         None => app.get_matches(),
@@ -306,6 +306,6 @@ where
         once: args.is_present("once"),
         poll: args.occurrences_of("poll") > 0,
         poll_interval,
-        watch_idle: args.is_present("watch-idle"),
+        watch_when_idle: args.is_present("watch-when-idle"),
     })
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -236,7 +236,7 @@ impl Handler for ExecHandler {
             // Custom restart behaviour (--restart was given, and --signal specified):
             // Send specified signal to the child, wait for it to exit, then run the command again
             (true, true) => {
-                if self.args.watch_idle {
+                if self.args.watch_when_idle {
                     if !running_process {
                         self.spawn(ops)?;
                     }
@@ -251,7 +251,7 @@ impl Handler for ExecHandler {
             (true, false) => {
                 let sigterm = signal::new(Some("SIGTERM".into()));
 
-                if self.args.watch_idle {
+                if self.args.watch_when_idle {
                     if !running_process {
                         self.spawn(ops)?;
                     }
@@ -268,7 +268,7 @@ impl Handler for ExecHandler {
             // Default behaviour (neither --signal nor --restart specified):
             // Make sure the previous run was ended, then run the command again
             (false, false) => {
-                if self.args.watch_idle {
+                if self.args.watch_when_idle {
                     if !running_process {
                         self.spawn(ops)?;
                     }


### PR DESCRIPTION
Added the flag which allows to ignore incoming processes while some process is still in execution. Not sure if the implementation is correct regarding the 4 scenarios though. Would be great if someone could elaborate on that matter.