### PR TITLE
docs(lib): quit on Terminate in home page example

### DIFF
--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -125,8 +125,11 @@ async fn main() -> Result<()> {
     // now we change what the action does:
     let auto_restart_abort = auto_restart.abort_handle();
     wx.config.on_action(move |mut action| {
-        // if we get Ctrl-C on the Watchexec instance, we quit
-        if action.signals().any(|sig| sig == Signal::Interrupt) {
+        // if we get Ctrl-C or SIGTERM on the Watchexec instance, we quit
+        if action
+            .signals()
+            .any(|sig| matches!(sig, Signal::Interrupt | Signal::Terminate))
+        {
             eprintln!("[Quitting...]");
             auto_restart_abort.abort();
             action.quit_gracefully(Signal::ForceStop, Duration::ZERO);

--- a/crates/lib/examples/readme.rs
+++ b/crates/lib/examples/readme.rs
@@ -104,8 +104,11 @@ async fn main() -> Result<()> {
 	// now we change what the action does:
 	let auto_restart_abort = auto_restart.abort_handle();
 	wx.config.on_action(move |mut action| {
-		// if we get Ctrl-C on the Watchexec instance, we quit
-		if action.signals().any(|sig| sig == Signal::Interrupt) {
+		// if we get Ctrl-C or SIGTERM on the Watchexec instance, we quit
+		if action
+			.signals()
+			.any(|sig| matches!(sig, Signal::Interrupt | Signal::Terminate))
+		{
 			eprintln!("[Quitting...]");
 			auto_restart_abort.abort();
 			action.quit_gracefully(Signal::ForceStop, Duration::ZERO);

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -25,8 +25,11 @@
 //!             eprintln!("EVENT: {event:?}");
 //!         }
 //!
-//!         // if Ctrl-C is received, quit
-//!         if action.signals().any(|sig| sig == Signal::Interrupt) {
+//!         // if Ctrl-C or SIGTERM is received, quit
+//!         if action
+//!             .signals()
+//!             .any(|sig| matches!(sig, Signal::Interrupt | Signal::Terminate))
+//!         {
 //!             action.quit();
 //!         }
 //!


### PR DESCRIPTION
## Summary
- Update the crate docs home page example to quit on `Signal::Terminate` as well as `Signal::Interrupt` (Ctrl-C), matching the common case of process managers sending SIGTERM.
- Keep `crates/lib/README.md` and `examples/readme.rs` in sync with the same quit condition.

Closes #942

## Test plan
- [ ] Confirm the example still builds conceptually (docs `no_run` / matching README example).
- [ ] Spot-check docs.rs rendering after merge for the home page snippet.