### PR TITLE
feat: propagate Unix job-control signals

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -21,7 +21,7 @@ use miette::{IntoDiagnostic, Report, Result};
 use notify_rust::Notification;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use tokio::{process::Command as TokioCommand, time::sleep};
-use tracing::{debug, debug_span, error, instrument, trace, trace_span, Instrument};
+use tracing::{debug, debug_span, error, instrument, trace, trace_span, warn, Instrument};
 use watchexec::{
 	action::ActionHandler,
 	command::{Command, Program, Shell, SpawnOptions},
@@ -66,7 +66,8 @@ struct TimeoutConfig {
 
 pub fn make_config(args: &Args, state: &State) -> Result<Config> {
 	let _span = debug_span!("args-runtime").entered();
-	let config = Config::default();
+	let mut config = Config::default();
+	config.signal_job_control = true;
 	config.on_error(|err: ErrorHook| {
 		if let RuntimeError::IoError {
 			about: "waiting on process group",
@@ -90,7 +91,6 @@ pub fn make_config(args: &Args, state: &State) -> Result<Config> {
 
 	config.throttle(args.events.debounce.0);
 	config.keyboard_events(args.events.stdin_quit || args.events.interactive);
-
 	if let Some(interval) = args.events.poll {
 		config.file_watcher(Watcher::Poll(interval.0));
 	}
@@ -107,6 +107,11 @@ pub fn make_config(args: &Args, state: &State) -> Result<Config> {
 
 	if args.only_emit_events {
 		config.on_action(move |mut action| {
+			#[cfg(unix)]
+			if action.signals().any(|sig| sig == Signal::TerminalSuspend) {
+				suspend_self();
+			}
+
 			// if we got a terminate or interrupt signal, quit
 			if action
 				.signals()
@@ -490,6 +495,14 @@ pub fn make_config(args: &Args, state: &State) -> Result<Config> {
 						}
 						None => {
 							debug!(?signal, "passing signal on");
+							#[cfg(unix)]
+							if signal == Signal::TerminalSuspend {
+								job.signal(signal).await;
+								suspend_self();
+							} else {
+								job.signal(signal);
+							}
+							#[cfg(not(unix))]
 							job.signal(signal);
 						}
 					}
@@ -1334,5 +1347,15 @@ pub fn reset_screen() {
 		ClearScreen::default(),
 	] {
 		cs.clear().ok();
+	}
+}
+
+#[cfg(unix)]
+fn suspend_self() {
+	// SAFETY: raise() is async-signal-safe and SIGSTOP cannot be caught or ignored. At this point
+	// SIGTSTP has already been forwarded to the child, so stopping ourselves preserves shell job
+	// control without racing the propagation.
+	if unsafe { libc::raise(libc::SIGSTOP) } != 0 {
+		warn!(error = ?std::io::Error::last_os_error(), "failed to suspend watchexec");
 	}
 }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -124,6 +124,17 @@ pub struct Config {
 	/// This maps directly to [`notify::Config::with_follow_symlinks`].
 	pub follow_symlinks: Changeable<bool>,
 
+	/// Listen for Unix job-control signals (`SIGTSTP` and `SIGCONT`).
+	///
+	/// This is disabled by default because installing a `SIGTSTP` listener suppresses the operating
+	/// system's default suspend behaviour. Applications which enable this must suspend themselves
+	/// after handling the emitted [`Signal::TerminalSuspend`](watchexec_signals::Signal) event.
+	///
+	/// This has no effect on non-Unix platforms. It is unchangeable at runtime and must be set
+	/// before Watchexec instantiation because Unix signal dispositions cannot be restored after a
+	/// Tokio signal listener is installed.
+	pub signal_job_control: bool,
+
 	/// Watch stdin and emit events when input comes in over the keyboard.
 	///
 	/// If this is true, the keyboard event source is started and stdin is switched to raw mode
@@ -179,6 +190,7 @@ impl Default for Config {
 			pathset: Default::default(),
 			file_watcher: Default::default(),
 			follow_symlinks: Changeable::new(true),
+			signal_job_control: false,
 			keyboard_events: Default::default(),
 			throttle: Changeable::new(Duration::from_millis(50)),
 			filterer: Default::default(),

--- a/crates/lib/src/sources/signal.rs
+++ b/crates/lib/src/sources/signal.rs
@@ -46,7 +46,7 @@ pub async fn worker(
 
 #[cfg(unix)]
 async fn imp_worker(
-	_config: Arc<Config>,
+	config: Arc<Config>,
 	errors: mpsc::Sender<RuntimeError>,
 	events: priority::Sender<Event, Priority>,
 ) -> Result<(), CriticalError> {
@@ -55,13 +55,13 @@ async fn imp_worker(
 	debug!("launching unix signal worker");
 
 	macro_rules! listen {
-    ($sig:ident) => {{
-        trace!(kind=%stringify!($sig), "listening for unix signal");
-        signal(SignalKind::$sig()).map_err(|err| CriticalError::IoError {
-        about: concat!("setting ", stringify!($sig), " signal listener"), err
-    })?
-    }}
-}
+		($sig:ident) => {{
+			trace!(kind=%stringify!($sig), "listening for unix signal");
+			signal(SignalKind::$sig()).map_err(|err| CriticalError::IoError {
+				about: concat!("setting ", stringify!($sig), " signal listener"), err
+			})?
+		}};
+	}
 
 	let mut s_hangup = listen!(hangup);
 	let mut s_interrupt = listen!(interrupt);
@@ -69,6 +69,23 @@ async fn imp_worker(
 	let mut s_terminate = listen!(terminate);
 	let mut s_user1 = listen!(user_defined1);
 	let mut s_user2 = listen!(user_defined2);
+
+	let (mut s_tstp, mut s_cont) = if config.signal_job_control {
+		debug!("configuring unix job-control signals");
+		let tstp =
+			signal(SignalKind::from_raw(libc::SIGTSTP)).map_err(|err| CriticalError::IoError {
+				about: "setting SIGTSTP signal listener",
+				err,
+			})?;
+		let cont =
+			signal(SignalKind::from_raw(libc::SIGCONT)).map_err(|err| CriticalError::IoError {
+				about: "setting SIGCONT signal listener",
+				err,
+			})?;
+		(Some(tstp), Some(cont))
+	} else {
+		(None, None)
+	};
 
 	loop {
 		let sig = select!(
@@ -78,6 +95,18 @@ async fn imp_worker(
 			_ = s_terminate.recv() => Signal::Terminate,
 			_ = s_user1.recv() => Signal::User1,
 			_ = s_user2.recv() => Signal::User2,
+			_ = async {
+				match &mut s_tstp {
+					Some(signal) => signal.recv().await,
+					None => std::future::pending().await,
+				}
+			} => Signal::TerminalSuspend,
+			_ = async {
+				match &mut s_cont {
+					Some(signal) => signal.recv().await,
+					None => std::future::pending().await,
+				}
+			} => Signal::Continue,
 		);
 
 		debug!(?sig, "received unix signal");

--- a/crates/signals/CHANGELOG.md
+++ b/crates/signals/CHANGELOG.md
@@ -22,6 +22,7 @@
 ## v2.1.0 (2023-12-09)
 
 - Derive `Hash` for `Signal`.
+- Add `Continue`, `Suspend`, and `TerminalSuspend` as first-class signals.
 
 ## v2.0.0 (2023-11-29)
 

--- a/crates/signals/src/lib.rs
+++ b/crates/signals/src/lib.rs
@@ -192,8 +192,15 @@ impl Signal {
 impl From<i32> for Signal {
 	/// Converts from a raw signal number.
 	///
-	/// This uses hardcoded numbers for the first-class signals.
+	/// On Unix this uses the platform's signal table. Elsewhere it uses Linux signal numbers as a
+	/// portable approximation.
 	fn from(raw: i32) -> Self {
+		#[cfg(unix)]
+		if let Ok(signal) = NixSignal::try_from(raw) {
+			return Self::from_nix(signal);
+		}
+
+		#[cfg(not(unix))]
 		match raw {
 			1 => Self::Hangup,
 			2 => Self::Interrupt,
@@ -207,6 +214,9 @@ impl From<i32> for Signal {
 			20 => Self::TerminalSuspend,
 			_ => Self::Custom(raw),
 		}
+
+		#[cfg(unix)]
+		Self::Custom(raw)
 	}
 }
 
@@ -439,6 +449,39 @@ mod serde_support {
 				SerdeSignal::Named(NamedSignal::TerminalSuspend) => Self::TerminalSuspend,
 				SerdeSignal::Number(number) => Self::Custom(number),
 			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Signal;
+
+	#[test]
+	fn parses_and_displays_job_control_signals() {
+		for (name, signal) in [
+			("SIGCONT", Signal::Continue),
+			("SIGSTOP", Signal::Suspend),
+			("SIGTSTP", Signal::TerminalSuspend),
+		] {
+			assert_eq!(Signal::from_unix_str(name).unwrap(), signal);
+			assert_eq!(signal.to_string(), name);
+		}
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn converts_job_control_signals_to_and_from_nix() {
+		use nix::sys::signal::Signal as NixSignal;
+
+		for (nix, signal) in [
+			(NixSignal::SIGCONT, Signal::Continue),
+			(NixSignal::SIGSTOP, Signal::Suspend),
+			(NixSignal::SIGTSTP, Signal::TerminalSuspend),
+		] {
+			assert_eq!(signal.to_nix(), Some(nix));
+			assert_eq!(Signal::from_nix(nix), signal);
+			assert_eq!(Signal::from(nix as i32), signal);
 		}
 	}
 }


### PR DESCRIPTION
Adds first-class `SIGCONT`, `SIGSTOP`, and `SIGTSTP` signal variants and completes Unix shell job-control propagation.

The library exposes opt-in, initialization-only listening for catchable job-control signals. The CLI enables it, forwards `SIGTSTP` to the child before suspending itself with `SIGSTOP`, then forwards `SIGCONT` after the shell resumes Watchexec. `SIGSTOP` itself is not listened for because it cannot be caught.

Signal parsing and platform-native numeric conversion are covered by tests.

Closes #386