### PR TITLE
fix(cli): --map-signal errors name neither the flag nor the value

### DIFF
--- a/crates/cli/src/args/events.rs
+++ b/crates/cli/src/args/events.rs
@@ -1,7 +1,9 @@
 use std::{ffi::OsStr, path::PathBuf};
 
 use clap::{
-	builder::TypedValueParser, error::ErrorKind, Arg, Command, CommandFactory, Parser, ValueEnum,
+	builder::TypedValueParser,
+	error::{ContextKind, ContextValue, ErrorKind},
+	Arg, Command, CommandFactory, Parser, ValueEnum,
 };
 use miette::Result;
 
@@ -388,28 +390,116 @@ impl TypedValueParser for SignalMappingValueParser {
 
 	fn parse_ref(
 		&self,
-		_cmd: &Command,
-		_arg: Option<&Arg>,
+		cmd: &Command,
+		arg: Option<&Arg>,
 		value: &OsStr,
 	) -> Result<Self::Value, clap::error::Error> {
-		let value = value
-			.to_str()
-			.ok_or_else(|| clap::error::Error::raw(ErrorKind::ValueValidation, "invalid UTF-8"))?;
-		let (from, to) = value
-			.split_once(':')
-			.ok_or_else(|| clap::error::Error::raw(ErrorKind::ValueValidation, "missing ':'"))?;
+		let invalid = |reason: String| invalid_signal_mapping(cmd, arg, value, reason);
 
-		let from = from
-			.parse::<Signal>()
-			.map_err(|sigparse| clap::error::Error::raw(ErrorKind::ValueValidation, sigparse))?;
+		let string = value
+			.to_str()
+			.ok_or_else(|| invalid("value is not valid UTF-8".into()))?;
+		let (from, to) = string.split_once(':').ok_or_else(|| {
+			invalid("missing ':' separator between the received and sent signals".into())
+		})?;
+
+		let from = from.parse::<Signal>().map_err(|sigparse| {
+			invalid(format!("invalid signal to map from ('{from}'): {sigparse}"))
+		})?;
 		let to = if to.is_empty() {
 			None
 		} else {
 			Some(to.parse::<Signal>().map_err(|sigparse| {
-				clap::error::Error::raw(ErrorKind::ValueValidation, sigparse)
+				invalid(format!("invalid signal to map to ('{to}'): {sigparse}"))
 			})?)
 		};
 
 		Ok(Self::Value { from, to })
+	}
+}
+
+/// Build a `ValueValidation` error through clap's machinery, so that it names the flag, echoes the
+/// offending value, and is rendered (and terminated) by clap's formatter.
+fn invalid_signal_mapping(
+	cmd: &Command,
+	arg: Option<&Arg>,
+	value: &OsStr,
+	reason: String,
+) -> clap::error::Error {
+	let mut err = clap::error::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+	err.insert(
+		ContextKind::InvalidArg,
+		ContextValue::String(arg.map_or_else(
+			|| "--map-signal <SIGNAL:SIGNAL>".into(),
+			ToString::to_string,
+		)),
+	);
+	err.insert(
+		ContextKind::InvalidValue,
+		ContextValue::String(value.to_string_lossy().into_owned()),
+	);
+	err.insert(
+		ContextKind::Suggested,
+		ContextValue::StyledStrs(vec![reason.into()]),
+	);
+	err
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn parse_map_signal(value: &str) -> Result<Vec<SignalMapping>, String> {
+		super::super::Args::command()
+			.try_get_matches_from(["watchexec", "--map-signal", value, "true"])
+			.map(|matches| {
+				matches
+					.get_many::<SignalMapping>("signal_map")
+					.into_iter()
+					.flatten()
+					.copied()
+					.collect()
+			})
+			.map_err(|err| err.render().to_string())
+	}
+
+	#[test]
+	fn valid_signal_mapping_parses() {
+		let mappings = parse_map_signal("TERM:INT").expect("TERM:INT should parse");
+		assert_eq!(mappings.len(), 1);
+		assert_eq!(mappings[0].from, Signal::Terminate);
+		assert_eq!(mappings[0].to, Some(Signal::Interrupt));
+
+		let mappings = parse_map_signal("TERM:").expect("TERM: should parse");
+		assert_eq!(mappings.len(), 1);
+		assert_eq!(mappings[0].from, Signal::Terminate);
+		assert_eq!(mappings[0].to, None);
+	}
+
+	#[test]
+	fn invalid_signal_mapping_errors_name_the_flag_and_the_value() {
+		for (value, reason) in [
+			("FOO", "missing ':' separator"),
+			(":TERM", "invalid signal to map from ('')"),
+			("TERM:FOO", "invalid signal to map to ('FOO')"),
+		] {
+			let err = parse_map_signal(value).expect_err("should not parse");
+			assert!(
+				err.contains("--map-signal"),
+				"error for {value:?} should name the flag: {err:?}"
+			);
+			assert!(
+				err.contains(&format!("'{value}'")),
+				"error for {value:?} should echo the value: {err:?}"
+			);
+			assert!(
+				err.contains(reason),
+				"error for {value:?} should explain the problem: {err:?}"
+			);
+			assert!(
+				err.ends_with('\n'),
+				"error for {value:?} should end with a newline: {err:?}"
+			);
+		}
 	}
 }


### PR DESCRIPTION
## What's broken

A bad `--map-signal` value produces a raw error that names neither the flag nor the value, and has no trailing newline.

```
$ watchexec -1 --map-signal "FOO" true | cat -A
error: missing ':'
$ watchexec -1 --map-signal ":TERM" true | cat -A
error: invalid signal ``: unknown control name
```

The second is the clearest: the left side of the mapping is missing, and it reports an empty pair of backticks instead of saying so.

Every other flag looks like this:

```
$ watchexec -1 --clear bogus true | cat -A
error: invalid value 'bogus' for '--clear [<MODE>]'$
  [possible values: clear, reset]$
$
For more information, try '--help'.$
```

## The fix

`SignalMappingValueParser::parse_ref` built its errors with `clap::error::Error::raw`, which bypasses clap's formatter entirely, and ignored the `cmd` and `arg` parameters it was handed. It now builds a `ValueValidation` error through clap's own machinery, using those parameters, so the flag name and the offending value come from clap rather than from a hand-written string.

```
$ watchexec -1 --map-signal "FOO" true | cat -A
error: invalid value 'FOO' for '--map-signal <SIGNAL:SIGNAL>'$
$
  tip: missing ':' separator between the received and sent signals$
$
For more information, try '--help'.$

$ watchexec -1 --map-signal ":TERM" true | cat -A
error: invalid value ':TERM' for '--map-signal <SIGNAL:SIGNAL>'$
$
  tip: invalid signal to map from (''): invalid signal ``: unknown control name$
$
For more information, try '--help'.$
```

`TERM:FOO` says "invalid signal to map to ('FOO')", so which side is wrong is now stated rather than inferred.

Valid values are untouched: `--map-signal TERM:INT` and the empty-right-hand form `TERM:` both still parse to the same values.

## Verification

Two tests in a new `mod tests` in the same file, following the pattern in `args/command.rs`. One pins the valid parses, the other asserts each error names the flag, echoes the value, and gives the reason. With the error construction reverted to `Error::raw` the second fails with `error for "FOO" should name the flag: "error: missing ':'"`.

`cargo test -p watchexec-cli` passes and `cargo fmt -- --check` is clean. Clippy shows nothing new, the remaining warnings are pre-existing in `config.rs`, which this does not touch. No version or `Cargo.toml` changes.

Per CONTRIBUTING: this was written with AI assistance, disclosed in the commit trailer.
