### PR TITLE
Configuration file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,17 +92,22 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
 
-      - uses: actions/cache@v2
-        if: startsWith(matrix.name, 'linux-')
-        with:
-          path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-bin-${{ hashFiles('.github/workflows/release.yml') }}
+      - name: Add musl tools
+        run: sudo apt install -y musl musl-dev musl-tools
+        if: endsWith(matrix.target, '-musl')
+      - name: Add aarch-gnu tools
+        run: sudo apt install -y gcc-aarch64-linux-gnu
+        if: startsWith(matrix.target, 'aarch64-unknown-linux')
+      - name: Add arm7hf-gnu tools
+        run: sudo apt install -y gcc-arm-linux-gnueabihf
+        if: startsWith(matrix.target, 'armv7-unknown-linux-gnueabihf')
+
       - name: Install cargo-deb
         if: startsWith(matrix.name, 'linux-')
-        run: which cargo-deb || cargo install cargo-deb --version 1.34.2 --locked
+        run: cargo install cargo-deb --version 1.35.0 --locked
       - name: Install cargo-generate-rpm
         if: startsWith(matrix.name, 'linux-')
-        run: which cargo-generate-rpm || cargo install cargo-generate-rpm --version 0.6.0 --locked
+        run: cargo install cargo-generate-rpm --version 0.6.0 --locked
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kdl"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114071e31456ec827056ca691d141f8e96327d9d9a29140da2e6fba9a5f17b83"
+dependencies = [
+ "nom 7.1.0",
+ "phf",
+ "thiserror",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,7 +1429,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
+ "phf_macros",
  "phf_shared",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -1439,6 +1452,20 @@ checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
  "phf_shared",
  "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1552,6 +1579,12 @@ dependencies = [
  "thiserror",
  "toml",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1833,18 +1866,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "96b3c34c1690edf8174f5b289a336ab03f568a4460d8c6df75f2f3a692b3bc6a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "784ed1fbfa13fe191077537b0d70ec8ad1e903cfe04831da608aa36457cb653d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2583,6 +2616,7 @@ dependencies = [
  "embed-resource",
  "futures",
  "insta",
+ "kdl",
  "miette",
  "mimalloc",
  "notify-rust",

--- a/Watchexec.kdl
+++ b/Watchexec.kdl
@@ -1,0 +1,72 @@
+command "hello-world" {
+	run shell="bash" "echo 'hello world' > /tmp/test.txt"
+	// run "echo" "hello world"
+	// run shell="bash" "echo" "hello world" // error!
+
+	process-group true
+
+	debounce (ms)50
+	postpone true
+
+	on-action {
+		when-idle {
+			print "Once more..."
+			start
+		}
+
+		when-busy restart
+		// when-busy {
+		// 	signal "KILL"
+		// 	restart
+		// }
+	}
+
+	environment {
+		set SET_VAR="value"
+		set MULTIPLE="vars" ON="one line"
+		unset "UNSET_VAR"
+		path-changes false
+	}
+
+	notifications {
+		on-start false
+		on-finish default=false {
+			on-error {
+				body "That didn't work"
+			}
+
+			on-signal {
+				body "Who did this?!"
+			}
+
+			title "Whoopsie"
+		}
+	}
+
+	clear {
+		on-start method="reset"
+	}
+
+	ignores {
+		vcs "git"
+		global false
+	}
+
+	filters engine="tagged" {
+		path "*=" "hello.*"
+		file-event-kind "*=" "Create(*)"
+		file-type "!=" "dir"
+	}
+}
+
+command "and-another-thing" {
+	hook on="exit" match="success" {
+		subcommand name="hello-world" {
+			send-event /* (empty) */
+		}
+	}
+
+	hook on="exit" regex="(error|signal)\((\d+)\)" {
+		quit code="$1"
+	}
+}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/main.rs"
 console-subscriber = { version = "0.1.0", optional = true }
 dunce = "1.0.2"
 futures = "0.3.17"
+kdl = "3.0.0"
 miette = { version = "3.2.0", features = ["fancy"] }
 notify-rust = "4.5.2"
 tracing = "0.1.26"

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -126,7 +126,7 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 			.help(if cfg!(windows) {
 				"Use a different shell, or `none`. Try --shell=powershell, which will become the default in 2.0."
 			} else {
-			"Use a different shell, or `none`. E.g. --shell=bash"
+			"Use a different shell, or `none`. Defaults to `sh` (until 2.0, where that will change to `$SHELL`). E.g. --shell=bash"
 			})
 			.takes_value(true)
 			.long("shell"))

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -23,6 +23,7 @@ impl Clap3Compat for Arg<'_, '_> {}
 
 const OPTSET_FILTERING: &str = "Filtering options:";
 const OPTSET_COMMAND: &str = "Command options:";
+const OPTSET_CONFIG: &str = "Config file options:";
 const OPTSET_DEBUGGING: &str = "Debugging options:";
 const OPTSET_OUTPUT: &str = "Output options:";
 const OPTSET_BEHAVIOUR: &str = "Behaviour options:";
@@ -32,6 +33,12 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 		.version(crate_version!())
 		.about("Execute commands when watched files change")
 		.after_help("Use @argfile as first argument to load arguments from the file `argfile` (one argument per line) which will be inserted in place of the @argfile (further arguments on the CLI will override or add onto those in the file).")
+		.arg(Arg::with_name("config-file")
+			.help_heading(Some(OPTSET_CONFIG))
+			.help("Config file(s) to use")
+			.multiple(true)
+			.short("C")
+			.long("config"))
 		.arg(Arg::with_name("command")
 			.help_heading(Some(OPTSET_COMMAND))
 			.help("Command to execute")

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -78,7 +78,7 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 			.long("kill"))
 		.arg(Arg::with_name("debounce")
 			.help_heading(Some(OPTSET_BEHAVIOUR))
-			.help("Set the timeout between detected change and command execution, defaults to 100ms")
+			.help("Set the timeout between detected change and command execution, defaults to 50ms")
 			.takes_value(true)
 			.value_name("milliseconds")
 			.short("d")

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,5 +1,7 @@
+pub mod file;
 mod init;
 mod runtime;
 
+pub use file::Config as File;
 pub use init::init;
 pub use runtime::runtime;

--- a/cli/src/config/file.rs
+++ b/cli/src/config/file.rs
@@ -199,10 +199,7 @@ mod tests {
 			config.commands[0].run.as_ref().unwrap().shell,
 			Shell::default()
 		);
-		assert_eq!(
-			config.commands[0].run.as_ref().unwrap().shell,
-			Shell::None
-		);
+		assert_eq!(config.commands[0].run.as_ref().unwrap().shell, Shell::None);
 	}
 
 	#[test]

--- a/cli/src/config/file.rs
+++ b/cli/src/config/file.rs
@@ -1,0 +1,284 @@
+use kdl::{parse_document, KdlNode, KdlValue};
+use miette::{IntoDiagnostic, Report, Result};
+use watchexec::command::Shell;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Config {
+	pub commands: Vec<Command>,
+}
+
+impl Config {
+	pub fn parse(input: &str) -> Result<Config> {
+		let kdl = parse_document(input).into_diagnostic()?;
+		let mut config = Config::default();
+
+		for root in kdl {
+			match root.name.as_str() {
+				"command" => config.commands.push(Command::parse(root)?),
+				otherwise => todo!("Root: {:?}", otherwise),
+			}
+		}
+
+		Ok(config)
+	}
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Command {
+	pub name: String,
+	pub run: Option<Run>,
+}
+
+impl Command {
+	fn parse(node: KdlNode) -> Result<Self> {
+		let name = node
+			.values
+			.first()
+			.ok_or_else(|| Report::msg("Command has no name"))
+			.and_then(|name| match name {
+				KdlValue::String(s) => Ok(s.to_owned()),
+				otherwise => Err(Report::msg("Command name is not a string")
+					.wrap_err(format!("{:?}", otherwise))),
+			})?;
+
+		let mut runs = node
+			.children
+			.iter()
+			.filter(|node| node.name == "run")
+			.map(Run::parse)
+			.collect::<Result<Vec<_>>>()?;
+
+		if runs.len() > 1 {
+			return Err(Report::msg("Command has multiple runs"));
+		}
+
+		Ok(Command {
+			name,
+			run: runs.pop(),
+		})
+	}
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Run {
+	pub shell: Shell,
+	pub args: Vec<String>,
+}
+
+impl Run {
+	fn parse(node: &KdlNode) -> Result<Self> {
+		let args = node
+			.values
+			.iter()
+			.enumerate()
+			.map(|(n, v)| match v {
+				KdlValue::String(s) => Ok(s.to_owned()),
+				otherwise => Err(Report::msg(format!("Run argument {n} is not a string"))
+					.wrap_err(format!("{otherwise:?}"))),
+			})
+			.collect::<Result<Vec<_>>>()
+			.and_then(|run| {
+				if run.is_empty() {
+					Err(Report::msg("Run has no arguments"))
+				} else {
+					Ok(run)
+				}
+			})?;
+
+		let shell = node
+			.properties
+			.get("shell")
+			.map(|shell| match shell {
+				KdlValue::String(s) => Ok(s.to_owned()),
+				otherwise => {
+					Err(Report::msg("Run shell is not a string").wrap_err(format!("{otherwise:?}")))
+				}
+			})
+			.transpose()?
+			.map(|shell| match shell.as_str() {
+				"powershell" | "pwsh" => Shell::Powershell,
+				"none" => Shell::None,
+				#[cfg(windows)]
+				"cmd" => Shell::Cmd,
+				unix => Shell::Unix(unix.to_owned()),
+			})
+			.unwrap_or_default();
+
+		if args.len() > 1 && shell != Shell::None {
+			Err(Report::msg("Run has more than one argument and a shell"))
+		} else {
+			Ok(Run { shell, args })
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn empty_command() {
+		let config = Config::parse(r#"command "empty""#).unwrap();
+		assert_eq!(config.commands.len(), 1);
+		assert_eq!(config.commands[0].name, "empty");
+	}
+
+	#[test]
+	fn empty_command_with_braces() {
+		let config = Config::parse(r#"command "empty" {}"#).unwrap();
+		assert_eq!(config.commands.len(), 1);
+		assert_eq!(config.commands[0].name, "empty");
+	}
+
+	#[test]
+	fn command_with_run_one() {
+		let config = Config::parse(
+			r#"command "running" {
+			run "echo hello-world"
+		}"#,
+		)
+		.unwrap();
+		assert_eq!(config.commands.len(), 1);
+		assert_eq!(config.commands[0].name, "running");
+		assert_eq!(
+			config.commands[0].run,
+			Some(Run {
+				args: vec!["echo hello-world".to_owned()],
+				shell: Shell::default()
+			})
+		);
+	}
+
+	#[test]
+	fn command_with_run_two() {
+		let config = Config::parse(
+			r#"command "running" {
+			run "echo" "hello-world"
+		}"#,
+		)
+		.unwrap();
+		assert_eq!(config.commands.len(), 1);
+		assert_eq!(config.commands[0].name, "running");
+		assert_eq!(
+			config.commands[0].run,
+			Some(Run {
+				args: vec!["echo".to_owned(), "hello-world".to_owned()],
+				shell: Shell::default()
+			})
+		);
+	}
+
+	#[test]
+	fn command_with_no_run() {
+		let config = Config::parse(r#"command "running" {}"#).unwrap();
+		assert_eq!(config.commands.len(), 1);
+		assert_eq!(config.commands[0].name, "running");
+		assert_eq!(config.commands[0].run, None);
+	}
+
+	#[test]
+	#[should_panic]
+	fn command_with_empty_run() {
+		Config::parse(
+			r#"command "running" {
+			run
+		}"#,
+		)
+		.unwrap();
+	}
+
+	#[test]
+	fn run_with_default_shell() {
+		let config = Config::parse(
+			r#"command "running" {
+			run "echo hello-world"
+		}"#,
+		)
+		.unwrap();
+		assert_eq!(
+			config.commands[0].run.as_ref().unwrap().shell,
+			Shell::default()
+		);
+		assert_eq!(
+			config.commands[0].run.as_ref().unwrap().shell,
+			Shell::None
+		);
+	}
+
+	#[test]
+	fn run_with_explicit_shell() {
+		let config = Config::parse(
+			r#"command "running" {
+			run shell="bash" "echo hello-world"
+		}"#,
+		)
+		.unwrap();
+		assert_eq!(
+			config.commands[0].run.as_ref().unwrap().shell,
+			Shell::Unix("bash".to_owned())
+		);
+	}
+
+	#[test]
+	fn run_with_powershell() {
+		let config = Config::parse(
+			r#"command "running" {
+			run shell="powershell" "echo hello-world"
+		}"#,
+		)
+		.unwrap();
+		assert_eq!(
+			config.commands[0].run.as_ref().unwrap().shell,
+			Shell::Powershell
+		);
+
+		let config = Config::parse(
+			r#"command "running" {
+			run shell="pwsh" "echo hello-world"
+		}"#,
+		)
+		.unwrap();
+		assert_eq!(
+			config.commands[0].run.as_ref().unwrap().shell,
+			Shell::Powershell
+		);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn run_with_cmd_unix() {
+		let config = Config::parse(
+			r#"command "running" {
+			run shell="cmd" "echo hello-world"
+		}"#,
+		)
+		.unwrap();
+		assert_eq!(
+			config.commands[0].run.as_ref().unwrap().shell,
+			Shell::Unix("cmd".to_owned())
+		);
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn run_with_cmd_windows() {
+		let config = Config::parse(
+			r#"command "running" {
+			run shell="cmd" "echo hello-world"
+		}"#,
+		)
+		.unwrap();
+		assert_eq!(config.commands[0].run.as_ref().unwrap().shell, Shell::Cmd);
+	}
+
+	#[test]
+	#[should_panic]
+	fn multi_arg_run_with_shell() {
+		Config::parse(
+			r#"command "running" {
+			run shell="bash" "echo" "hello-world"
+		}"#,
+		)
+		.unwrap();
+	}
+}

