### PR TITLE
fix(cli): --emit-events-to=stdio never emits the documented rename: prefix

### DIFF
--- a/crates/cli/src/emits.rs
+++ b/crates/cli/src/emits.rs
@@ -2,7 +2,10 @@ use std::{fmt::Write, path::PathBuf};
 
 use miette::{IntoDiagnostic, Result};
 use watchexec::paths::summarise_events_to_env;
-use watchexec_events::{filekind::FileEventKind, Event, Tag};
+use watchexec_events::{
+	filekind::{FileEventKind, ModifyKind},
+	Event, Tag,
+};
 
 use crate::{args::command::EnvVar, state::RotatingTempFile};
 
@@ -41,6 +44,7 @@ pub fn events_to_simple_format(events: &[Event]) -> Result<String> {
 						FileEventKind::Any | FileEventKind::Other => "other",
 						FileEventKind::Access(_) => "access",
 						FileEventKind::Create(_) => "create",
+						FileEventKind::Modify(ModifyKind::Name(_)) => "rename",
 						FileEventKind::Modify(_) => "modify",
 						FileEventKind::Remove(_) => "remove",
 					},
@@ -71,4 +75,56 @@ pub fn emits_to_json_file(target: &RotatingTempFile, events: &[Event]) -> Result
 		target.write(b"\n")?;
 	}
 	Ok(target.path())
+}
+
+#[cfg(test)]
+mod tests {
+	use watchexec_events::{
+		filekind::{DataChange, MetadataKind, ModifyKind, RenameMode},
+		FileType,
+	};
+
+	use super::*;
+
+	fn event(kind: FileEventKind) -> Event {
+		Event {
+			tags: vec![
+				Tag::Path {
+					path: PathBuf::from("/tmp/file"),
+					file_type: Some(FileType::File),
+				},
+				Tag::FileEventKind(kind),
+			],
+			metadata: Default::default(),
+		}
+	}
+
+	#[test]
+	fn renames_are_prefixed_rename_not_modify() {
+		assert_eq!(
+			events_to_simple_format(&[event(FileEventKind::Modify(ModifyKind::Name(
+				RenameMode::Both
+			)))])
+			.unwrap(),
+			"rename:/tmp/file\n"
+		);
+	}
+
+	#[test]
+	fn other_modifies_are_still_prefixed_modify() {
+		assert_eq!(
+			events_to_simple_format(&[event(FileEventKind::Modify(ModifyKind::Data(
+				DataChange::Content
+			)))])
+			.unwrap(),
+			"modify:/tmp/file\n"
+		);
+		assert_eq!(
+			events_to_simple_format(&[event(FileEventKind::Modify(ModifyKind::Metadata(
+				MetadataKind::Permissions
+			)))])
+			.unwrap(),
+			"modify:/tmp/file\n"
+		);
+	}
 }


### PR DESCRIPTION
## What's broken

`--emit-events-to=stdio` and `=file` document a `rename:` prefix, but it is never emitted. Renames come out as `modify:`.

The prefix is documented in the `--emit-events-to` help text (`crates/cli/src/args/events.rs`) and in `doc/watchexec.1`.

## Repro

`mv a.txt b.txt` in a watched directory:

```
$ watchexec -1 --postpone --emit-events-to=stdio -w $D --shell=none -- cat

before:
modify:$D/a.txt
modify:$D/b.txt

after:
rename:$D/a.txt
rename:$D/b.txt
```

## The fix

`events_to_simple_format` matched `FileEventKind::Modify(_)` before looking at the `ModifyKind`, so the rename case was unreachable. Added a `Modify(ModifyKind::Name(_))` arm above it. Data and metadata changes still map to `modify:`.

## Verification

Two tests in `crates/cli/src/emits.rs`: one asserts a rename gets `rename:`, one asserts data and metadata changes still get `modify:` so the narrower arm did not capture them. Flipping the new arm back to `modify` fails the first with an assertion, not a build error. Output above is from the rebuilt binary, not the unit test.

`cargo test -p watchexec-cli` passes, 23 lib tests plus the e2e ignore test. Two pre-existing issues unrelated to this change, both present on a clean `main`: `cargo fmt --check` fails in `crates/supervisor`, and there is an unused-import warning in `crates/cli/src/config.rs`.
