### PR TITLE
add Kate (KDE default editor) swap file to default ignores

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -253,6 +253,7 @@ where
         String::from("*.py[co]"),
         String::from("#*#"),
         String::from(".#*"),
+        String::from(".*.kate-swp"),
         String::from(".*.sw?"),
         String::from(".*.sw?x"),
         format!("**{}.git{}**", MAIN_SEPARATOR, MAIN_SEPARATOR),


### PR DESCRIPTION
.filename.kate-swp format according to https://unix.stackexchange.com/a/112400
