### PR TITLE
Call init_logger from the binary code, not the library code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,23 @@
+use std::io::Write;
+
 extern crate watchexec;
 
 use watchexec::{cli, error, run};
 
 fn main() -> error::Result<()> {
     run(cli::get_args()?)
+}
+
+fn init_logger(debug: bool) {
+    let mut log_builder = env_logger::Builder::new();
+    let level = if debug {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Warn
+    };
+
+    log_builder
+        .format(|buf, r| writeln!(buf, "*** {}", r.args()))
+        .filter(None, level)
+        .init();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ extern crate watchexec;
 use watchexec::{cli, error, run};
 
 fn main() -> error::Result<()> {
-    run(cli::get_args()?)
+    let args = cli::get_args()?;
+    init_logger(args.debug);
+    run(args)
 }
 
 fn init_logger(debug: bool) {

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,27 +10,12 @@ use crate::watcher::{Event, Watcher};
 use std::{
     collections::HashMap,
     fs::canonicalize,
-    io::Write,
     sync::{
         mpsc::{channel, Receiver},
         Arc, RwLock,
     },
     time::Duration,
 };
-
-fn init_logger(debug: bool) {
-    let mut log_builder = env_logger::Builder::new();
-    let level = if debug {
-        log::LevelFilter::Debug
-    } else {
-        log::LevelFilter::Warn
-    };
-
-    log_builder
-        .format(|buf, r| writeln!(buf, "*** {}", r.args()))
-        .filter(None, level)
-        .init();
-}
 
 pub trait Handler {
     /// Called through a manual request, such as an initial run.
@@ -76,7 +61,6 @@ where
     H: Handler,
 {
     let args = handler.args();
-    init_logger(args.debug);
 
     let mut paths = vec![];
     for path in &args.paths {


### PR DESCRIPTION
Closes #159. This PR moves the call of `init_logger` out of the library portion of the code and into main.

Turned out to be very easy, and the usage of the `debug` flag is preserved.

I don't know what you want to do with the semver; this could be considered a breaking change in that any downstream clients that were using the lib and expecting to have logging initialised for them now need changing to do it themselves.