### PR TITLE
ci: enforce the committed dependency lockfile

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -57,4 +57,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
 
-    - run: cargo clippy
+    - run: cargo clippy --locked

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,10 @@ jobs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Run library test suite
-      run: cargo test --workspace --exclude watchexec-cli --exclude watchexec-events
+      run: cargo test --locked --workspace --exclude watchexec-cli --exclude watchexec-events
 
     - name: Run watchexec-events integration tests
-      run: cargo test -p watchexec-events -F serde
+      run: cargo test --locked -p watchexec-events -F serde
 
   cli-e2e:
     strategy:
@@ -91,7 +91,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Build CLI programs
-      run: cargo build
+      run: cargo build --locked
 
     - name: Run CLI integration tests
       run: crates/cli/run-tests.sh ${{ matrix.platform }}
@@ -115,7 +115,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Generate manpage
-      run: cargo run -p watchexec-cli -- --manual > doc/watchexec.1
+      run: cargo run --locked -p watchexec-cli -- --manual > doc/watchexec.1
     - name: Check that manpage is up to date
       run: git diff --exit-code -- doc/
 
@@ -154,7 +154,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Run CLI unit tests
-      run: cargo test -p watchexec-cli
+      run: cargo test --locked -p watchexec-cli
 
   bosion:
     strategy:
@@ -213,7 +213,7 @@ jobs:
       run: sudo apt-get install -y musl-tools
 
     - uses: Swatinem/rust-cache@v2
-    - run: cargo check --target ${{ matrix.target }}
+    - run: cargo check --locked --target ${{ matrix.target }}
 
   tests-pass:
     if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -52,15 +67,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -544,7 +568,7 @@ version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -2952,9 +2976,12 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "siphasher"
@@ -2976,11 +3003,11 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snapbox"
-version = "0.6.24"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1abc378119f77310836665f8523018532cf7e3faeb3b10b01da5a7321bf8e1"
+checksum = "8de56eb4784a2c5c1efede55a0f06fbf481bc12b42b355b9525c15db1e3581a8"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "normalize-line-endings",
  "similar",
@@ -2989,11 +3016,11 @@ dependencies = [
 
 [[package]]
 name = "snapbox-macros"
-version = "0.4.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b750c344002d7cc69afb9da00ebd9b5c0f8ac2eb7d115d9d45d5b5f47718d74"
+checksum = "ed4a172e483585ebbc7c7f7d1705ca7e3f94f606ed78caa14805673189fd5455"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
 ]
 
 [[package]]
@@ -3784,7 +3811,7 @@ dependencies = [
  "futures",
  "libc",
  "miette",
- "nix 0.31.1",
+ "nix 0.31.2",
  "normalize-path",
  "notify",
  "thiserror 2.0.18",
@@ -3827,7 +3854,7 @@ dependencies = [
  "libc",
  "miette",
  "mimalloc",
- "nix 0.31.1",
+ "nix 0.31.2",
  "notify-rust",
  "pid1",
  "project-origins",
@@ -3897,7 +3924,7 @@ name = "watchexec-signals"
 version = "5.0.1"
 dependencies = [
  "miette",
- "nix 0.31.1",
+ "nix 0.31.2",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -3908,7 +3935,7 @@ version = "5.2.0"
 dependencies = [
  "boxcar",
  "futures",
- "nix 0.31.1",
+ "nix 0.31.2",
  "process-wrap",
  "tokio",
  "tracing",


### PR DESCRIPTION
## Summary

- refresh `Cargo.lock` after the `snapbox` requirement update in #1044
- add `--locked` to regular Cargo test, build, documentation, cross-check, and Clippy jobs
- make manifest/lockfile drift fail during ordinary CI instead of first appearing in the tagged release workflow

This was discovered while validating the Windows ARM64 release work tracked in #1070. The existing release command already uses `--locked`, and every release target failed before compilation because the checked-in lockfile still resolved `snapbox` 0.6.x while the manifest requires 1.2.1.

This PR is a prerequisite for the separate Windows ARM64 release PR; it does not close #1070 itself.

## Validation

- `cargo check --locked --workspace --all-targets`
- `cargo test --locked --workspace --no-run`
- the fork release workflow advances past the previous lockfile-resolution failure

Prepared with assistance from OpenAI Codex; the commit includes a `Co-authored-by` trailer.