### PR TITLE
handle relative paths when using Ignore programmatically

### DIFF
--- a/crates/ignore-files/Cargo.toml
+++ b/crates/ignore-files/Cargo.toml
@@ -20,10 +20,11 @@ gix-config = "0.22.0"
 ignore = "0.4.18"
 miette = "5.3.0"
 thiserror = "1.0.31"
-tokio = { version = "1.24.2", default-features = false, features = ["fs"] }
+tokio = { version = "1.24.2", default-features = false, features = ["fs", "macros", "rt"] }
 tracing = "0.1.35"
 radix_trie = "0.2.1"
 dunce = "1.0.4"
+
 
 [dependencies.project-origins]
 version = "1.2.0"

--- a/crates/ignore-files/src/error.rs
+++ b/crates/ignore-files/src/error.rs
@@ -37,4 +37,15 @@ pub enum Error {
 	#[error("multiple: {0:?}")]
 	#[diagnostic(code(ignore_file::set))]
 	Multi(#[related] Vec<Error>),
+
+	/// Error received when trying to canonicalize a path
+	#[error("cannot canonicalize '{path:?}'")]
+	Canonicalize {
+		/// the path that cannot be canonicalized
+		path: PathBuf,
+
+		/// the underlying error
+		#[source]
+		err: std::io::Error,
+	},
 }


### PR DESCRIPTION
## What it does
This fixes the issue where using `IgnoreFiler::new` with relative paths causes a runtime exception. 

