### PR TITLE
CLI 1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,16 @@ jobs:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
 
+      - name: Add musl tools
+        run: sudo apt install -y musl musl-dev musl-tools
+        if: endsWith(matrix.target, '-musl')
+      - name: Add aarch-gnu tools
+        run: sudo apt install -y gcc-aarch64-linux-gnu
+        if: startsWith(matrix.target, 'aarch64-unknown-linux')
+      - name: Add arm7hf-gnu tools
+        run: sudo apt install -y gcc-arm-linux-gnueabihf
+        if: startsWith(matrix.target, 'armv7-unknown-linux-gnueabihf')
+
       - name: Install cargo-deb
         if: startsWith(matrix.name, 'linux-')
         uses: baptiste0928/cargo-install@v1

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -66,6 +66,7 @@ assert_cmd = "2.0.4"
 insta = "1.10.0"
 
 [features]
+## For debugging only: enables the Tokio Console.
 dev-console = ["console-subscriber"]
 
 [package.metadata.binstall]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -76,7 +76,7 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 			.long("kill"))
 		.arg(Arg::with_name("debounce")
 			.help_heading(Some(OPTSET_BEHAVIOUR))
-			.help("Set the timeout between detected change and command execution, defaults to 100ms")
+			.help("Set the timeout between detected change and command execution, defaults to 50ms")
 			.takes_value(true)
 			.value_name("milliseconds")
 			.short("d")

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -47,7 +47,7 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 			.multiple(true)
 			.takes_value(true))
 		.arg(Arg::with_name("clear")
-			.help_heading(Some(OPTSET_BEHAVIOUR))
+			.help_heading(Some(OPTSET_OUTPUT))
 			.help("Clear screen before executing command")
 			.short("c")
 			.long("clear"))
