### PR TITLE
Update effective MSRV

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           - windows
         toolchain:
           - stable
-          - 1.61.0
+          - 1.62.1
 
     name: Test ${{ matrix.platform }} with Rust ${{ matrix.toolchain }}
     runs-on: "${{ matrix.platform }}-latest"


### PR DESCRIPTION
Current stable is 1.67, so bump the tested MSRV to 1.62