### PR TITLE
fix(cli): don't use a verbatim UNC path as the workdir

### DIFF
--- a/crates/cli/src/args/command.rs
+++ b/crates/cli/src/args/command.rs
@@ -1,7 +1,7 @@
 use std::{
 	ffi::{OsStr, OsString},
 	mem::take,
-	path::PathBuf,
+	path::{Path, PathBuf},
 };
 
 use clap::{
@@ -321,7 +321,8 @@ impl CommandArgs {
 			w
 		} else {
 			let curdir = std::env::current_dir().into_diagnostic()?;
-			dunce::canonicalize(curdir).into_diagnostic()?
+			let canonical = dunce::canonicalize(&curdir).into_diagnostic()?;
+			prefer_non_verbatim(canonical, curdir)
 		};
 		info!(path=?workdir, "effective working directory");
 		self.workdir = Some(workdir);
@@ -329,6 +330,22 @@ impl CommandArgs {
 		debug_assert!(self.workdir.is_some());
 		Ok(())
 	}
+}
+
+/// `dunce::canonicalize` only strips the `\\?\` prefix off verbatim *disk* paths, so canonicalising
+/// inside a network share yields `\\?\UNC\server\share\...`, which many programs (notably the Go
+/// toolchain) refuse as a working directory. In that case keep the uncanonicalised path, as long as
+/// it isn't verbatim itself.
+fn prefer_non_verbatim(canonical: PathBuf, original: PathBuf) -> PathBuf {
+	if is_verbatim(&canonical) && !is_verbatim(&original) {
+		original
+	} else {
+		canonical
+	}
+}
+
+fn is_verbatim(path: &Path) -> bool {
+	path.as_os_str().as_encoded_bytes().starts_with(br"\\?\")
 }
 
 #[derive(Clone, Copy, Debug, Default, ValueEnum)]
@@ -375,5 +392,40 @@ impl TypedValueParser for EnvVarValueParser {
 			key: key.into(),
 			value: value.into(),
 		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn keeps_uncanonicalised_path_when_canonical_is_verbatim_unc() {
+		assert_eq!(
+			prefer_non_verbatim(
+				PathBuf::from(r"\\?\UNC\Mac\my-directory"),
+				PathBuf::from(r"Z:\my-directory"),
+			),
+			PathBuf::from(r"Z:\my-directory"),
+		);
+	}
+
+	#[test]
+	fn keeps_canonical_path_when_it_is_not_verbatim() {
+		assert_eq!(
+			prefer_non_verbatim(PathBuf::from(r"Z:\real"), PathBuf::from(r"Z:\link")),
+			PathBuf::from(r"Z:\real"),
+		);
+	}
+
+	#[test]
+	fn keeps_canonical_path_when_original_is_verbatim_too() {
+		assert_eq!(
+			prefer_non_verbatim(
+				PathBuf::from(r"\\?\UNC\Mac\my-directory"),
+				PathBuf::from(r"\\?\UNC\Mac\other"),
+			),
+			PathBuf::from(r"\\?\UNC\Mac\my-directory"),
+		);
 	}
 }


### PR DESCRIPTION
Closes #925.

## Problem

When `--workdir` isn't given, `CommandArgs::normalise` derives the workdir with `dunce::canonicalize(std::env::current_dir()?)`.

`dunce` only strips the `\\?\` prefix when the canonical path is a `Prefix::VerbatimDisk` — its `is_safe_to_strip_unc` bails out on every other prefix kind, including `VerbatimUNC`. So inside a network share (in the report, a macOS folder shared into a Parallels Windows VM and mapped to `Z:\`), `fs::canonicalize` resolves the mapping to `\\?\UNC\Mac\my-directory` and dunce leaves it as-is. That path is then handed to `Command::current_dir`, and the Go toolchain (among others) can't work with it.

The reporter's workaround was to pass `--workdir $PWD.ProviderPath` — i.e. the plain, uncanonicalised current directory.

## Change

If canonicalising produced a verbatim path *and* the pre-canonicalisation `current_dir()` wasn't verbatim, keep the latter. Otherwise nothing changes:

- Non-Windows: `current_dir()` never starts with `\\?\`, and neither does the canonical form, so this is a no-op and symlink resolution is preserved.
- Windows local disks: `dunce::canonicalize` already returns a non-verbatim path, so it's kept as before.
- Explicit `--workdir` is untouched.

Only the case that previously produced an unusable `\\?\UNC\...` workdir behaves differently.

I kept `canonicalize` rather than dropping it, so this stays the narrowest change that fixes the reported breakage.

## Tests

`prefer_non_verbatim` is pure string/path manipulation, so the three regression tests run on every platform rather than being gated behind `cfg(windows)`.

## Verification

- `cargo test --workspace` — all green (the 3 new tests included).
- `cargo clippy -p watchexec-cli --all-targets` — no new lints on the touched file; the three warnings it reports there (`struct_excessive_bools`, `redundant_pub_crate`, `unused_async`) are all pre-existing.
- `cargo fmt --check` — the touched file is clean; the two diffs it reports are pre-existing, in `crates/supervisor/src/job/`.
- Workspace-wide `cargo clippy --all-targets -- -D warnings` fails on `watchexec-events` and `watchexec-supervisor`; I confirmed against a `git stash` baseline that those failures are identical with and without this change.

**Limitation, disclosed honestly:** I developed and tested this on macOS. I could not exercise the actual Windows network-share path — the reasoning about dunce's behaviour comes from reading `dunce` 1.0.5's `is_safe_to_strip_unc`, not from observing it on a Windows VM. The runtime behaviour change is therefore unverified on the affected platform, though the logic itself is covered by the unit tests.

---

Per CONTRIBUTING.md's disclosure requirement: this patch was written with AI assistance (Claude), and the commit carries a `Co-authored-by` line. A human reviewed the diff and ran the commands above.