### PR TITLE
fix: match git's actual global ignore behavior

### DIFF
--- a/crates/ignore-files/src/discover.rs
+++ b/crates/ignore-files/src/discover.rs
@@ -368,19 +368,15 @@ pub async fn from_environment(appname: Option<&str>) -> (Vec<IgnoreFile>, Vec<Er
 	}
 
 	if !found_git_global {
-		let mut tries = Vec::with_capacity(5);
+		let mut tries = Vec::with_capacity(3);
 		if let Ok(home) = env::var("XDG_CONFIG_HOME") {
 			tries.push(Path::new(&home).join("git/ignore"));
 		}
-		if let Ok(home) = env::var("APPDATA") {
-			tries.push(Path::new(&home).join(".gitignore"));
-		}
-		if let Ok(home) = env::var("USERPROFILE") {
-			tries.push(Path::new(&home).join(".gitignore"));
-		}
 		if let Ok(home) = env::var("HOME") {
 			tries.push(Path::new(&home).join(".config/git/ignore"));
-			tries.push(Path::new(&home).join(".gitignore"));
+		}
+		if let Ok(home) = env::var("USERPROFILE") {
+			tries.push(Path::new(&home).join(".config/git/ignore"));
 		}
 
 		for path in tries {


### PR DESCRIPTION
Hi!

I came across this while helping diagnose watchexec not triggering for someone: files in a repo that git _was not ignoring_ were filtered _as ignored_ by watchexec.  Our workaround was `--no-global-ignore`.

This general feature was first requested in issue #58, and released with 1.18.0 in early 2022.  I don't know if you'd consider this "breaking" to come in line with git or not, but this PR does just that.

My extended commit message follows:

---

Git's global ignore is based on the `conf.excludesFile` value, which has a default and a couple variable fallbacks.  Any other files are only considered by git if they are actually specified as excludesFile.

The default is `$XDG_CONFIG_HOME/git/ignore`, or substituting `$HOME/.config` if XDG_CONFIG_HOME isn't set [1], or, only on MinGW builds, `HOME=$USERPROFILE` if HOME isn't set. [2]  APPDATA isn't considered anywhere by git at runtime.

Checking these non-default paths regardless can lead to surprising behavior that differs from git itself, and require the user to invoke with `--no-global-ignore` when they don't actually have global ignores, as a workaround.

Since excludesFile is checked and followed above, the paths removed here are still covered if they are in use, and the remaining checks align with git's defaults, which look unchanged for 10+ years.

1: https://git-scm.com/docs/gitignore
2: [git `compat/mingw.c` /calculate HOME if not set/](https://github.com/git/git/blob/master/compat/mingw.c#L2782-L2804)