--- a/cli/src/config/runtime.rs
+++ b/cli/src/config/runtime.rs
@@ -30,7 +30,7 @@ pub fn runtime(args: &ArgMatches<'static>) -> Result<RuntimeConfig> {
 
 	config.action_throttle(Duration::from_millis(
 		args.value_of("debounce")
-			.unwrap_or("100")
+			.unwrap_or("50")
 			.parse()
 			.into_diagnostic()?,
 	));

--- a/cli/tests/snapshots/help__help_unix.snap
+++ b/cli/tests/snapshots/help__help_unix.snap
@@ -12,6 +12,7 @@ USAGE:
 
 FLAGS:
     -c, --clear                Clear screen before executing command
+    -C, --config               Config file(s) to use
     -h, --help                 Prints help information
         --no-default-ignore    Skip auto-ignoring of commonly ignored globs
         --no-environment       Do not set WATCHEXEC_*_PATH environment variables for the command

--- a/cli/tests/snapshots/help__help_unix.snap
+++ b/cli/tests/snapshots/help__help_unix.snap
@@ -1,5 +1,6 @@
 ---
 source: cli/tests/help.rs
+assertion_line: 16
 expression: "String::from_utf8(output.stdout).unwrap()"
 
 ---
@@ -29,7 +30,7 @@ FLAGS:
 
 OPTIONS:
     -d, --debounce <milliseconds>            Set the timeout between detected change and command execution, defaults to
-                                             100ms
+                                             50ms
     -e, --exts <extensions>                  Comma-separated list of file extensions to watch (e.g. js,css,html)
     -f, --filter <pattern>...                Ignore all modifications except those matching the pattern
     -i, --ignore <pattern>...                Ignore modifications to paths matching the pattern
@@ -38,7 +39,8 @@ OPTIONS:
                                              [possible values: do-nothing, queue, restart, signal]
     -w, --watch <path>...                    Watch a specific file or directory
         --force-poll <interval>              Force polling mode (interval in milliseconds)
-        --shell <shell>                      Use a different shell, or `none`. E.g. --shell=bash
+        --shell <shell>                      Use a different shell, or `none`. Defaults to `sh` (until 2.0, where that
+                                             will change to `$SHELL`). E.g. --shell=bash
     -s, --signal <signal>                    Specify the signal to send when using --on-busy-update=signal [default:
                                              SIGTERM]
 

--- a/cli/tests/snapshots/help__help_windows.snap
+++ b/cli/tests/snapshots/help__help_windows.snap
@@ -11,6 +11,7 @@ USAGE:
 
 FLAGS:
     -c, --clear                Clear screen before executing command
+    -C, --config               Config file(s) to use
     -h, --help                 Prints help information
         --no-default-ignore    Skip auto-ignoring of commonly ignored globs
         --no-environment       Do not set WATCHEXEC_*_PATH environment variables for the command


### PR DESCRIPTION
**Feedback wanted!**

First draft of format:

```kdl
command "hello-world" {
	run shell="bash" "echo 'hello world' > /tmp/test.txt"
	// run "echo" "hello world"
	// run shell="bash" "echo" "hello world" // error!

	process-group true

	debounce (ms)50
	postpone true

	on-action {
		when-idle {
			print "Once more..."
			start
		}

		when-busy restart
		// when-busy {
		// 	signal "KILL"
		// 	restart
		// }
	}

	environment {
		set SET_VAR="value"
		set MULTIPLE="vars" ON="one line"
		unset "UNSET_VAR"
		path-changes false
	}

	notifications {
		on-start false
		on-finish default=false {
			on-error {
				body "That didn't work"
			}

			on-signal {
				body "Who did this?!"
			}

			title "Whoopsie"
		}
	}

	clear {
		on-start method="reset"
	}

	ignores {
		vcs "git"
		global false
	}

	filters engine="tagged" {
		path "*=" "hello.*"
		file-event-kind "*=" "Create(*)"
		file-type "!=" "dir"
	}
}

command "and-another-thing" {
	with-profile "custom"

	hook on="exit" match="success" {
		subcommand name="hello-world" {
			send-event /* (empty) */
		}
	}

	hook on="exit" regex="(error|signal)\((\d+)\)" {
		quit code="$1"
	}
}

profile "default" {
	environment {
		set ALWAYS="present"
	}
}

profile "custom" {
	environment {
		set ALWAYS="custom"
	}
}
```

Syntax is from [KDL](https://kdl.dev).

Invocations:

- With explicit config file:
	  ```
	  $ watchexec -C config.kdl :hello-world
	  ```
- With multiple explicit files (merged):
	  ```
	  $ watchexec -C config1.kdl -C config2.kdl :hello-world
	  ```
- With default project-local config at `Watchexec.kdl`:
	  ```
	  $ watchexec :hello-world
	  ```
- With default global config at `~/config/watchexec/config.kdl`:
	  ```
	  $ watchexec :hello-world
	  ```
- Calling a configured command with additional options:
	  ```
	  $ watchexec -vvv :hello-world
	  ```
- Calling a configured command with additional arguments:
	  ```
	  $ watchexec :hello-world args args
	  ```
- Calling a configured command that doesn't have a `run`:
	  ```
	  $ watchexec :hello-world command to run
	  ```
- Just using config for defaults:
	  ```
	  $ watchexec do something
	  ```
- With a different profile:
	  ```
	  $ watchexec -P custom do something
	  ```