### PR TITLE
Add arm64 musl build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
           - linux-i686-musl
           - linux-armhf-gnu
           - linux-arm64-gnu
+          - linux-arm64-musl
           - mac-x86-64
           - mac-arm64
           - windows-x86-64
@@ -49,6 +50,12 @@ jobs:
             target: aarch64-unknown-linux-gnu
             cross: true
             experimental: false
+          
+          - name: linux-arm64-musl
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            cross: true
+            experimental: true
 
           - name: mac-x86-64
             os: macos-latest


### PR DESCRIPTION
Hi! I recently set up an apt repo of cool rust CLI tools at https://apt.cli.rs. I added the i686/x86_64 musl debs to it, but I figured it would be useful to also generate aarch64 packages, so here is a PR which I believe should add that.