### PR TITLE
Fixed some clippy warnings

### DIFF
--- a/src/gitignore.rs
+++ b/src/gitignore.rs
@@ -97,7 +97,7 @@ impl Gitignore {
             .iter()
             .filter(|f| path.starts_with(&f.root))
             .collect();
-        applicable_files.sort_by(|l, r| l.root_len().cmp(&r.root_len()));
+        applicable_files.sort_by_key(|l| l.root_len());
 
         // TODO: add user gitignores
 

--- a/src/ignore.rs
+++ b/src/ignore.rs
@@ -103,7 +103,7 @@ impl Ignore {
             .iter()
             .filter(|f| path.starts_with(&f.root))
             .collect();
-        applicable_files.sort_by(|l, r| l.root_len().cmp(&r.root_len()));
+        applicable_files.sort_by_key(|l| l.root_len());
 
         // TODO: add user ignores
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,8 @@
 #![warn(
     clippy::all,
     clippy::missing_const_for_fn,
-    clippy::option_unwrap_used,
-    clippy::result_unwrap_used,
-    intra_doc_link_resolution_failure
+    clippy::unwrap_used,
+    broken_intra_doc_links
 )]
 
 #[macro_use]

--- a/src/process.rs
+++ b/src/process.rs
@@ -130,15 +130,13 @@ mod imp {
             unsafe {
                 command.pre_exec(|| setsid().map_err(from_nix_error).map(|_| ()));
             }
-            command.spawn().and_then(|p| {
-                Ok(Self {
-                    pgid: p
-                        .id()
-                        .try_into()
-                        .expect("u32 -> i32 failed in process::new"),
-                    lock: Mutex::new(false),
-                    cvar: Condvar::new(),
-                })
+            command.spawn().map(|p| Self {
+                pgid: p
+                    .id()
+                    .try_into()
+                    .expect("u32 -> i32 failed in process::new"),
+                lock: Mutex::new(false),
+                cvar: Condvar::new(),
             })
         }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -50,11 +50,7 @@ impl Watcher {
         Ok(Self { watcher_impl: imp })
     }
 
-    pub fn is_polling(&self) -> bool {
-        if let WatcherImpl::Poll(_) = self.watcher_impl {
-            true
-        } else {
-            false
-        }
+    pub const fn is_polling(&self) -> bool {
+        matches!(self.watcher_impl, WatcherImpl::Poll(_))
     }
 }


### PR DESCRIPTION
The warnings in lib.rs show up when building the project, the others one
only show up in clippy.

Warning when building:
```
warning: lint `intra_doc_link_resolution_failure` has been renamed to `broken_intra_doc_links`
  --> src/lib.rs:18:5
   |
18 |     intra_doc_link_resolution_failure
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `broken_intra_doc_links`
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default

warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
```

Edit : Didn't notice the minimum version required is 1.38 and these changes are not compatible 