### PR TITLE
Pin clap to < 3.2

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,7 +31,7 @@ tracing = "0.1.26"
 tracing-log = "0.1.3"
 
 [dependencies.clap]
-version = "3.1.18"
+version = "< 3.2"
 features = ["cargo", "wrap_help"]
 
 [dependencies.ignore-files]


### PR DESCRIPTION
Without this, the following error occurs when passing `-w path`, e.g.:

```
RUST_BACKTRACE=full watchexec @$HOME/.watchexec -w myfile.txt -- "cat myfile.txt"
thread 'main' panicked at 'Must use `Arg::allow_invalid_utf8` with `_os` lookups', /home/patrick/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.6/src/parser/matches/arg_matches.rs:1721:13
stack backtrace:
   0:     0x55c2e5b546fd - std::backtrace_rs::backtrace::libunwind::trace::h22893a5306c091b4
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x55c2e5b546fd - std::backtrace_rs::backtrace::trace_unsynchronized::h29c3bc6f9e91819d
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x55c2e5b546fd - std::sys_common::backtrace::_print_fmt::he497d8a0ec903793
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/sys_common/backtrace.rs:66:5
   3:     0x55c2e5b546fd - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h9c2a9d2774d81873
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/sys_common/backtrace.rs:45:22
   4:     0x55c2e5b7acfc - core::fmt::write::hba4337c43d992f49
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/fmt/mod.rs:1194:17
   5:     0x55c2e5b4e381 - std::io::Write::write_fmt::heb73de6e02cfabed
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/io/mod.rs:1655:15
   6:     0x55c2e5b56385 - std::sys_common::backtrace::_print::h63c8b24acdd8e8ce
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/sys_common/backtrace.rs:48:5
   7:     0x55c2e5b56385 - std::sys_common::backtrace::print::h426700d6240cdcc2
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/sys_common/backtrace.rs:35:9
   8:     0x55c2e5b56385 - std::panicking::default_hook::{{closure}}::hc9a76eed0b18f82b
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:295:22
   9:     0x55c2e5b56039 - std::panicking::default_hook::h2e88d02087fae196
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:314:9
  10:     0x55c2e5b568d2 - std::panicking::rust_panic_with_hook::habfdcc2e90f9fd4c
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:698:17
  11:     0x55c2e5b56779 - std::panicking::begin_panic_handler::{{closure}}::he054b2a83a51d2cd
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:586:13
  12:     0x55c2e5b54bb4 - std::sys_common::backtrace::__rust_end_short_backtrace::ha48b94ab49b30915
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/sys_common/backtrace.rs:138:18
  13:     0x55c2e5b564e9 - rust_begin_unwind
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:584:5
  14:     0x55c2e5554083 - core::panicking::panic_fmt::h366d3a309ae17c94
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panicking.rs:143:14
  15:     0x55c2e55a2611 - clap::parser::matches::arg_matches::unwrap_os_string::hcd94b2fffb22b97c
  16:     0x55c2e5907282 - <clap::parser::matches::arg_matches::OsValues as core::iter::traits::iterator::Iterator>::next::h58eecaac7a93990c
  17:     0x55c2e559e2fa - <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter::hb1bc58cde78967ff
  18:     0x55c2e556ef84 - watchexec::config::runtime::runtime::h6d6f144e758066f2
  19:     0x55c2e55f17c4 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hb226c4b3e6ec7138
  20:     0x55c2e55c60ad - std::thread::local::LocalKey<T>::with::h1e84ef08a44bf04a
  21:     0x55c2e556c98a - tokio::park::thread::CachedParkThread::block_on::hbf4e0852b550a551
  22:     0x55c2e5562d5d - tokio::runtime::thread_pool::ThreadPool::block_on::hbe95c0eb28aa6583
  23:     0x55c2e55a957c - tokio::runtime::Runtime::block_on::hd3e5b62b9ad30afb
  24:     0x55c2e558562a - watchexec::main::h35d8a8869add89c3
  25:     0x55c2e555c823 - std::sys_common::backtrace::__rust_begin_short_backtrace::hff5367952eb91120
  26:     0x55c2e557a80d - std::rt::lang_start::{{closure}}::h6c8d32b82db78422
  27:     0x55c2e5b4883e - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::had4f69b3aefb47a8
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/ops/function.rs:259:13
  28:     0x55c2e5b4883e - std::panicking::try::do_call::hf2ad5355fcafe775
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:492:40
  29:     0x55c2e5b4883e - std::panicking::try::h0a63ac363423e61e
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:456:19
  30:     0x55c2e5b4883e - std::panic::catch_unwind::h18088edcecb8693a
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panic.rs:137:14
  31:     0x55c2e5b4883e - std::rt::lang_start_internal::{{closure}}::ha7dad166dc711761
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/rt.rs:128:48
  32:     0x55c2e5b4883e - std::panicking::try::do_call::hda0c61bf3a57d6e6
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:492:40
  33:     0x55c2e5b4883e - std::panicking::try::hbc940e68560040a9
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:456:19
  34:     0x55c2e5b4883e - std::panic::catch_unwind::haed0df2aeb3fa368
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panic.rs:137:14
  35:     0x55c2e5b4883e - std::rt::lang_start_internal::h9c06694362b5b80c
                               at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/rt.rs:128:20
  36:     0x55c2e5585702 - main
  37:     0x7fc5a3429d90 - __libc_start_call_main
                               at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  38:     0x7fc5a3429e40 - __libc_start_main_impl
                               at ./csu/../csu/libc-start.c:392:3
  39:     0x55c2e5554325 - _start
  40:                0x0 - <unknown>

```

See https://github.com/clap-rs/clap/issues/3826 for more details.

Another option would be to adapt or replace calls to `matches.value_of_os(str)` as in:
* https://github.com/woodruffw/kbs2/pull/371/commits/337f8d8d1f7c7c17a27ee5f631239237b4297682
* https://github.com/gbdev/rgbobj/commit/b4e1fe42dbc297d67d67ed17004a3f6956de199f