### PR TITLE
fix(cli): project origin discovery never sees the watched paths

### DIFF
--- a/crates/cli/src/dirs.rs
+++ b/crates/cli/src/dirs.rs
@@ -15,7 +15,8 @@ use crate::args::{command::CommandArgs, filtering::FilteringArgs, Args};
 pub async fn project_origin(
 	FilteringArgs {
 		project_origin,
-		paths,
+		recursive_paths,
+		non_recursive_paths,
 		..
 	}: &FilteringArgs,
 	CommandArgs { workdir, .. }: &CommandArgs,
@@ -30,18 +31,21 @@ pub async fn project_origin(
 		};
 		debug!(?homedir, "home directory");
 
-		let homedir_requested = homedir.as_ref().map_or(false, |home| {
-			paths
-				.binary_search_by_key(home, |w| PathBuf::from(w.clone()))
-				.is_ok()
-		});
+		// The watched paths aren't resolved yet at this point (that needs the origin), so do it
+		// here against the workdir, without canonicalising, so that missing paths aren't fatal.
+		let paths = watch_candidates(recursive_paths, non_recursive_paths, workdir.as_deref());
+		debug!(?paths, "candidate paths for origin discovery");
+
+		let homedir_requested = homedir
+			.as_ref()
+			.map_or(false, |home| paths.iter().any(|path| path == home));
 		debug!(
 			?homedir_requested,
 			"resolved whether the homedir is explicitly requested"
 		);
 
 		let mut origins = HashSet::new();
-		for path in paths {
+		for path in &paths {
 			origins.extend(project_origins::origins(path).await);
 		}
 
@@ -71,6 +75,36 @@ pub async fn project_origin(
 	debug!(?project_origin, "resolved common/project origin");
 
 	Ok(project_origin)
+}
+
+/// Resolves the paths given with `-w` / `-W` against the workdir, for use as starting points of
+/// origin discovery. Relative paths are joined onto the workdir; the `/dev/null` sentinel (which
+/// means "watch nothing") is skipped. If nothing is left, the workdir itself is the only candidate.
+fn watch_candidates(
+	recursive_paths: &[PathBuf],
+	non_recursive_paths: &[PathBuf],
+	workdir: Option<&Path>,
+) -> Vec<PathBuf> {
+	let mut paths: Vec<PathBuf> = recursive_paths
+		.iter()
+		.chain(non_recursive_paths)
+		.filter(|path| path.as_path() != Path::new("/dev/null"))
+		.map(|path| {
+			if path.is_absolute() {
+				path.clone()
+			} else {
+				workdir.map_or_else(|| path.clone(), |wd| wd.join(path))
+			}
+		})
+		.collect();
+
+	if paths.is_empty() {
+		if let Some(workdir) = workdir {
+			paths.push(workdir.to_owned());
+		}
+	}
+
+	paths
 }
 
 pub async fn vcs_types(origin: &Path) -> Vec<ProjectType> {
@@ -226,4 +260,109 @@ pub async fn ignores(args: &Args, vcs_types: &[ProjectType]) -> Result<Vec<Ignor
 
 	info!(files=?ignores.iter().map(|ig| ig.path.as_path()).collect::<Vec<_>>(), "found some ignores");
 	Ok(ignores)
+}
+
+#[cfg(test)]
+mod tests {
+	use clap::Parser;
+
+	use super::*;
+	use crate::args::Args;
+
+	fn args_in(workdir: &Path, extra: &[&str]) -> Args {
+		let mut args = Args::parse_from(
+			std::iter::once("watchexec")
+				.chain(extra.iter().copied())
+				.chain(std::iter::once("true")),
+		);
+		args.command.workdir = Some(workdir.to_owned());
+		args
+	}
+
+	async fn origin_in(workdir: &Path, extra: &[&str]) -> PathBuf {
+		let args = args_in(workdir, extra);
+		project_origin(&args.filtering, &args.command)
+			.await
+			.expect("origin should resolve")
+	}
+
+	/// The origin has to be discovered by walking up from the watched paths (or the workdir when
+	/// there are none), so running from anywhere inside a project must find the same origin, not
+	/// whichever directory happens to be current.
+	#[tokio::test]
+	async fn discovers_the_same_origin_from_anywhere_in_the_project() {
+		let tmp = tempfile::tempdir().expect("tempdir");
+		let root = tmp.path().join("project");
+		let deep = root.join("deep");
+		let sub = deep.join("sub");
+		std::fs::create_dir_all(&sub).expect("create dirs");
+		std::fs::write(root.join("Cargo.toml"), "").expect("write marker");
+
+		let from_root = origin_in(&root, &[]).await;
+		let from_deep = origin_in(&deep, &[]).await;
+		let from_sub = origin_in(&sub, &[]).await;
+
+		assert_eq!(
+			from_deep, from_root,
+			"origin from {deep:?} should be the same as from {root:?}"
+		);
+		assert_eq!(
+			from_sub, from_root,
+			"origin from {sub:?} should be the same as from {root:?}"
+		);
+		assert_ne!(
+			from_sub, sub,
+			"origin should not just be the current directory"
+		);
+	}
+
+	/// Same, but for a path given with '-w' rather than the workdir.
+	#[tokio::test]
+	async fn discovers_the_origin_of_a_watched_path() {
+		let tmp = tempfile::tempdir().expect("tempdir");
+		let root = tmp.path().join("project");
+		let sub = root.join("deep").join("sub");
+		let outside = tmp.path().join("outside");
+		std::fs::create_dir_all(&sub).expect("create dirs");
+		std::fs::create_dir_all(&outside).expect("create dirs");
+		std::fs::write(root.join("Cargo.toml"), "").expect("write marker");
+
+		let watched = origin_in(&outside, &["-w", sub.to_str().expect("utf-8 path")]).await;
+		assert_eq!(
+			watched,
+			origin_in(&root, &[]).await,
+			"origin of watched {sub:?} should be the project origin"
+		);
+	}
+
+	#[test]
+	fn watch_candidates_resolve_against_the_workdir() {
+		let workdir = Path::new("/work/dir");
+		assert_eq!(
+			watch_candidates(
+				&[PathBuf::from("rel"), PathBuf::from("/abs")],
+				&[PathBuf::from("nonrec")],
+				Some(workdir),
+			),
+			vec![
+				PathBuf::from("/work/dir/rel"),
+				PathBuf::from("/abs"),
+				PathBuf::from("/work/dir/nonrec"),
+			]
+		);
+	}
+
+	#[test]
+	fn watch_candidates_fall_back_to_the_workdir() {
+		let workdir = Path::new("/work/dir");
+		assert_eq!(
+			watch_candidates(&[], &[], Some(workdir)),
+			vec![PathBuf::from("/work/dir")]
+		);
+		assert_eq!(
+			watch_candidates(&[PathBuf::from("/dev/null")], &[], Some(workdir)),
+			vec![PathBuf::from("/work/dir")],
+			"/dev/null means watch nothing, so it isn't a discovery starting point"
+		);
+	}
 }


### PR DESCRIPTION
## What's broken

Project origin discovery never runs. `FilteringArgs::normalise` calls `dirs::project_origin` at line 426 but only populates `self.paths` at line 433, and `project_origin` read `paths`, so it always saw an empty list, took the "no origins" branch, and used the working directory.

That silently changes which ignore files are loaded, which VCS is detected, and what a leading `/` means in a filter pattern.

Regressed in #827, which moved path resolution after origin resolution.

## Repro

Run from a subdirectory of a git repo:

```
before: effective project origin path="/var/tmp/x/repo/deep/sub"
after:  effective project origin path="/var/tmp/x/repo"
```

Same from outside the repo with `-w /var/tmp/x/repo/deep/sub`: `outside` before, `repo` after.

## The fix

Read `recursive_paths` and `non_recursive_paths`, which are populated at that point, and resolve them against the workdir. `watch_candidates` skips the `/dev/null` sentinel and falls back to the workdir when nothing is left.

## Verification

Four tests, two on `watch_candidates` and two on discovery. Restoring the empty-list behaviour fails both discovery tests with the subdirectory as the origin.

I checked the cases this could have broken, using binaries built before and after: `--project-origin` still overrides, a directory with no repo is unchanged, and `-w /dev/null` still watches nothing.

`cargo test -p watchexec-cli` passes, 27 plus 1. `rustfmt --check` clean on the file, and clippy reports the same 3 warnings as the baseline.

One limit: I did not add canonicalisation, which the pre-#827 code had. It would change how a nonexistent `-w` path fails, so a symlinked `-w` may discover the origin of the link's parent rather than the target's.
