### PR TITLE
fix: exec-replace safe shell commands so restart waits for the old process to actually exit

### DIFF
--- a/crates/supervisor/src/command/conversions.rs
+++ b/crates/supervisor/src/command/conversions.rs
@@ -112,10 +112,106 @@ fn pass_program_args_quoted(
 		command.arg(progopt);
 	}
 
-	command.arg(command_str);
+	// On Unix, have the shell replace itself with the command via `exec` instead of forking
+	// and waiting on it, when it's safe to do so (see `shell_command_is_execable`).
+	//
+	// Without this, the shell (e.g. `sh -c "the-command"`) is the direct child process that
+	// watchexec spawns and waits on, and the actual command is the shell's own child. A shell
+	// invoked this way has no signal handlers of its own, so when watchexec sends a graceful
+	// stop signal to the process group (e.g. for `--restart`), the shell is killed immediately
+	// while the real command - which may have its own signal handler to shut down gracefully -
+	// keeps running as an orphan in the same group. watchexec only waits on the shell, so it
+	// concludes the command has exited and starts a new one right away, even though the old
+	// command is still alive. See https://github.com/watchexec/watchexec/issues/960.
+	if cfg!(unix) && shell_command_is_execable(command_str) {
+		command.arg(format!("exec {command_str}"));
+	} else {
+		command.arg(command_str);
+	}
 
 	for arg in args {
 		command.arg(arg);
+	}
+}
+
+/// Whether it's safe to prefix `command` with `exec ` so the wrapping shell replaces itself
+/// with it, rather than running it as a child.
+///
+/// This is unsafe for commands that rely on the shell surviving past the first program it
+/// runs: sequencing (`;`, newlines), conditionals (`&&`, `||`), pipes (`|`), and backgrounding
+/// (`&`). `exec`ing into the first program of such a command would silently skip the rest of
+/// it, since control never returns to the shell.
+fn shell_command_is_execable(command: &str) -> bool {
+	!command.contains([';', '&', '|', '\n'])
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn simple_commands_are_execable() {
+		assert!(shell_command_is_execable("bun run src/test.ts"));
+		assert!(shell_command_is_execable("make"));
+		assert!(shell_command_is_execable("echo 'hello world'"));
+		assert!(shell_command_is_execable("cmd --flag=a > out.log"));
+		assert!(shell_command_is_execable("cmd $(echo sub)"));
+	}
+
+	#[test]
+	fn compound_commands_are_not_execable() {
+		assert!(!shell_command_is_execable("make build && make test"));
+		assert!(!shell_command_is_execable("make build; make test"));
+		assert!(!shell_command_is_execable("make build || make test"));
+		assert!(!shell_command_is_execable("cat file | grep foo"));
+		assert!(!shell_command_is_execable("server &"));
+		assert!(!shell_command_is_execable("line one\nline two"));
+	}
+
+	fn shell() -> Shell {
+		Shell::new("sh")
+	}
+
+	#[test]
+	fn quoted_args_exec_prefix_for_simple_command() {
+		let mut cmd = TokioCommand::new("sh");
+		pass_program_args_quoted(
+			&mut cmd,
+			&shell(),
+			&Vec::new(),
+			&"bun run src/test.ts".to_string(),
+		);
+
+		let args: Vec<_> = cmd
+			.as_std()
+			.get_args()
+			.map(|a| a.to_string_lossy().into_owned())
+			.collect();
+
+		if cfg!(unix) {
+			assert_eq!(args, vec!["-c", "exec bun run src/test.ts"]);
+		} else {
+			assert_eq!(args, vec!["-c", "bun run src/test.ts"]);
+		}
+	}
+
+	#[test]
+	fn quoted_args_no_exec_prefix_for_compound_command() {
+		let mut cmd = TokioCommand::new("sh");
+		pass_program_args_quoted(
+			&mut cmd,
+			&shell(),
+			&Vec::new(),
+			&"make build && make test".to_string(),
+		);
+
+		let args: Vec<_> = cmd
+			.as_std()
+			.get_args()
+			.map(|a| a.to_string_lossy().into_owned())
+			.collect();
+
+		assert_eq!(args, vec!["-c", "make build && make test"]);
 	}
 }
 

--- a/crates/supervisor/tests/programs.rs
+++ b/crates/supervisor/tests/programs.rs
@@ -1,4 +1,10 @@
-use watchexec_supervisor::command::{Command, Program, Shell};
+use std::{sync::Arc, time::Duration};
+
+use watchexec_supervisor::{
+	command::{Command, Program, Shell, SpawnOptions},
+	job::start_job,
+	Signal,
+};
 
 #[tokio::test]
 #[cfg(unix)]
@@ -76,6 +82,70 @@ async fn unix_shell_alternate_shopts() -> Result<(), std::io::Error> {
 	.await?
 	.success());
 	Ok(())
