### PR TITLE
ci: build and test the CLI on native Windows ARM64

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -131,7 +131,7 @@ jobs:
             os: windows-11-arm
             target: aarch64-pc-windows-msvc
             cross: false
-            experimental: false
+            experimental: true
 
     name: Binaries for ${{ matrix.name }}
     needs: info

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -127,11 +127,11 @@ jobs:
             cross: false
             experimental: false
 
-          #- name: windows-arm64
-          #  os: windows-latest
-          #  target: aarch64-pc-windows-msvc
-          #  cross: true
-          #  experimental: true
+          - name: windows-arm64
+            os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            cross: false
+            experimental: false
 
     name: Binaries for ${{ matrix.name }}
     needs: info

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - macos
-          - ubuntu
-          - windows
+        include:
+          - { platform: macos, runner: macos-latest }
+          - { platform: ubuntu, runner: ubuntu-latest }
+          - { platform: windows, runner: windows-latest }
+          - { platform: windows-arm64, runner: windows-11-arm }
 
     name: Test libraries ${{ matrix.platform }}
-    runs-on: "${{ matrix.platform }}-latest"
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - uses: actions/checkout@v6
@@ -61,13 +62,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - macos
-          - ubuntu
-          - windows
+        include:
+          - { platform: macos, runner: macos-latest, test-platform: macos }
+          - { platform: ubuntu, runner: ubuntu-latest, test-platform: ubuntu }
+          - { platform: windows, runner: windows-latest, test-platform: windows }
+          - { platform: windows-arm64, runner: windows-11-arm, test-platform: windows }
 
     name: Test CLI (e2e) ${{ matrix.platform }}
-    runs-on: "${{ matrix.platform }}-latest"
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - uses: actions/checkout@v6
@@ -94,7 +96,7 @@ jobs:
       run: cargo build --locked
 
     - name: Run CLI integration tests
-      run: crates/cli/run-tests.sh ${{ matrix.platform }}
+      run: crates/cli/run-tests.sh ${{ matrix.test-platform }}
       shell: bash
       env:
         WATCHEXEC_BIN: target/debug/watchexec
@@ -128,13 +130,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - macos
-          - ubuntu
-          - windows
+        include:
+          - { platform: macos, runner: macos-latest }
+          - { platform: ubuntu, runner: ubuntu-latest }
+          - { platform: windows, runner: windows-latest }
+          - { platform: windows-arm64, runner: windows-11-arm }
 
     name: Test CLI (unit) ${{ matrix.platform }}
-    runs-on: "${{ matrix.platform }}-latest"
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - uses: actions/checkout@v6
@@ -160,13 +163,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - macos
-          - ubuntu
-          - windows
+        include:
+          - { platform: macos, runner: macos-latest }
+          - { platform: ubuntu, runner: ubuntu-latest }
+          - { platform: windows, runner: windows-latest }
+          - { platform: windows-arm64, runner: windows-11-arm }
 
     name: Bosion integration tests on ${{ matrix.platform }}
-    runs-on: "${{ matrix.platform }}-latest"
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - uses: actions/checkout@v6

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -167,6 +167,9 @@ pkg-fmt = "txz"
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"
 
+[package.metadata.binstall.overrides.aarch64-pc-windows-msvc]
+pkg-fmt = "zip"
+
 [package.metadata.deb]
 maintainer = "Félix Saparelli <felix@passcod.name>"
 license-file = ["../../LICENSE", "0"]


### PR DESCRIPTION
## Summary

- build `aarch64-pc-windows-msvc` on GitHub's native `windows-11-arm` runner
- run the library, CLI unit, CLI end-to-end, and Bosion test suites on Windows ARM64
- package the release through the existing Windows ZIP path
- declare the ZIP format for Cargo Binstall's Windows ARM64 target metadata

Depends on #1071. Until that prerequisite merges, GitHub will also show its lockfile/CI commit in this stacked PR; after #1071 merges, this PR reduces to the Windows ARM64 release and test commits.

Closes #1070.

## Validation

The native Windows ARM64 release job successfully completed the locked build, packaging, ZIP creation, and artifact upload:

https://github.com/meop/watchexec/actions/runs/31947048296/job/95164633676

The newly added ARM64 test jobs are exercised by the updated PR workflow. The earlier overall fork release matrix was red from unrelated existing release-tool failures on other targets; the linked Windows ARM64 release job was green.

Prepared with assistance from OpenAI Codex; the ARM64 commits include `Co-authored-by` trailers.