### PR TITLE
fix(cli): recursive paths provided by user getting treated non-recursively

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1243,7 +1243,7 @@ pub async fn get_args() -> Result<(Args, Option<WorkerGuard>)> {
 					canonicalize(project_origin.join(path)).into_diagnostic()
 				}
 			}
-			.map(WatchedPath::non_recursive)
+			.map(WatchedPath::recursive)
 		})
 		.chain(take(&mut args.non_recursive_paths).into_iter().map(|path| {
 			{


### PR DESCRIPTION
I ran into an issue where I provided a directory using the --watch flag but it gets treated non-recursively:
`watchexec -vvv --watch in -- ls -a`
Relevant log output (with path obscured):
`effective watched paths paths=[WatchedPath { path: "..in", recursive: false }]`

With the change from this PR:
`effective watched paths paths=[WatchedPath { path: "..in", recursive: true }]`

The behavior is now as expected. I'm assuming this was just a missed line when the non-recursive watch feature was added.