### PR TITLE
Make project origin absolute

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1260,6 +1260,8 @@ pub async fn get_args() -> Result<(Args, Option<WorkerGuard>)> {
 	} else {
 		crate::dirs::project_origin(&args).await?
 	};
+	debug!(path=?project_origin, "resolved project origin");
+	let project_origin = dunce::canonicalize(project_origin).into_diagnostic()?;
 	info!(path=?project_origin, "effective project origin");
 	args.project_origin = Some(project_origin.clone());
 

--- a/crates/lib/tests/env_reporting.rs
+++ b/crates/lib/tests/env_reporting.rs
@@ -330,9 +330,11 @@ fn multipath_is_sorted() {
 				"OTHERWISE_CHANGED",
 				OsString::from(
 					String::new()
-						+ "0123.txt" + ENV_SEP + "a.txt"
-						+ ENV_SEP + "b.txt" + ENV_SEP
-						+ "c.txt" + ENV_SEP + "ᄁ.txt"
+						+ "0123.txt" + ENV_SEP
+						+ "a.txt" + ENV_SEP
+						+ "b.txt" + ENV_SEP
+						+ "c.txt" + ENV_SEP
+						+ "ᄁ.txt"
 				)
 			),
 			("COMMON", ospath("")),
@@ -360,9 +362,11 @@ fn multipath_is_deduped() {
 				"OTHERWISE_CHANGED",
 				OsString::from(
 					String::new()
-						+ "0123.txt" + ENV_SEP + "a.txt"
-						+ ENV_SEP + "b.txt" + ENV_SEP
-						+ "c.txt" + ENV_SEP + "ᄁ.txt"
+						+ "0123.txt" + ENV_SEP
+						+ "a.txt" + ENV_SEP
+						+ "b.txt" + ENV_SEP
+						+ "c.txt" + ENV_SEP
+						+ "ᄁ.txt"
 				)
 			),
 			("COMMON", ospath("")),

--- a/crates/project-origins/src/lib.rs
+++ b/crates/project-origins/src/lib.rs
@@ -157,9 +157,11 @@ impl ProjectType {
 		matches!(
 			self,
 			Self::Bazaar
-				| Self::Darcs | Self::Fossil
+				| Self::Darcs
+				| Self::Fossil
 				| Self::Git | Self::Mercurial
-				| Self::Pijul | Self::Subversion
+				| Self::Pijul
+				| Self::Subversion
 		)
 	}
 
@@ -170,12 +172,14 @@ impl ProjectType {
 			self,
 			Self::Bundler
 				| Self::C | Self::Cargo
-				| Self::Docker | Self::Elixir
-				| Self::Gradle | Self::JavaScript
+				| Self::Docker
+				| Self::Elixir
+				| Self::Gradle
+				| Self::JavaScript
 				| Self::Leiningen
-				| Self::Maven | Self::Perl
-				| Self::PHP | Self::Pip
-				| Self::V
+				| Self::Maven
+				| Self::Perl | Self::PHP
+				| Self::Pip | Self::V
 		)
 	}
 }


### PR DESCRIPTION
That should fix #886, from the [changes introduced in 2.1.0](https://github.com/watchexec/watchexec/compare/v2.0.0...v2.1.0).