### PR TITLE
Remove ignore-files dependency from watchexec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4409,7 +4409,6 @@ dependencies = [
  "async-recursion",
  "atomic-take",
  "futures",
- "ignore-files",
  "miette",
  "nix",
  "normalize-path",

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -41,10 +41,6 @@ path = "../signals"
 version = "4.0.0"
 path = "../supervisor"
 
-[dependencies.ignore-files]
-version = "3.0.3"
-path = "../ignore-files"
-
 [dependencies.project-origins]
 version = "1.4.1"
 path = "../project-origins"

--- a/crates/lib/src/error/runtime.rs
+++ b/crates/lib/src/error/runtime.rs
@@ -176,19 +176,6 @@ pub enum RuntimeError {
 	#[error("empty shell program")]
 	CommandShellEmptyShell,
 
-	/// Error received from the [`ignore-files`](ignore_files) crate.
-	#[error("ignore files: {0}")]
-	#[deprecated(
-		since = "3.0.2",
-		note = "ignore-files is no longer part of Watchexec directly"
-	)]
-	// on removal, delete the dependency too
-	IgnoreFiles(
-		#[diagnostic_source]
-		#[from]
-		ignore_files::Error,
-	),
-
 	/// Error emitted by a [`Filterer`](crate::filter::Filterer).
 	#[error("{kind} filterer: {err}")]
 	Filterer {


### PR DESCRIPTION
`ignore-files` in `watchexec` is only used for a deprecated error variant. `ignore-files` pulls in well over 20 extra transitive dependencies through gix which are just completely unused when using `watchexec` as a library by itself.