### PR TITLE
feat(config): add fs_ready signal for watcher readiness

### DIFF
--- a/crates/lib/src/sources/fs.rs
+++ b/crates/lib/src/sources/fs.rs
@@ -132,6 +132,7 @@ pub async fn worker(
 			);
 			watcher.take();
 			pathset.clear();
+			let _ = config.fs_ready.send(());
 			continue;
 		}
 
@@ -217,6 +218,8 @@ pub async fn worker(
 				pathset.insert(path);
 			}
 		}
+
+		let _ = config.fs_ready.send(());
 	}
 }
 


### PR DESCRIPTION
There is a race between spawning the fs worker and it actually registering OS watches (inotify/FSEvents). File changes that happen in that window are silently missed, and consumers have no way to know when watches are active. A yield_now() or sleep is insufficient because the worker may need multiple poll cycles to complete setup, especially on macOS where FSEvents restarts the stream on path changes.

The fs worker now signals via a watch channel after applying each pathset change, so consumers can subscribe before calling pathset() and await actual OS watch registration.