### PR TITLE
Actually check process when querying for completion

### DIFF
--- a/lib/src/process.rs
+++ b/lib/src/process.rs
@@ -423,7 +423,15 @@ mod imp {
         }
 
         pub fn is_complete(&self) -> bool {
-            self.wait_for_completion(0).unwrap_or(false)
+            // you need to poll a few times to get the real answer
+            // if the process has already completed... odd but okay
+            for _ in 0..5 {
+                if let Some(true) = self.wait_for_completion(0) {
+                    return true;
+                }
+            }
+
+            false
         }
 
         pub fn wait(&self) {


### PR DESCRIPTION
With --on-update=do-nothing, we need to know when the process is done
before we can spawn a new one, but we never actually used to truly check
the process, only the presence or absence of a spawned process. That
process may have already completed, but because we don't wait on it when
in do-nothing mode, there is no opportunity to notice this.

So now we either actually check the completion status of the process (on
Windows), or we expose the `done` mutex value on demand (Unix).
Essentially this adds a way to check the completion status of the
process without blocking (modulo a mutex lock on unix).

Fixes #200