### PR TITLE
feat(supervisor): add SpawnFn to allow custom process spawning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2528,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "9.0.3"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd9713fe2c91c3c85ac388b31b89de339365d2c995146e630b5e0da9d06526a"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
@@ -3806,7 +3806,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/supervisor/Cargo.toml
+++ b/crates/supervisor/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.29"
 tracing = "0.1.40"
 
 [dependencies.process-wrap]
-version = "9.0.1"
+version = "9.1.0"
 features = ["reset-sigmask", "tokio1"]
 
 [dependencies.tokio]

--- a/crates/supervisor/src/job.rs
+++ b/crates/supervisor/src/job.rs
@@ -5,7 +5,7 @@ pub use self::{
 	job::Job,
 	messages::{Control, Ticket},
 	state::CommandState,
-	task::JobTaskContext,
+	task::{JobTaskContext, SpawnFn},
 };
 
 #[cfg(test)]

--- a/crates/supervisor/src/job/messages.rs
+++ b/crates/supervisor/src/job/messages.rs
@@ -12,6 +12,7 @@ use crate::flag::Flag;
 
 use super::task::{
 	AsyncErrorHandler, AsyncFunc, AsyncSpawnHook, SyncErrorHandler, SyncFunc, SyncSpawnHook,
+	SpawnFn,
 };
 
 /// The underlying control message types for [`Job`](super::Job).
@@ -66,6 +67,11 @@ pub enum Control {
 	SetAsyncErrorHandler(AsyncErrorHandler),
 	/// For [`Job::unset_error_handler()`](super::Job::unset_error_handler()).
 	UnsetErrorHandler,
+
+	/// For [`Job::set_spawn_fn()`](super::Job::set_spawn_fn()).
+	SetSpawnFn(SpawnFn),
+	/// For [`Job::unset_spawn_fn()`](super::Job::unset_spawn_fn()).
+	ClearSpawnFn,
 }
 
 impl std::fmt::Debug for Control {
@@ -107,6 +113,8 @@ impl std::fmt::Debug for Control {
 				.debug_struct("SetAsyncErrorHandler")
 				.finish_non_exhaustive(),
 			Self::UnsetErrorHandler => f.debug_struct("UnsetErrorHandler").finish(),
+			Self::SetSpawnFn(_) => f.debug_struct("SetSpawnFn").finish_non_exhaustive(),
+			Self::ClearSpawnFn => f.debug_struct("ClearSpawnFn").finish(),
 		}
 	}
 }

--- a/crates/supervisor/src/job/task.rs
+++ b/crates/supervisor/src/job/task.rs
@@ -55,6 +55,7 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 		tokio::spawn(async move {
 			let mut error_handler = ErrorHandler::None;
 			let mut spawn_hook = SpawnHook::None;
+			let mut spawn_fn: Option<SpawnFn> = None;
 			let mut command_state = CommandState::Pending;
 			let mut previous_run = None;
 			let mut stop_timer = None;
@@ -100,7 +101,7 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 												},
 											)
 											.await;
-										if let Err(err) = command_state.spawn(command.clone(), spawnable) {
+										if let Err(err) = command_state.spawn(command.clone(), spawnable, spawn_fn.as_ref()) {
 											let fut = error_handler.call(sync_io_error(err));
 											fut.await;
 											return Loop::Skip;
@@ -165,7 +166,7 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 												},
 											)
 											.await;
-										try_with_handler!(command_state.spawn(command.clone(), spawnable));
+										try_with_handler!(command_state.spawn(command.clone(), spawnable, spawn_fn.as_ref()));
 									}
 								}
 								Control::Stop => {
@@ -231,7 +232,7 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 												},
 											)
 											.await;
-										try_with_handler!(command_state.spawn(command.clone(), spawnable));
+										try_with_handler!(command_state.spawn(command.clone(), spawnable, spawn_fn.as_ref()));
 									} else {
 										trace!("child isn't running, skip");
 									}
@@ -282,7 +283,7 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 											},
 										)
 										.await;
-									try_with_handler!(command_state.spawn(command.clone(), spawnable));
+									try_with_handler!(command_state.spawn(command.clone(), spawnable, spawn_fn.as_ref()));
 								}
 								Control::Signal(signal) => {
 									if let CommandState::Running { child, .. } = &mut command_state {
@@ -347,6 +348,14 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 								Control::UnsetSpawnHook => {
 									trace!("unsetting spawn hook");
 									spawn_hook = SpawnHook::None;
+								}
+								Control::SetSpawnFn(f) => {
+									trace!("setting spawn fn");
+									spawn_fn = Some(f);
+								}
+								Control::ClearSpawnFn => {
+									trace!("clearing spawn fn");
+									spawn_fn = None;
 								}
 							}
 
@@ -433,6 +442,23 @@ pub type AsyncFunc = Box<
 pub type SyncSpawnHook = Arc<dyn Fn(&mut CommandWrap, &JobTaskContext<'_>) + Send + Sync + 'static>;
 pub type AsyncSpawnHook = Arc<
 	dyn (Fn(&mut CommandWrap, &JobTaskContext<'_>) -> Box<dyn Future<Output = ()> + Send + Sync>)
+		+ Send
+		+ Sync
+		+ 'static,
+>;
+
+/// A function that customises how the underlying process is spawned.
+///
+/// When set on a [`Job`](super::Job), this function is passed to
+/// [`CommandWrap::spawn_with()`](process_wrap::tokio::CommandWrap::spawn_with) instead of using
+/// the default [`CommandWrap::spawn()`](process_wrap::tokio::CommandWrap::spawn). It receives a
+/// `&mut tokio::process::Command` and must return the spawned `tokio::process::Child`.
+///
+/// All process-wrap layers are still applied around the child, so this only customises the
+/// low-level spawn step. This is useful for delegating process spawning to a privileged helper
+/// (e.g. for Linux capability granting) while keeping the supervisor's lifecycle management.
+pub type SpawnFn = Arc<
+	dyn Fn(&mut tokio::process::Command) -> std::io::Result<tokio::process::Child>
 		+ Send
 		+ Sync
 		+ 'static,


### PR DESCRIPTION
Add a SpawnFn type and set_spawn_fn/unset_spawn_fn API to Job, enabling callers to replace the default CommandWrap::spawn() with a custom function. This is useful for delegating process spawning to a privileged helper (e.g. for Linux capability granting) while keeping the supervisor's lifecycle management.