### PR TITLE
[ignore-files] Dynamically create ignore entries when calling `add_globs()` and `add_file()`

### DIFF
--- a/crates/filterer/ignore/tests/filtering.rs
+++ b/crates/filterer/ignore/tests/filtering.rs
@@ -1,3 +1,4 @@
+use ignore_files::IgnoreFilter;
 use watchexec_filterer_ignore::IgnoreFilterer;
 
 mod helpers;
@@ -255,3 +256,55 @@ async fn self_ignored() {
 	filterer.file_doesnt_pass("tests/ignores/self.ignore");
 	filterer.file_does_pass("self.ignore");
 }
+
+#[tokio::test]
+async fn add_globs_without_any_ignore_file() {
+  let origin = std::fs::canonicalize(".").unwrap();
+  let mut ignore_filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+  ignore_filter.add_globs(&["other/"], Some(&origin)).expect("Failed to add globs to ignore filter");
+
+  let filterer= IgnoreFilterer(ignore_filter);
+  filterer.file_doesnt_pass("other/some/file.txt");
+  filterer.file_does_pass("tests/ignores/self.ignore");
+}
+
+#[tokio::test]
+async fn add_globs_to_existing_ignore_file() {
+  let ignore_file = file("self.ignore").applies_in("tests/ignores");
+  let ignore_file_applies_in = ignore_file.applies_in.clone().unwrap();
+  let origin = std::fs::canonicalize(".").unwrap();
+  let mut ignore_filter = IgnoreFilter::new(&origin, &[ignore_file]).await.unwrap();
+  ignore_filter.add_globs(&["other/"], Some(&ignore_file_applies_in)).expect("Failed to add globs to ignore filter");
+
+  let filterer= IgnoreFilterer(ignore_filter);
+  filterer.file_doesnt_pass("tests/ignores/other/some/file.txt");
+  filterer.file_doesnt_pass("tests/ignores/self.ignore");
+  filterer.file_does_pass("README.md");
+}
+
+#[tokio::test]
+async fn add_ignore_file_without_any_preexisting_ignore_file() {
+  let origin = std::fs::canonicalize(".").unwrap();
+  let mut ignore_filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+  let new_ignore_file = file("self.ignore").applies_in("tests/ignores");
+  ignore_filter.add_file(&new_ignore_file).await.unwrap();
+
+  let filterer= IgnoreFilterer(ignore_filter);
+  filterer.file_doesnt_pass("tests/ignores/self.ignore");
+  filterer.file_does_pass("README.md");
+}
+
+#[tokio::test]
+async fn add_ignore_file_to_existing_ignore_file() {
+  let ignore_file = file("scopes-global").applies_in("tests/ignores");
+  let origin = std::fs::canonicalize(".").unwrap();
+  let mut ignore_filter = IgnoreFilter::new(&origin, &[ignore_file]).await.unwrap();
+  let new_ignore_file = file("self.ignore").applies_in("tests/ignores");
+  ignore_filter.add_file(&new_ignore_file).await.unwrap();
+
+  let filterer= IgnoreFilterer(ignore_filter);
+  filterer.file_doesnt_pass("tests/ignores/self.ignore");
+  filterer.file_doesnt_pass("tests/ignores/global.txt");
+  filterer.file_does_pass("README.md");
+}
+

