### PR TITLE
Kill process on drop when using command-group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys 0.4.0",
 ]
 
 [[package]]
@@ -850,6 +859,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1566,7 +1586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ffa5bf0772f9b01de501c035b6b084cf9b8bb07dec41e3afc6a17336a65f47"
 dependencies = [
  "bitflags",
- "dirs",
+ "dirs 4.0.0",
  "gix-path",
  "libc",
  "windows 0.43.0",
@@ -3193,7 +3213,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da31aef70da0f6352dbcb462683eb4dd2bfad01cf3fc96cf204547b9a839a585"
 dependencies = [
- "dirs",
+ "dirs 4.0.0",
  "fnv",
  "nom 5.1.2",
  "phf",
@@ -3838,7 +3858,7 @@ dependencies = [
  "clap_mangen",
  "command-group",
  "console-subscriber",
- "dirs",
+ "dirs 5.0.0",
  "embed-resource",
  "futures",
  "humantime",
@@ -4149,7 +4169,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "derivative",
- "dirs",
+ "dirs 4.0.0",
  "enumflags2",
  "event-listener",
  "futures-core",

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0.26"
 normalize-path = "0.2.0"
 
 [dependencies.command-group]
-version = "2.0.1"
+version = "2.1.0"
 features = ["with-tokio"]
 
 [dependencies.watchexec-events]

--- a/crates/lib/src/command/supervisor.rs
+++ b/crates/lib/src/command/supervisor.rs
@@ -280,7 +280,6 @@ async fn spawn_process(
 	let (pre_spawn, spawnable) = span.in_scope::<_, Result<_, RuntimeError>>(|| {
 		debug!(%grouped, ?command, "preparing command");
 		let mut spawnable = command.to_spawnable()?;
-		spawnable.kill_on_drop(true);
 
 		// Required from Rust 1.66:
 		// https://github.com/rust-lang/rust/pull/101077
@@ -323,7 +322,9 @@ async fn spawn_process(
 		debug!(command=?spawnable, "spawning command");
 		let (proc, id) = if grouped {
 			let proc = spawnable
-				.group_spawn()
+				.group()
+				.kill_on_drop(true)
+				.spawn()
 				.map_err(|err| RuntimeError::IoError {
 					about: "spawning process group",
 					err,
@@ -332,10 +333,14 @@ async fn spawn_process(
 			debug!(pgid=%id, "process group spawned");
 			(Process::Grouped(proc), id)
 		} else {
-			let proc = spawnable.spawn().map_err(|err| RuntimeError::IoError {
-				about: "spawning process (ungrouped)",
-				err,
-			})?;
+			let proc =
+				spawnable
+					.kill_on_drop(true)
+					.spawn()
+					.map_err(|err| RuntimeError::IoError {
+						about: "spawning process (ungrouped)",
+						err,
+					})?;
 			let id = proc.id().ok_or(RuntimeError::ProcessDeadOnArrival)?;
 			debug!(pid=%id, "process spawned");
 			(Process::Ungrouped(proc), id)


### PR DESCRIPTION
Enabled by command-group 2.1.0

Fixes #274.