@@ -135,7 +135,7 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 			.short("n")
 			.long("no-shell"))
 		.arg(Arg::with_name("no-environment")
-			.help_heading(Some(OPTSET_OUTPUT))
+			.help_heading(Some(OPTSET_COMMAND))
 			.help("Do not set WATCHEXEC_*_PATH environment variables for the command")
 			.long("no-environment"))
 		.arg(Arg::with_name("no-process-group")
@@ -158,7 +158,20 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 			.help_heading(Some(OPTSET_FILTERING))
 			.help("Override the project origin: the directory from which ignore files are detected")
 			.value_name("path")
-			.long("project-origin"));
+			.long("project-origin"))
+		.arg(Arg::with_name("command-workdir")
+			.help_heading(Some(OPTSET_COMMAND))
+			.help("Change the working directory of the command")
+			.value_name("path")
+			.long("workdir"))
+		.arg(Arg::with_name("command-env")
+			.help_heading(Some(OPTSET_COMMAND))
+			.help("Add an environment variable to the command")
+			.value_name("name=value")
+			.long("env")
+			.short("E")
+			.number_of_values(1)
+			.multiple(true));
 
 	let app = if tagged_filterer {
 		app.arg(

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -124,7 +124,7 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 			.help(if cfg!(windows) {
 				"Use a different shell, or `none`. Try --shell=powershell, which will become the default in 2.0."
 			} else {
-			"Use a different shell, or `none`. E.g. --shell=bash"
+			"Use a different shell, or `none`. Defaults to `sh` (until 2.0, where that will change to `$SHELL`). E.g. --shell=bash"
 			})
 			.takes_value(true)
 			.long("shell"))

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -153,7 +153,12 @@ pub fn get_args(tagged_filterer: bool) -> Result<ArgMatches<'static>> {
 			.help_heading(Some(OPTSET_OUTPUT))
 			.help("Send a desktop notification when the command ends")
 			.short("N")
-			.long("notify"));
+			.long("notify"))
+		.arg(Arg::with_name("project-origin")
+			.help_heading(Some(OPTSET_FILTERING))
+			.help("Override the project origin: the directory from which ignore files are detected")
+			.value_name("path")
+			.long("project-origin"));
 
 	let app = if tagged_filterer {
 		app.arg(

--- a/cli/src/config/runtime.rs
+++ b/cli/src/config/runtime.rs
@@ -30,7 +30,7 @@ pub fn runtime(args: &ArgMatches<'static>) -> Result<RuntimeConfig> {
 
 	config.action_throttle(Duration::from_millis(
 		args.value_of("debounce")
-			.unwrap_or("100")
+			.unwrap_or("50")
 			.parse()
 			.into_diagnostic()?,
 	));

--- a/cli/src/filterer/common.rs
+++ b/cli/src/filterer/common.rs
@@ -20,56 +20,61 @@ pub async fn dirs(args: &ArgMatches<'static>) -> Result<(PathBuf, PathBuf)> {
 		.into_diagnostic()?;
 	debug!(?curdir, "current directory");
 
-	let homedir = dirs::home_dir()
-		.map(canonicalize)
-		.transpose()
-		.into_diagnostic()?;
-	debug!(?homedir, "home directory");
+	let project_origin = if let Some(origin) = args.value_of("project-origin") {
+		debug!(?origin, "project origin override");
+		canonicalize(origin).into_diagnostic()?
+	} else {
+		let homedir = dirs::home_dir()
+			.map(canonicalize)
+			.transpose()
+			.into_diagnostic()?;
+		debug!(?homedir, "home directory");
 
-	let mut paths = HashSet::new();
-	for path in args.values_of("paths").unwrap_or_default() {
-		paths.insert(canonicalize(path).into_diagnostic()?);
-	}
-
-	let homedir_requested = homedir.as_ref().map_or(false, |home| paths.contains(home));
-	debug!(
-		?homedir_requested,
-		"resolved whether the homedir is explicitly requested"
-	);
-
-	if paths.is_empty() {
-		debug!("no paths, using current directory");
-		paths.insert(curdir.clone());
-	}
-
-	debug!(?paths, "resolved all watched paths");
-
-	let mut origins = HashSet::new();
-	for path in paths {
-		origins.extend(project::origins(&path).await);
-	}
-
-	match (homedir, homedir_requested) {
-		(Some(ref dir), false) if origins.contains(dir) => {
-			debug!("removing homedir from origins");
-			origins.remove(dir);
+		let mut paths = HashSet::new();
+		for path in args.values_of("paths").unwrap_or_default() {
+			paths.insert(canonicalize(path).into_diagnostic()?);
 		}
-		_ => {}
-	}
 
-	if origins.is_empty() {
-		debug!("no origins, using current directory");
-		origins.insert(curdir.clone());
-	}
+		let homedir_requested = homedir.as_ref().map_or(false, |home| paths.contains(home));
+		debug!(
+			?homedir_requested,
+			"resolved whether the homedir is explicitly requested"
+		);
 
-	debug!(?origins, "resolved all project origins");
+		if paths.is_empty() {
+			debug!("no paths, using current directory");
+			paths.insert(curdir.clone());
+		}
 
-	// This canonicalize is probably redundant
-	let project_origin = canonicalize(
-		common_prefix(&origins)
-			.ok_or_else(|| miette!("no common prefix, but this should never fail"))?,
-	)
-	.into_diagnostic()?;
+		debug!(?paths, "resolved all watched paths");
+
+		let mut origins = HashSet::new();
+		for path in paths {
+			origins.extend(project::origins(&path).await);
+		}
+
+		match (homedir, homedir_requested) {
+			(Some(ref dir), false) if origins.contains(dir) => {
+				debug!("removing homedir from origins");
+				origins.remove(dir);
+			}
+			_ => {}
+		}
+
+		if origins.is_empty() {
+			debug!("no origins, using current directory");
+			origins.insert(curdir.clone());
+		}
+
+		debug!(?origins, "resolved all project origins");
+
+		// This canonicalize is probably redundant
+		canonicalize(
+			common_prefix(&origins)
+				.ok_or_else(|| miette!("no common prefix, but this should never fail"))?,
+		)
+		.into_diagnostic()?
+	};
 	debug!(?project_origin, "resolved common/project origin");
 
 	let workdir = curdir;

--- a/cli/tests/snapshots/help__help_unix.snap
+++ b/cli/tests/snapshots/help__help_unix.snap
@@ -39,6 +39,8 @@ OPTIONS:
                                              [possible values: do-nothing, queue, restart, signal]
     -w, --watch <path>...                    Watch a specific file or directory
         --force-poll <interval>              Force polling mode (interval in milliseconds)
+        --project-origin <path>              Override the project origin: the directory from which ignore files are
+                                             detected
         --shell <shell>                      Use a different shell, or `none`. Defaults to `sh` (until 2.0, where that
                                              will change to `$SHELL`). E.g. --shell=bash
     -s, --signal <signal>                    Specify the signal to send when using --on-busy-update=signal

--- a/cli/tests/snapshots/help__help_unix.snap
+++ b/cli/tests/snapshots/help__help_unix.snap
@@ -30,7 +30,7 @@ FLAGS:
 
 OPTIONS:
     -d, --debounce <milliseconds>            Set the timeout between detected change and command execution, defaults to
-                                             100ms
+                                             50ms
     -e, --exts <extensions>                  Comma-separated list of file extensions to watch (e.g. js,css,html)
     -f, --filter <pattern>...                Ignore all modifications except those matching the pattern
     -i, --ignore <pattern>...                Ignore modifications to paths matching the pattern
@@ -39,7 +39,8 @@ OPTIONS:
                                              [possible values: do-nothing, queue, restart, signal]
     -w, --watch <path>...                    Watch a specific file or directory
         --force-poll <interval>              Force polling mode (interval in milliseconds)
-        --shell <shell>                      Use a different shell, or `none`. E.g. --shell=bash
+        --shell <shell>                      Use a different shell, or `none`. Defaults to `sh` (until 2.0, where that
+                                             will change to `$SHELL`). E.g. --shell=bash
     -s, --signal <signal>                    Specify the signal to send when using --on-busy-update=signal
 
 ARGS:

--- a/cli/tests/snapshots/help__help_unix.snap
+++ b/cli/tests/snapshots/help__help_unix.snap
@@ -2,7 +2,6 @@
 source: cli/tests/help.rs
 assertion_line: 16
 expression: "String::from_utf8(output.stdout).unwrap()"
-
 ---
 watchexec 1.18.12
 Execute commands when watched files change
@@ -29,6 +28,8 @@ FLAGS:
     -v, --verbose              Print debugging messages (-v, -vv, -vvv, -vvvv; use -vvv for bug reports)
 
 OPTIONS:
+    -E, --env <name=value>...                Add an environment variable to the command
+        --workdir <path>                     Change the working directory of the command
     -d, --debounce <milliseconds>            Set the timeout between detected change and command execution, defaults to
                                              50ms
     -e, --exts <extensions>                  Comma-separated list of file extensions to watch (e.g. js,css,html)

--- a/cli/tests/snapshots/help__help_windows.snap
+++ b/cli/tests/snapshots/help__help_windows.snap
@@ -28,8 +28,10 @@ FLAGS:
     -v, --verbose              Print debugging messages (-v, -vv, -vvv, -vvvv; use -vvv for bug reports)
 
 OPTIONS:
+    -E, --env <name=value>...                Add an environment variable to the command
+        --workdir <path>                     Change the working directory of the command
     -d, --debounce <milliseconds>            Set the timeout between detected change and command execution, defaults to
-                                             100ms
+                                             50ms
     -e, --exts <extensions>                  Comma-separated list of file extensions to watch (e.g. js,css,html)
     -f, --filter <pattern>...                Ignore all modifications except those matching the pattern
     -i, --ignore <pattern>...                Ignore modifications to paths matching the pattern

--- a/cli/tests/snapshots/help__help_windows.snap
+++ b/cli/tests/snapshots/help__help_windows.snap
@@ -38,6 +38,8 @@ OPTIONS:
                                              [possible values: do-nothing, queue, restart, signal]
     -w, --watch <path>...                    Watch a specific file or directory
         --force-poll <interval>              Force polling mode (interval in milliseconds)
+        --project-origin <path>              Override the project origin: the directory from which ignore files are
+                                             detected
         --shell <shell>                      Use a different shell, or `none`. Try --shell=powershell, which will become
                                              the default in 2.0.
     -s, --signal <signal>                    Specify the signal to send when using --on-busy-update=signal

--- a/doc/watchexec.1.ronn
+++ b/doc/watchexec.1.ronn
@@ -87,11 +87,16 @@ Skip loading of version control system (VCS) ignore files. By default, watchexec
 * `--no-project-ignore`, `--no-ignore` (deprecated alias):
 Skip loading of project-local ignore files (include VCS ignore files). By default, watchexec loads .ignore, .gitignore, .hgignore, and other such files in the current directory (or child directories as applicable) and uses them to filter change events.
 
+The `--no-ignore` alias will be replaced by a new option in 2.0.0, beware!
+
 * `--no-default-ignore`:
 Skip default ignore statements. By default, watchexec ignores common temporary files for you, for example `*.swp`, `*.pyc`, and `.DS_Store`, as well as the data directories of known VCS: `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, and `.svn`.
 
 * `--no-global-ignore`:
 Skip loading of global ignore files. By default, watchexec loads $HOME/.gitignore and other such global files and uses them to filter change events.
+
+* `--project-origin` <path>:
+Overrides the project origin, where ignore files are resolved from (see PATHS section below).
 
 * `-v`, `--verbose`, `-vv`, etc:
 Prints diagnostic and debugging messages to STDERR. Increase the amount of `v`s to get progressively more output: for bug reports use **three**, and for deep debugging **four** can be helpful.
@@ -119,6 +124,8 @@ Once it has a list of "potential project origins", it resolves the common prefix
 The overall project origin is used to find and resolve ignore files, such that in most cases it acts as one would expect for a tool that runs anywhere inside a project.
 
 For this reason, it is not recommended to use Watchexec for watching disparate folders in a filesystem, where those would resolve to a too-broad project origin.
+
+The project origin can be overridden with the `--project-origin` option.
 
 ## ENVIRONMENT
 

--- a/doc/watchexec.1.ronn
+++ b/doc/watchexec.1.ronn
@@ -3,7 +3,9 @@ watchexec(1) -- execute commands when watched files change
 
 ## SYNOPSIS
 
-watchexec [`--exts` | `-e` <extensions>]... [`--filter` | `-f` <pattern>]... [`--ignore` | `-i` <pattern>]... [`--watch` | `-w` <path>]... [`--restart` | `-r`] [`--clear` | `-c`] [`--postpone` | `-p`] [`--force-poll` <interval>] [`--debounce` | `-d` <interval>] [`--no-vcs-ignore`] [`--no-default-ignore`] [`--verbose` | `-v` | `-vv` | `-vvv` | `-vvvv`] [`--changes-only`] [`--version` | `-V`] [--] <command> [<argument>...]
+watchexec [OPTIONS] [--] <command> [<argument>...]
+watchexec -V|--version
+watchexec [-h|--help]
 
 ## DESCRIPTION
 
@@ -13,19 +15,27 @@ At startup, the specified <command> (passing any supplied <argument>s) is run on
 
 ## OPTIONS
 
+### Command options
+
 * <command>:
 Command to run when watched files are modified, and at startup, unless `--postpone` is specified. All <argument>s are passed to <command>. If you pass flags to the command, you should separate it with `--`, for example: `watchexec -w src -- rsync -a src dest`.
 
 Behaviour depends on the value of `--shell`: for all except `none`, every part of <command> is joined together into one string with a single ascii space character, and given to the shell as described. For `none`, each distinct element of <command> is passed as per the execvp(3) convention: first argument is the program, as a file or searched in the `PATH`, rest are arguments.
 
-* `-e`, `--exts` <extensions>:
-Comma-separated list of file extensions to filter by. Leading dots (.rs) are allowed. (This is a shorthand for `-f`).
+* `-E`, `--env` <key=value pair>:
+Set additional environment variables on the command (not to Watchexec itself). Can be given multiple times (one per variable to set).
 
-* `-f`, `--filter` <pattern>:
-Ignores modifications from paths that do not match <pattern>. This option can be specified multiple times, where a match on any given pattern causes the path to trigger <command>.
+* `-n`:
+Shorthand for `--shell=none`.
 
-* `-s`, `--signal`:
-Sends the specified signal (e.g. `SIGKILL`) to the command. Defaults to `SIGTERM`.
+* `--no-process-group`:
+Do not use a process group when running <command>.
+
+* `--no-environment`:
+Do not set WATCHEXEC_*_PATH environment variables for the command.
+
+* `--no-shell`:
+Deprecated. Alias for `--shell=none`.
 
 * `--shell` <shell>:
 Change the shell used to run the command. Set to `none` to run the command directly without a shell.
@@ -40,54 +50,19 @@ If not a special value, the string provided may contain arguments to the shell a
 
 See the [EXAMPLES] for uses of each of these.
 
-* `--no-shell`:
-Deprecated. Alias for `--shell=none`.
+* `--workdir <path>`:
+Set the working directory of the command (not of Watchexec itself!). By default not set, and inherited from the Watchexec instance as is usual.
 
-* `-n`:
-Shorthand for `--shell=none`.
+### Filtering options
 
-* `--no-meta`:
-Ignore metadata changes.
+* `-e`, `--exts` <extensions>:
+Comma-separated list of file extensions to filter by. Leading dots (.rs) are allowed. (This is a shorthand for `-f`).
 
-* `--no-environment`:
-Do not set WATCHEXEC_*_PATH environment variables for the command.
+* `-f`, `--filter` <pattern>:
+Ignores modifications from paths that do not match <pattern>. This option can be specified multiple times, where a match on any given pattern causes the path to trigger <command>.
 
 * `-i`, `--ignore` <pattern>:
 Ignores modifications from paths that match <pattern>. This option can be specified multiple times, and a match on any pattern causes the path to be ignored.
-
-* `-w`, `--watch` <path>:
-Monitor a specific path for changes. By default, the current working directory is watched. This may be specified multiple times, where a change in any watched directory (and subdirectories) causes <command> to be executed.
-
-* `-r`, `--restart`:
-Terminates the command if it is still running when subsequent file modifications are detected. By default, sends `SIGTERM`; use `--signal` to change that.
-
-* `-W`, `--watch-when-idle`:
-Ignore events while the process is still running. This is distinct from `--restart` in that with this option, events received while the command is running will not trigger a new run immediately after the current command is done.
-
-This behaviour will become the default in v2.0.
-
-* `--no-process-group`:
-Do not use a process group when running <command>.
-
-* `-c`, `--clear`:
-Clears the screen before executing <command>.
-
-* `-p`, `--postpone`:
-Postpone execution of <command> until the first file modification is detected.
-
-* `--force-poll` <interval>:
-Poll for changes every <interval> ms instead of using system-specific notification mechanisms (such as inotify). This is useful when you are monitoring NFS shares.
-
-* `-d`, `--debounce`:
-Set the timeout between detected change and command execution, to avoid restarting too frequently when there are many events; defaults to 100ms.
-
-* `--no-vcs-ignore`:
-Skip loading of version control system (VCS) ignore files. By default, watchexec loads .gitignore, .hgignore, and other such files in the current directory (or child directories as applicable) and uses them to filter change events.
-
-* `--no-project-ignore`, `--no-ignore` (deprecated alias):
-Skip loading of project-local ignore files (include VCS ignore files). By default, watchexec loads .ignore, .gitignore, .hgignore, and other such files in the current directory (or child directories as applicable) and uses them to filter change events.
-
-The `--no-ignore` alias will be replaced by a new option in 2.0.0, beware!
 
 * `--no-default-ignore`:
 Skip default ignore statements. By default, watchexec ignores common temporary files for you, for example `*.swp`, `*.pyc`, and `.DS_Store`, as well as the data directories of known VCS: `.bzr`, `_darcs`, `.fossil-settings`, `.git`, `.hg`, `.pijul`, and `.svn`.
@@ -95,17 +70,60 @@ Skip default ignore statements. By default, watchexec ignores common temporary f
 * `--no-global-ignore`:
 Skip loading of global ignore files. By default, watchexec loads $HOME/.gitignore and other such global files and uses them to filter change events.
 
-* `--project-origin` <path>:
-Overrides the project origin, where ignore files are resolved from (see PATHS section below).
+* `--no-meta`:
+Ignore metadata changes.
 
-* `-v`, `--verbose`, `-vv`, etc:
-Prints diagnostic and debugging messages to STDERR. Increase the amount of `v`s to get progressively more output: for bug reports use **three**, and for deep debugging **four** can be helpful.
+* `--no-project-ignore`, `--no-ignore` (deprecated alias):
+Skip loading of project-local ignore files (include VCS ignore files). By default, watchexec loads .ignore, .gitignore, .hgignore, and other such files in the current directory (or child directories as applicable) and uses them to filter change events.
+
+The `--no-ignore` alias will be replaced by a new option in 2.0.0, beware!
+
+* `--no-vcs-ignore`:
+Skip loading of version control system (VCS) ignore files. By default, watchexec loads .gitignore, .hgignore, and other such files in the current directory (or child directories as applicable) and uses them to filter change events.
+
+* `--project-origin` <path>:
+Overrides the project origin, where ignore files are resolved from (see [PATHS] section below).
+
+* `-w`, `--watch` <path>:
+Monitor a specific path for changes. By default, the current working directory is watched. This may be specified multiple times, where a change in any watched directory (and subdirectories) causes <command> to be executed.
+
+### Behaviour options
+
+* `-d`, `--debounce`:
+Set the timeout between detected change and command execution, to avoid restarting too frequently when there are many events; defaults to 100ms.
+
+* `--force-poll` <interval>:
+Poll for changes every <interval> ms instead of using system-specific notification mechanisms (such as inotify). This is useful when you are monitoring NFS shares.
+
+* `-p`, `--postpone`:
+Postpone execution of <command> until the first file modification is detected.
+
+* `-r`, `--restart`:
+Terminates the command if it is still running when subsequent file modifications are detected. By default, sends `SIGTERM`; use `--signal` to change that.
+
+* `-s`, `--signal`:
+Sends the specified signal (e.g. `SIGKILL`) to the command. Defaults to `SIGTERM`.
+
+* `-W`, `--watch-when-idle`:
+Ignore events while the process is still running. This is distinct from `--restart` in that with this option, events received while the command is running will not trigger a new run immediately after the current command is done.
+
+This behaviour will become the default in v2.0.
+
+### Output options
+
+* `-c`, `--clear`:
+Clears the screen before executing <command>.
+
+* `-N`, `--notify`:
+Sends desktop notifications on command start and command end.
+
+### Debugging options
 
 * `--print-events`, `--changes-only` (deprecated alias):
 Prints the events (changed paths, etc) that have triggered an action to STDERR.
 
-* `-N`, `--notify`:
-Sends desktop notifications on command start and command end.
+* `-v`, `--verbose`, `-vv`, etc:
+Prints diagnostic and debugging messages to STDERR. Increase the amount of `v`s to get progressively more output: for bug reports use **three**, and for deep debugging **four** can be helpful.
 
 * `-V`, `--version`:
 Print the version of watchexec.


### PR DESCRIPTION
- Final change to the `--debounce` default, down now to 50ms. This was a gradual decrease starting from late 2020, and was an idea from @Calinou in #168: thank you.
- A notice is added to the help text for the `--shell` option that its default will be changing, as per the new policy for breaking changes, which requires a deprecation at least one minor version prior a major bump.
- New option: `--project-origin` allows to override the project origin detection (closes #246).
- New option: `--workdir` allows to set the working directory of the command independent of that of Watchexec.
- New option: `-E` / `--env` allows to set additional env vars on the command.