+}
+
+/// Regression test for https://github.com/watchexec/watchexec/issues/960
+///
+/// The command here is a *script*, invoked via `sh -c "/path/to/script"` - a single simple
+/// invocation, same shape as `watchexec -- ./script.sh`. Before the fix, that outer `sh` forks
+/// the script as its own child instead of exec-ing into it; the outer `sh` has no signal handler
+/// of its own, so sending the graceful-stop signal to the process group kills it immediately.
+/// Since that outer `sh` is the direct child the job waits on, the job would consider the
+/// command finished and start a new one right away - even though the actual script (a trapped,
+/// still-running child of that wrapper) hadn't exited yet. With the fix, the outer shell `exec`s
+/// into the script instead of forking it, so there's no separate un-trapped wrapper to kill
+/// early, and the job correctly waits for the script's own trap-driven shutdown.
+#[tokio::test]
+#[cfg(unix)]
+async fn restart_with_signal_waits_for_the_actual_command_to_exit() {
+	use std::os::unix::fs::PermissionsExt;
+
+	let unique = std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.expect("system time")
+		.as_nanos();
+	let script =
+		std::env::temp_dir().join(format!("watchexec-test-trap-{}-{unique}.sh", std::process::id()));
+	std::fs::write(
+		&script,
+		"#!/bin/sh\ntrap 'sleep 1; exit 0' TERM\nsleep 30\n",
+	)
+	.expect("write test script");
+	std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+		.expect("chmod test script");
+
+	let (job, task) = start_job(Arc::new(Command {
+		program: Program::Shell {
+			shell: Shell::new("sh"),
+			command: script.to_string_lossy().into_owned(),
+			args: Vec::new(),
+		},
+		options: SpawnOptions {
+			grouped: true,
+			..Default::default()
+		},
+	}));
+
+	job.start().await;
+
+	// give the shell a moment to exec into the script and install the trap before signalling
+	tokio::time::sleep(Duration::from_millis(300)).await;
+
+	let began = std::time::Instant::now();
+	job.restart_with_signal(Signal::Terminate, Duration::from_secs(5))
+		.await;
+	let elapsed = began.elapsed();
+
+	job.stop().await;
+	task.abort();
+	let _ = std::fs::remove_file(&script);
+
+	// the trap sleeps for 1s before exiting; if the restart didn't actually wait for it,
+	// this would resolve almost instantly instead
+	assert!(
+		elapsed >= Duration::from_millis(800),
+		"restart resolved after {elapsed:?}, expected it to wait for the trapped shutdown (~1s)"
+	);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What's the bug

`watchexec -r` (and `--on-busy-update=restart`) don't actually wait for the old process to exit before starting the new one, even with `--stop-signal`/`--stop-timeout` set. Reported in #960 with a script that traps `SIGTERM` and takes ~3s to shut down: the moment the signal is sent, watchexec immediately starts a new instance, and the old one keeps running (and logging) for several more seconds in parallel.

## Root cause

By default (unless `-n`/`--shell=none` is passed) watchexec spawns the user's command through a shell, e.g. `sh -c "the-command"`. That `sh` process is the *direct child* watchexec spawns and `.wait()`s on to know when the command has finished - but `sh` itself has no `SIGTERM` handler. When watchexec sends the graceful-stop signal to the whole process group (for a restart), `sh` is killed immediately by the default signal disposition, while the actual command - a *child* of that `sh`, and the one that may have its own signal handler doing a graceful shutdown - is orphaned but keeps running in the same process group.

Since watchexec only waits on the shell it directly spawned, it sees that direct child exit and concludes the whole command is done, so the queued "start the new process" control fires right away - while the real old process is still alive and shutting down.

I confirmed this by building the CLI and running a close repro of the issue's script in Docker (trace logs + `ps` snapshots): the wrapping `sh` is a distinct, un-trapped PID from the actual script, and it dies within ~1ms of the signal being sent, well before the script's own trap-driven shutdown (which takes the full delay) completes.

Note: watchexec already wraps Unix commands in a process group and, per `process-wrap`'s `ProcessGroupChild::wait()`, loop-reaps the whole group via `waitpid(-pgid, ...)` after the direct child exits - but that can only reap processes that are still watchexec's *children*. Once `sh` dies, the real command is orphaned and reparented to PID 1 (neither watchexec nor process-wrap register as a child subreaper), so it falls out of reach of that wait loop entirely - group membership and parentage are separate things in POSIX. Exec-prefixing sidesteps this by removing the extra process, so the command stays a direct child and the existing group-wait logic just works.

## The fix

`crates/supervisor/src/command/conversions.rs`: when building the shell invocation, prefix the command with `exec ` so the shell replaces itself with the program (`execve`) instead of forking and waiting on it. This removes the extra, un-trapped wrapper process entirely - the program watchexec's job supervisor waits on *is* the real command.

This is only applied when it's actually safe:
- Unix only (`cfg!(unix)`) - Windows doesn't have the same signal/process-group semantics, and `cmd.exe`/PowerShell aren't touched by this at all.
- Only for commands that don't rely on the shell surviving past the first program in them - i.e. no `;`, `&&`, `||`, `|`, `&`, or newlines (checked by a small `shell_command_is_execable` heuristic). A command like `make build && make test` genuinely needs the shell to stay alive to run the second half, so `exec`-prefixing it would silently drop `make test`. The common case of `watchexec -- prog arg1 arg2` (which is how the CLI joins positional args into the shell command string) is always a single simple invocation and is always safe.

## Testing

- Added `crates/supervisor/tests/programs.rs::restart_with_signal_waits_for_the_actual_command_to_exit`: spawns a real shell script that installs a `SIGTERM` trap with a deliberate 1s delay, then asserts `restart_with_signal(...).await` actually takes ~1s rather than resolving almost instantly. I verified this test fails without the fix (resolves in ~1-2ms) and passes with it.
- Added unit tests for the `shell_command_is_execable` heuristic and for the actual argv produced by `pass_program_args_quoted`, covering both the simple (`exec`-prefixed) and compound (untouched) cases.
- `cargo test --workspace` passes in full (built/tested in Docker on Linux, since I don't have a Rust toolchain on this machine).
- Manually re-ran a close repro of the issue's script end-to-end against the built CLI, before and after the fix - confirmed the new process now only starts after the old one's trapped shutdown actually completes, and that the spawned process is now a direct child of watchexec with no intermediate shell in `ps`.

Will partially fix <!-- break github's autoclose --> #960

