### PR TITLE
feat: under --clear reset, always reset at exit

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -114,15 +114,7 @@ pub fn make_config(args: &Args, state: &State) -> Result<Config> {
 						clearscreen::clear().ok();
 					}
 					ClearMode::Reset => {
-						for cs in [
-							ClearScreen::WindowsCooked,
-							ClearScreen::WindowsVt,
-							ClearScreen::VtLeaveAlt,
-							ClearScreen::VtWellDone,
-							ClearScreen::default(),
-						] {
-							cs.clear().ok();
-						}
+						reset_screen();
 					}
 				}
 			}
@@ -678,5 +670,17 @@ fn emit_events_to_command(
 	if let Some(stdin) = stdin {
 		debug!("set command stdin");
 		command.stdin(stdin);
+	}
+}
+
+pub(crate) fn reset_screen() {
+	for cs in [
+		ClearScreen::WindowsCooked,
+		ClearScreen::WindowsVt,
+		ClearScreen::VtLeaveAlt,
+		ClearScreen::VtWellDone,
+		ClearScreen::default(),
+	] {
+		cs.clear().ok();
 	}
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -113,6 +113,11 @@ async fn run_watchexec(args: Args) -> Result<()> {
 
 	info!("running main loop");
 	wx.main().await.into_diagnostic()??;
+
+	if matches!(args.screen_clear, Some(args::ClearMode::Reset)) {
+		config::reset_screen();
+	}
+
 	info!("done with main loop");
 
 	Ok(())


### PR DESCRIPTION
The thing I'm watching corrupts the screen something horrible when it shuts down.

Make `watchexec --clear reset` mean to completely destroy the contents of the screen during shutdown.

---

This obviously isn't where you would want this code, but:

 * [in the middle of clean shutdown](https://github.com/watchexec/watchexec/blob/e4e8d3954601c778a5f4e2d442a99b4179361793/crates/lib/src/action/worker.rs#L83 ), we're inside lib watchexec (not cli), which doesn't know anything about the `clearscreen` library, so this doesn't feel like a good place; nor does it feel appropriate to call back to some config object / lambda here?
 * the [quit worker code](https://github.com/watchexec/watchexec/blob/eb4f2ce201ab7074b00baebeb7d5dd0e748c6bcb/crates/cli/src/config.rs#L251) runs [after event printing](https://github.com/watchexec/watchexec/blob/eb4f2ce201ab7074b00baebeb7d5dd0e748c6bcb/crates/cli/src/config.rs#L310-L311) (although this is weird, because it will be in intermingled with app output in some conditions?), so isn't an appropriate place to clear.
 * the `Config` object doesn't maintain the clear mode (again, because the lib, not the cli, doesn't care about screens?), so none of these have easy access to the data; the cli `main` function I'm editing here doesn't even know, without manually inspecting the `Args`, like I am here

