### PR TITLE
Fix #375: urgent events bypass throttle

### DIFF
--- a/crates/lib/src/action/worker.rs
+++ b/crates/lib/src/action/worker.rs
@@ -76,7 +76,9 @@ pub async fn worker(
 					trace!(?event, ?priority, "got event");
 
 					if priority == Priority::Urgent {
-						trace!("urgent event, by-passing filters");
+						trace!("urgent event, by-passing filters and throttle");
+						set.push(event);
+						break;
 					} else if event.is_empty() {
 						trace!("empty event, by-passing filters");
 					} else {


### PR DESCRIPTION
This will let signals through without waiting for the full debounce, for example.