--- a/crates/filterer/ignore/tests/filtering.rs
+++ b/crates/filterer/ignore/tests/filtering.rs
@@ -259,52 +259,55 @@ async fn self_ignored() {
 
 #[tokio::test]
 async fn add_globs_without_any_ignore_file() {
-  let origin = std::fs::canonicalize(".").unwrap();
-  let mut ignore_filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
-  ignore_filter.add_globs(&["other/"], Some(&origin)).expect("Failed to add globs to ignore filter");
+	let origin = std::fs::canonicalize(".").unwrap();
+	let mut ignore_filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+	ignore_filter
+		.add_globs(&["other/"], Some(&origin))
+		.expect("Failed to add globs to ignore filter");
 
-  let filterer= IgnoreFilterer(ignore_filter);
-  filterer.file_doesnt_pass("other/some/file.txt");
-  filterer.file_does_pass("tests/ignores/self.ignore");
+	let filterer = IgnoreFilterer(ignore_filter);
+	filterer.file_doesnt_pass("other/some/file.txt");
+	filterer.file_does_pass("tests/ignores/self.ignore");
 }
 
 #[tokio::test]
 async fn add_globs_to_existing_ignore_file() {
-  let ignore_file = file("self.ignore").applies_in("tests/ignores");
-  let ignore_file_applies_in = ignore_file.applies_in.clone().unwrap();
-  let origin = std::fs::canonicalize(".").unwrap();
-  let mut ignore_filter = IgnoreFilter::new(&origin, &[ignore_file]).await.unwrap();
-  ignore_filter.add_globs(&["other/"], Some(&ignore_file_applies_in)).expect("Failed to add globs to ignore filter");
+	let ignore_file = file("self.ignore").applies_in("tests/ignores");
+	let ignore_file_applies_in = ignore_file.applies_in.clone().unwrap();
+	let origin = std::fs::canonicalize(".").unwrap();
+	let mut ignore_filter = IgnoreFilter::new(&origin, &[ignore_file]).await.unwrap();
+	ignore_filter
+		.add_globs(&["other/"], Some(&ignore_file_applies_in))
+		.expect("Failed to add globs to ignore filter");
 
-  let filterer= IgnoreFilterer(ignore_filter);
-  filterer.file_doesnt_pass("tests/ignores/other/some/file.txt");
-  filterer.file_doesnt_pass("tests/ignores/self.ignore");
-  filterer.file_does_pass("README.md");
+	let filterer = IgnoreFilterer(ignore_filter);
+	filterer.file_doesnt_pass("tests/ignores/other/some/file.txt");
+	filterer.file_doesnt_pass("tests/ignores/self.ignore");
+	filterer.file_does_pass("README.md");
 }
 
 #[tokio::test]
 async fn add_ignore_file_without_any_preexisting_ignore_file() {
-  let origin = std::fs::canonicalize(".").unwrap();
-  let mut ignore_filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
-  let new_ignore_file = file("self.ignore").applies_in("tests/ignores");
-  ignore_filter.add_file(&new_ignore_file).await.unwrap();
+	let origin = std::fs::canonicalize(".").unwrap();
+	let mut ignore_filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+	let new_ignore_file = file("self.ignore").applies_in("tests/ignores");
+	ignore_filter.add_file(&new_ignore_file).await.unwrap();
 
-  let filterer= IgnoreFilterer(ignore_filter);
-  filterer.file_doesnt_pass("tests/ignores/self.ignore");
-  filterer.file_does_pass("README.md");
+	let filterer = IgnoreFilterer(ignore_filter);
+	filterer.file_doesnt_pass("tests/ignores/self.ignore");
+	filterer.file_does_pass("README.md");
 }
 
 #[tokio::test]
 async fn add_ignore_file_to_existing_ignore_file() {
-  let ignore_file = file("scopes-global").applies_in("tests/ignores");
-  let origin = std::fs::canonicalize(".").unwrap();
-  let mut ignore_filter = IgnoreFilter::new(&origin, &[ignore_file]).await.unwrap();
-  let new_ignore_file = file("self.ignore").applies_in("tests/ignores");
-  ignore_filter.add_file(&new_ignore_file).await.unwrap();
+	let ignore_file = file("scopes-global").applies_in("tests/ignores");
+	let origin = std::fs::canonicalize(".").unwrap();
+	let mut ignore_filter = IgnoreFilter::new(&origin, &[ignore_file]).await.unwrap();
+	let new_ignore_file = file("self.ignore").applies_in("tests/ignores");
+	ignore_filter.add_file(&new_ignore_file).await.unwrap();
 
-  let filterer= IgnoreFilterer(ignore_filter);
-  filterer.file_doesnt_pass("tests/ignores/self.ignore");
-  filterer.file_doesnt_pass("tests/ignores/global.txt");
-  filterer.file_does_pass("README.md");
+	let filterer = IgnoreFilterer(ignore_filter);
+	filterer.file_doesnt_pass("tests/ignores/self.ignore");
+	filterer.file_doesnt_pass("tests/ignores/global.txt");
+	filterer.file_does_pass("README.md");
 }
-

--- a/crates/ignore-files/src/filter.rs
+++ b/crates/ignore-files/src/filter.rs
@@ -202,13 +202,12 @@ impl IgnoreFilter {
 	///
 	/// Does nothing silently otherwise.
 	pub async fn add_file(&mut self, file: &IgnoreFile) -> Result<(), Error> {
-		let applies_in = get_applies_in_path(&self.origin, file)
-			.display()
-			.to_string();
+		let applies_in = get_applies_in_path(&self.origin, file);
+		let applies_in_str = applies_in.display().to_string();
 
-		if self.ignores.get(&applies_in).is_none() {
+		if self.ignores.get(&applies_in_str).is_none() {
 			self.ignores.insert(
-				applies_in.clone(),
+				applies_in_str.clone(),
 				Ignore {
 					gitignore: Gitignore::empty(),
 					builder: Some(GitignoreBuilder::new(&applies_in)),
@@ -219,7 +218,7 @@ impl IgnoreFilter {
 		let Some(Ignore {
 			builder: Some(ref mut builder),
 			..
-		}) = self.ignores.get_mut(&applies_in)
+		}) = self.ignores.get_mut(&applies_in_str)
 		else {
 			return Ok(());
 		};
@@ -240,7 +239,7 @@ impl IgnoreFilter {
 
 			trace!(?line, "adding ignore line");
 			builder
-				.add_line(file.applies_in.clone(), line)
+				.add_line(Some(applies_in.clone()), line)
 				.map_err(|err| Error::Glob {
 					file: Some(file.path.clone()),
 					err,
@@ -295,12 +294,17 @@ impl IgnoreFilter {
 	///
 	/// Does nothing silently otherwise.
 	pub fn add_globs(&mut self, globs: &[&str], applies_in: Option<&PathBuf>) -> Result<(), Error> {
-		let applies_in = applies_in.unwrap_or(&self.origin);
-		let ignores_key = applies_in.display().to_string();
+		let virtual_ignore_file = IgnoreFile {
+			path: "manual glob".into(),
+			applies_in: applies_in.cloned(),
+			applies_to: None,
+		};
+		let applies_in = get_applies_in_path(&self.origin, &virtual_ignore_file);
+		let applies_in_str = applies_in.display().to_string();
 
-		if self.ignores.get(&ignores_key).is_none() {
+		if self.ignores.get(&applies_in_str).is_none() {
 			self.ignores.insert(
-				ignores_key.clone(),
+				applies_in_str.clone(),
 				Ignore {
 					gitignore: Gitignore::empty(),
 					builder: Some(GitignoreBuilder::new(&applies_in)),
@@ -311,7 +315,7 @@ impl IgnoreFilter {
 		let Some(Ignore {
 			builder: Some(builder),
 			..
-		}) = self.ignores.get_mut(&ignores_key)
+		}) = self.ignores.get_mut(&applies_in_str)
 		else {
 			return Ok(());
 		};
@@ -328,11 +332,7 @@ impl IgnoreFilter {
 				.map_err(|err| Error::Glob { file: None, err })?;
 		}
 
-		self.recompile(&IgnoreFile {
-			path: "manual glob".into(),
-			applies_in: Some(applies_in.clone()),
-			applies_to: None,
-		})?;
+		self.recompile(&virtual_ignore_file)?;
 
 		Ok(())
 	}

--- a/crates/ignore-files/src/filter.rs
+++ b/crates/ignore-files/src/filter.rs
@@ -206,6 +206,13 @@ impl IgnoreFilter {
 			.display()
 			.to_string();
 
+		if self.ignores.get(&applies_in).is_none() {
+			self.ignores.insert(applies_in.clone(), Ignore {
+				gitignore: Gitignore::empty(),
+				builder: Some(GitignoreBuilder::new(&applies_in)),
+			});
+		}
+
 		let Some(Ignore {
 			builder: Some(ref mut builder),
 			..
@@ -286,11 +293,19 @@ impl IgnoreFilter {
 	/// Does nothing silently otherwise.
 	pub fn add_globs(&mut self, globs: &[&str], applies_in: Option<&PathBuf>) -> Result<(), Error> {
 		let applies_in = applies_in.unwrap_or(&self.origin);
+		let ignores_key = applies_in.display().to_string();
+
+		if self.ignores.get(&ignores_key).is_none() {
+				self.ignores.insert(ignores_key.clone(), Ignore {
+					gitignore: Gitignore::empty(),
+					builder: Some(GitignoreBuilder::new(&applies_in)),
+				});
+		}
 
 		let Some(Ignore {
 			builder: Some(builder),
 			..
-		}) = self.ignores.get_mut(&applies_in.display().to_string())
+		}) = self.ignores.get_mut(&ignores_key)
 		else {
 			return Ok(());
 		};

--- a/crates/ignore-files/src/filter.rs
+++ b/crates/ignore-files/src/filter.rs
@@ -207,10 +207,13 @@ impl IgnoreFilter {
 			.to_string();
 
 		if self.ignores.get(&applies_in).is_none() {
-			self.ignores.insert(applies_in.clone(), Ignore {
-				gitignore: Gitignore::empty(),
-				builder: Some(GitignoreBuilder::new(&applies_in)),
-			});
+			self.ignores.insert(
+				applies_in.clone(),
+				Ignore {
+					gitignore: Gitignore::empty(),
+					builder: Some(GitignoreBuilder::new(&applies_in)),
+				},
+			);
 		}
 
 		let Some(Ignore {
@@ -296,10 +299,13 @@ impl IgnoreFilter {
 		let ignores_key = applies_in.display().to_string();
 
 		if self.ignores.get(&ignores_key).is_none() {
-				self.ignores.insert(ignores_key.clone(), Ignore {
+			self.ignores.insert(
+				ignores_key.clone(),
+				Ignore {
 					gitignore: Gitignore::empty(),
 					builder: Some(GitignoreBuilder::new(&applies_in)),
-				});
+				},
+			);
 		}
 
 		let Some(Ignore {


### PR DESCRIPTION
# Summary 
Calls to `add_globs()` and `add_file()` dynamically create a new ignore entry if there isn't one at the location of `applies_in` param. This allows users to e.g. add globs to a path that previously has no ignore files in.

Fixes #907