### PR TITLE
fix the ignore path handling to match the README by ignoring everything below a directory

### DIFF
--- a/src/notification_filter.rs
+++ b/src/notification_filter.rs
@@ -151,6 +151,8 @@ mod tests {
         // Make sure that sub-directories/-files are recursively ignored.
         assert!(filter.is_excluded(Path::new("target/rls")));
         assert!(filter.is_excluded(Path::new("target/rls/debug")));
+        // Assert that files containing subsets of the path are not ignored.
+        assert!(!filter.is_excluded(Path::new("target-file")));
         assert!(!filter.is_excluded(Path::new("hello.rs")));
         assert!(!filter.is_excluded(Path::new("Cargo.toml")));
     }


### PR DESCRIPTION
Currently there is a mismatch between the semantics described in the README and what is implemented. This PR fixes this.
I assumed the behavior from the README is more desirable, so I implemented that.


> Call `make test` when any file changes in this directory/subdirectory, except for everything below `target`:

    $ watchexec -i target make test
