### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4406,7 +4406,6 @@ name = "watchexec"
 version = "6.0.0"
 dependencies = [
  "async-priority-channel",
- "async-recursion",
  "atomic-take",
  "futures",
  "ignore-files",
@@ -4414,8 +4413,6 @@ dependencies = [
  "nix",
  "normalize-path",
  "notify",
- "process-wrap",
- "project-origins",
  "thiserror 2.0.11",
  "tokio",
  "tracing",
@@ -4482,7 +4479,6 @@ dependencies = [
 name = "watchexec-events"
 version = "5.0.0"
 dependencies = [
- "nix",
  "notify-types",
  "serde",
  "serde_json",
@@ -4519,7 +4515,6 @@ dependencies = [
  "tracing-subscriber",
  "watchexec",
  "watchexec-events",
- "watchexec-signals",
 ]
 
 [[package]]

--- a/crates/bosion/src/lib.rs
+++ b/crates/bosion/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use std::{env::var, fs::File, io::Write, path::PathBuf};
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(rust_2018_idioms)]
 #![allow(clippy::missing_const_for_fn, clippy::future_not_send)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use std::{
 	io::{IsTerminal, Write},

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -28,10 +28,6 @@ version = "4.0.1"
 path = "../signals"
 default-features = false
 
-[target.'cfg(unix)'.dependencies.nix]
-version = "0.29.0"
-features = ["signal"]
-
 [dev-dependencies]
 snapbox = "0.6.18"
 serde_json = "1.0.107"

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 #[doc(inline)]
 pub use event::*;

--- a/crates/filterer/globset/src/lib.rs
+++ b/crates/filterer/globset/src/lib.rs
@@ -6,11 +6,11 @@
 #![doc(html_favicon_url = "https://watchexec.github.io/logo:watchexec.svg")]
 #![doc(html_logo_url = "https://watchexec.github.io/logo:watchexec.svg")]
 #![warn(clippy::unwrap_used, missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(rust_2018_idioms)]
 
 use std::{
 	ffi::OsString,
-	fmt,
 	path::{Path, PathBuf},
 };
 
@@ -34,8 +34,8 @@ pub struct GlobsetFilterer {
 }
 
 #[cfg(not(feature = "full_debug"))]
-impl fmt::Debug for GlobsetFilterer {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Debug for GlobsetFilterer {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("GlobsetFilterer")
 			.field("origin", &self.origin)
 			.field("filters", &"ignore::gitignore::Gitignore{...}")

--- a/crates/filterer/ignore/Cargo.toml
+++ b/crates/filterer/ignore/Cargo.toml
@@ -33,10 +33,6 @@ path = "../../lib"
 version = "5.0.0"
 path = "../../events"
 
-[dependencies.watchexec-signals]
-version = "4.0.1"
-path = "../../signals"
-
 [dev-dependencies.project-origins]
 version = "1.4.1"
 path = "../../project-origins"

--- a/crates/filterer/ignore/src/lib.rs
+++ b/crates/filterer/ignore/src/lib.rs
@@ -9,6 +9,7 @@
 #![doc(html_favicon_url = "https://watchexec.github.io/logo:watchexec.svg")]
 #![doc(html_logo_url = "https://watchexec.github.io/logo:watchexec.svg")]
 #![warn(clippy::unwrap_used, missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(rust_2018_idioms)]
 
 use ignore::Match;

--- a/crates/ignore-files/src/filter.rs
+++ b/crates/ignore-files/src/filter.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::path::{Path, PathBuf};
 
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -20,8 +19,8 @@ struct Ignore {
 }
 
 #[cfg(not(feature = "full_debug"))]
-impl fmt::Debug for Ignore {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Debug for Ignore {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.debug_struct("Ignore")
 			.field("gitignore", &"ignore::gitignore::Gitignore{...}")
 			.field("builder", &"ignore::gitignore::GitignoreBuilder{...}")

--- a/crates/ignore-files/src/lib.rs
+++ b/crates/ignore-files/src/lib.rs
@@ -6,6 +6,8 @@
 //! more ignore files in _these_ subfolders, and so on. Discovering and interpreting all of these in
 //! a single context is not a simple task: this is what this crate provides.
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 use std::path::{Path, PathBuf};
 
 use normalize_path::NormalizePath;

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -17,17 +17,12 @@ edition = "2021"
 
 [dependencies]
 async-priority-channel = "0.2.0"
-async-recursion = "1.0.5"
 atomic-take = "1.0.0"
 futures = "0.3.29"
 miette = "7.2.0"
 notify = "8.0.0"
 thiserror = "2.0.11"
 normalize-path = "0.2.0"
-
-[dependencies.process-wrap]
-version = "8.0.0"
-features = ["tokio1"]
 
 [dependencies.watchexec-events]
 version = "5.0.0"
@@ -45,10 +40,6 @@ path = "../supervisor"
 version = "3.0.3"
 path = "../ignore-files"
 
-[dependencies.project-origins]
-version = "1.4.1"
-path = "../project-origins"
-
 [dependencies.tokio]
 version = "1.33.0"
 features = [
@@ -65,13 +56,13 @@ features = [
 version = "0.1.40"
 features = ["log"]
 
-[target.'cfg(unix)'.dependencies.nix]
-version = "0.29.0"
-features = ["signal"]
-
 [dev-dependencies.tracing-subscriber]
 version = "0.3.6"
 features = ["env-filter"]
+
+[target.'cfg(unix)'.dev-dependencies.nix]
+version = "0.29.0"
+features = ["signal"]
 
 [lints.clippy]
 nursery = "warn"

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -53,6 +53,7 @@
 #![doc(html_favicon_url = "https://watchexec.github.io/logo:watchexec.svg")]
 #![doc(html_logo_url = "https://watchexec.github.io/logo:watchexec.svg")]
 #![warn(clippy::unwrap_used, missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(rust_2018_idioms)]
 
 // the toolkit to make your own

--- a/crates/project-origins/src/lib.rs
+++ b/crates/project-origins/src/lib.rs
@@ -10,6 +10,8 @@
 //! directory and walking up, [`origins`] returns a set, rather than a single path. Determining
 //! which of these is the "one true origin" (if necessary) is left to the caller.
 
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
 use std::{
 	collections::{HashMap, HashSet},
 	fs::FileType,
@@ -270,7 +272,6 @@ pub async fn origins(path: impl AsRef<Path> + Send) -> HashSet<PathBuf> {
 		current = parent;
 		if check_list(&DirList::obtain(current).await) {
 			origins.insert(current.to_owned());
-			continue;
 		}
 	}
 

--- a/crates/signals/src/lib.rs
+++ b/crates/signals/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 use std::fmt;
 

--- a/crates/supervisor/Cargo.toml
+++ b/crates/supervisor/Cargo.toml
@@ -37,12 +37,12 @@ version = "4.0.1"
 default-features = false
 path = "../signals"
 
-[target.'cfg(unix)'.dependencies.nix]
-version = "0.29.0"
-features = ["signal"]
-
 [dev-dependencies]
 boxcar = "0.2.9"
+
+[target.'cfg(unix)'.dev-dependencies.nix]
+version = "0.29.0"
+features = ["signal"]
 
 [lints.clippy]
 nursery = "warn"

--- a/crates/supervisor/src/lib.rs
+++ b/crates/supervisor/src/lib.rs
@@ -133,6 +133,7 @@
 #![doc(html_favicon_url = "https://watchexec.github.io/logo:watchexec.svg")]
 #![doc(html_logo_url = "https://watchexec.github.io/logo:watchexec.svg")]
 #![warn(clippy::unwrap_used, missing_docs, rustdoc::unescaped_backticks)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(rust_2018_idioms)]
 
 #[doc(no_inline)]


### PR DESCRIPTION
Introduce `#![cfg_attr(not(test), warn(unused_crate_dependencies))]` to all crates to warn on unused (non-dev) dependencies. Plus a few warning fixes.