### PR TITLE
Fix zsh autocomplete after using --shell=bash

### DIFF
--- a/completions/zsh
+++ b/completions/zsh
@@ -11,7 +11,7 @@ cmd="$words[1]"
 args=(
 	'(-c --clear)'{-c,--clear}'[Clear screen before executing command]'
 	'(-h --help)'{-h,--help}'[Prints help information]'
-	'--shell=[Change the wrapping shell, or set to none to disable]'
+	'--shell=[Change the wrapping shell, or set to none to disable]:SHELL'
 	'-n[Shorthand for --shell=none]'
 	'--no-environment[Do not set WATCHEXEC_*_PATH environment variables for command]'
 	'--no-meta[Ignore metadata changes]'


### PR DESCRIPTION
## ❌ Before
```sh
$ watchexec --shell=bash --█ # press tab here does not autocomplete watchexec command options
```

## ✅ After
```sh
$ watchexec --shell=bash --█ # press tab here works as expected
```