### PR TITLE
Use distinct `WATCHEXEC_LOG` logging filter env variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ There are a few anti goals:
 To enable verbose logging in tests, run with:
 
 ```console
-$ env RUST_LOG=watchexec=trace,info RUST_TEST_THREADS=1 RUST_NOCAPTURE=1 cargo test --test testfile -- testname
+$ env WATCHEXEC_LOG=watchexec=trace,info RUST_TEST_THREADS=1 RUST_NOCAPTURE=1 cargo test --test testfile -- testname
 ```
 
 To use [Tokio Console](https://github.com/tokio-rs/console):

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -242,7 +242,9 @@ pub struct Guards {
 pub async fn get_args() -> Result<(Args, Guards)> {
 	let prearg_logs = logging::preargs();
 	if prearg_logs {
-		warn!("⚠ RUST_LOG environment variable set or hardcoded, logging options have no effect");
+		warn!(
+			"⚠ WATCHEXEC_LOG environment variable set or hardcoded, logging options have no effect"
+		);
 	}
 
 	debug!("expanding @argfile arguments if any");

--- a/crates/cli/src/args/logging.rs
+++ b/crates/cli/src/args/logging.rs
@@ -5,6 +5,7 @@ use miette::{bail, Result};
 use tokio::fs::metadata;
 use tracing::{info, warn};
 use tracing_appender::{non_blocking, non_blocking::WorkerGuard, rolling};
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use super::OPTSET_DEBUGGING;
 
@@ -82,13 +83,17 @@ pub fn preargs() -> bool {
 		}
 	}
 
-	if !log_on && var("RUST_LOG").is_ok() {
-		match tracing_subscriber::fmt::try_init() {
+	if !log_on && var("WATCHEXEC_LOG").is_ok() {
+		let subscriber =
+			FmtSubscriber::builder().with_env_filter(EnvFilter::from_env("WATCHEXEC_LOG"));
+		match subscriber.try_init() {
 			Ok(()) => {
-				warn!(RUST_LOG=%var("RUST_LOG").unwrap(), "logging configured from RUST_LOG");
+				warn!(RUST_LOG=%var("WATCHEXEC_LOG").unwrap(), "logging configured from WATCHEXEC_LOG");
 				log_on = true;
 			}
-			Err(e) => eprintln!("Failed to initialise logging with RUST_LOG, falling back\n{e}"),
+			Err(e) => {
+				eprintln!("Failed to initialise logging with WATCHEXEC_LOG, falling back\n{e}");
+			}
 		}
 	}
 

--- a/crates/cli/src/args/logging.rs
+++ b/crates/cli/src/args/logging.rs
@@ -20,8 +20,8 @@ pub struct LoggingArgs {
 	///
 	/// You may want to use with '--log-file' to avoid polluting your terminal.
 	///
-	/// Setting $RUST_LOG also works, and takes precedence, but is not recommended. However, using
-	/// $RUST_LOG is the only way to get logs from before these options are parsed.
+	/// Setting $WATCHEXEC_LOG also works, and takes precedence, but is not recommended. However, using
+	/// $WATCHEXEC_LOG is the only way to get logs from before these options are parsed.
 	#[arg(
 		long,
 		short,
@@ -88,7 +88,7 @@ pub fn preargs() -> bool {
 			FmtSubscriber::builder().with_env_filter(EnvFilter::from_env("WATCHEXEC_LOG"));
 		match subscriber.try_init() {
 			Ok(()) => {
-				warn!(RUST_LOG=%var("WATCHEXEC_LOG").unwrap(), "logging configured from WATCHEXEC_LOG");
+				warn!(WATCHEXEC_LOG=%var("WATCHEXEC_LOG").unwrap(), "logging configured from WATCHEXEC_LOG");
 				log_on = true;
 			}
 			Err(e) => {

--- a/doc/watchexec.1
+++ b/doc/watchexec.1
@@ -556,7 +556,7 @@ Goes up to \*(Aq\-vvvv\*(Aq. When submitting bug reports, default to a \*(Aq\-vv
 
 You may want to use with \*(Aq\-\-log\-file\*(Aq to avoid polluting your terminal.
 
-Setting $RUST_LOG also works, and takes precedence, but is not recommended. However, using $RUST_LOG is the only way to get logs from before these options are parsed.
+Setting $WATCHEXEC_LOG also works, and takes precedence, but is not recommended. However, using $WATCHEXEC_LOG is the only way to get logs from before these options are parsed.
 .TP
 \fB\-\-log\-file\fR=\fIPATH\fR
 Write diagnostic logs to a file

--- a/doc/watchexec.1.md
+++ b/doc/watchexec.1.md
@@ -848,8 +848,8 @@ Watch lib and src directories for changes, rebuilding each time:
     You may want to use with \--log-file to avoid polluting your
     terminal.
 
-    Setting \$RUST_LOG also works, and takes precedence, but is not
-    recommended. However, using \$RUST_LOG is the only way to get logs
+    Setting \$WATCHEXEC_LOG also works, and takes precedence, but is not
+    recommended. However, using \$WATCHEXEC_LOG is the only way to get logs
     from before these options are parsed.
 
 **\--log-file**=*PATH*


### PR DESCRIPTION
I use `watchexec` on a lot of Rust projects, and I often set the `RUST_LOG` env var, either manually or automatically with tools like direnv.

This means that I end up seeing watchexec logs, even if I absolutely don't care about them.

Rust itself switched from `RUST_LOG` over to `RUSTC_LOG` quite a while ago, with a similar motivation.

---

Since `watchexec` will be used in Rust development environments, it makes sense to :

- Stop respecting the `RUST_LOG` env var
- use a custom `WATCHEXEC_LOG` for logging configuration instead

I don't know how you feel about it from a breaking change point of view. I feel like this is more breaking for developers that are used to `RUST_LOG` when debugging `watchexec`.

Thanks