### PR TITLE
Print when processes start and stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
 name = "similar"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +972,7 @@ dependencies = [
  "log",
  "nix",
  "notify",
+ "shell-escape",
  "walkdir",
  "winapi 0.3.9",
 ]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -102,6 +102,10 @@ pub fn get_args() -> error::Result<(Config, LevelFilter)> {
                  .help("Force polling mode (interval in milliseconds)")
                  .long("force-poll")
                  .value_name("interval"))
+        .arg(Arg::with_name("print-exec")
+                 .help("Show the exit code when the process terminates")
+                 .short("x")
+                 .long("print-exec"))
         .arg(Arg::with_name("shell")
                  .help(if cfg!(windows) {
                      "Use a different shell, or `none`. Try --shell=powershell, which will become the default in 2.0."
@@ -239,6 +243,7 @@ pub fn get_args() -> error::Result<(Config, LevelFilter)> {
     builder.no_vcs_ignore(args.is_present("no-vcs-ignore"));
     builder.no_ignore(args.is_present("no-ignore"));
     builder.poll(args.occurrences_of("poll") > 0);
+    builder.print_exec(args.is_present("print-exec"));
 
     let mut config = builder.build().map_err(|err| err.to_string())?;
     if args.is_present("once") {

--- a/cli/tests/snapshots/help__help_unix.snap
+++ b/cli/tests/snapshots/help__help_unix.snap
@@ -20,6 +20,7 @@ FLAGS:
     -n, --no-shell             Do not wrap command in a shell. Deprecated: use --shell=none instead.
         --no-vcs-ignore        Skip auto-loading of .gitignore files for filtering
     -p, --postpone             Wait until first change to execute command
+    -x, --print-exec           Show the exit code when the process terminates
     -r, --restart              Restart the process if it's still running. Shorthand for --on-busy-update=restart
     -V, --version              Prints version information
     -v, --verbose              Print debugging messages to stderr

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -22,6 +22,7 @@ globset = "0.4.6"
 lazy_static = "1.1.0"
 log = "0.4.14"
 notify = "4.0.15"
+shell-escape = "0.1.5"
 walkdir = "2.3.2"
 
 [target.'cfg(unix)'.dependencies]

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -96,6 +96,10 @@ pub struct Config {
     /// Interval for polling.
     #[builder(default = "Duration::from_secs(1)")]
     pub poll_interval: Duration,
+
+    /// Print start and exit of processes
+    #[builder(default)]
+    pub print_exec: bool,
 }
 
 impl ConfigBuilder {


### PR DESCRIPTION
This is an attempt to lift a feature I've seen in @passcod's cargo-watch into watchexec.

Gives some feedback when a file modification has been registered, when the command is done, and also makes it easier to tell current and previous output apart.

The way I implemented this feels somewhat hacky but seems to work.

Thanks!