### PR TITLE
Use raw_arg for CMD on Windows

### DIFF
--- a/crates/lib/src/command/tests.rs
+++ b/crates/lib/src/command/tests.rs
@@ -85,7 +85,7 @@ async fn windows_shell_cmd() -> Result<(), std::io::Error> {
 	assert!(Command::Shell {
 		shell: Shell::Cmd,
 		args: Vec::new(),
-		command: "echo hi".into()
+		command: r#""echo" hi"#.into()
 	}
 	.to_spawnable()
 	.unwrap()


### PR DESCRIPTION
CMD uses special handling for arguments to passed to `/C`. Unfortunately, this causes errors with quoted program names in these arguments.

This commit implements a workaround: When CMD is requested, we build a `std::process::Command` and pass the the argument to `/C` using the special `std::os::windows::process::CommandExt::raw_arg` method. The `StdCommand` is then converted to a `TokioCommand` and returned.

Once tokio-rs/tokio#5810 is fixed, this workaround can be removed.

Fixes #613