### PR TITLE
fix: handle graceful stop when job handle dropped (#981)

### DIFF
--- a/crates/supervisor/src/job/task.rs
+++ b/crates/supervisor/src/job/task.rs
@@ -65,7 +65,9 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 								}
 								Ok(true) => {
 									trace!(existing=?stop_timer, "erasing stop timer");
-									stop_timer = None;
+									if let Some(timer) = stop_timer.take() {
+										timer.done.raise();
+									}
 									trace!(count=%on_end.len(), "raising all pending end flags");
 									for done in take(&mut on_end) {
 										done.raise();
@@ -351,6 +353,10 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 							break 'main;
 						}
 					}
+				}
+				else => {
+					trace!("all select branches disabled, exiting");
+					break 'main;
 				}
 				}
 			}


### PR DESCRIPTION
When a process responds to SIGTERM gracefully and the Job handle is dropped, the tokio::select! would panic with "all branches are disabled and there is no else branch". This fixes the issue by:

1. Adding an else branch to exit cleanly when both select branches are disabled (process not running and channels closed)
2. Raising the stop timer's done flag when clearing it after graceful exit, so the Ticket resolves properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)