### PR TITLE
Replace std::fs::canonicalize with dunce::canonicalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4085,6 +4085,7 @@ dependencies = [
  "console-subscriber",
  "dashmap",
  "dirs 5.0.1",
+ "dunce",
  "embed-resource",
  "eyra",
  "futures",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,6 +29,7 @@ clap_mangen = "0.2.15"
 clearscreen = "3.0.0"
 dashmap = "5.4.0"
 dirs = "5.0.0"
+dunce = "1.0.4"
 futures = "0.3.29"
 humantime = "2.1.0"
 indexmap = "2.2.6" # needs to be in sync with jaq's

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1,12 +1,13 @@
 use std::{
 	collections::BTreeSet,
 	ffi::{OsStr, OsString},
-	fs::canonicalize,
 	mem::take,
 	path::{Path, PathBuf},
 	str::FromStr,
 	time::Duration,
 };
+
+use dunce::canonicalize;
 
 use clap::{
 	builder::TypedValueParser, error::ErrorKind, Arg, Command, CommandFactory, Parser, ValueEnum,


### PR DESCRIPTION
Closes #830 by going back to non-UNC paths on windows
sample.bat:
```
echo Hello world
```
`cargo run -r -- .\sample.bat` now runs as expected.
Added the same version of dunce as in `ignore-files/Cargo.toml`