### PR TITLE
Add --changes-only option to only print path change information.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,9 @@ pub struct Args {
     /// Debug messages are printed via debug! so configure your logger appropriately instead.
     #[builder(default)]
     pub debug: bool,
+    /// Change messages are printed via info! so configure your logger appropriately instead.
+    #[builder(default)]
+    pub changes: bool,
     /// Run the commands right after starting.
     #[builder(default = "true")]
     pub run_initially: bool,
@@ -178,6 +181,9 @@ where
                  .help("Print debugging messages to stderr")
                  .short("v")
                  .long("verbose"))
+        .arg(Arg::with_name("changes")
+                 .help("Only print path change information. Overridden by --verbose")
+                 .long("changes-only"))
         .arg(Arg::with_name("filter")
                  .help("Ignore all modifications except those matching the pattern")
                  .short("f")
@@ -314,6 +320,7 @@ where
         restart: args.is_present("restart"),
         debounce,
         debug: args.is_present("verbose"),
+        changes: args.is_present("changes"),
         run_initially: !args.is_present("postpone"),
         no_shell: args.is_present("no-shell"),
         no_meta: args.is_present("no-meta"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,17 +6,20 @@ use watchexec::{cli, error, run};
 
 fn main() -> error::Result<()> {
     let args = cli::get_args()?;
-    init_logger(args.debug);
+
+    if args.debug {
+        init_logger(log::LevelFilter::Debug);
+    } else if args.changes {
+        init_logger(log::LevelFilter::Info);
+    } else {
+        init_logger(log::LevelFilter::Warn);
+    }
+
     run(args)
 }
 
-fn init_logger(debug: bool) {
+fn init_logger(level: log::LevelFilter) {
     let mut log_builder = env_logger::Builder::new();
-    let level = if debug {
-        log::LevelFilter::Debug
-    } else {
-        log::LevelFilter::Warn
-    };
 
     log_builder
         .format(|buf, r| writeln!(buf, "*** {}", r.args()))

--- a/src/run.rs
+++ b/src/run.rs
@@ -119,7 +119,7 @@ where
     loop {
         debug!("Waiting for filesystem activity");
         let paths = wait_fs(&rx, &filter, args.debounce, args.no_meta);
-        debug!("Paths updated: {:?}", paths);
+        info!("Paths updated: {:?}", paths);
 
         if !handler.on_update(&paths)? {
             break;


### PR DESCRIPTION
Implements the feature requested in https://github.com/watchexec/watchexec/issues/138
