### PR TITLE
ci: restrict Windows manifest version replacement

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -77,7 +77,7 @@ jobs:
 
           sed -i -E "s/^version: .*/version: \"$version\"/" CITATION.cff
           sed -i -E "s/^date-released: .*/date-released: $(date -u +%F)/" CITATION.cff
-          sed -i -E "s/version=\"[0-9]+(\.[0-9]+)*([-.][^\"]+)?\.0\"/version=\"$version.0\"/" crates/cli/watchexec.exe.manifest
+          sed -i -E "s/^([[:space:]]+)version=\"[^\"]+\"/\1version=\"$version.0\"/" crates/cli/watchexec.exe.manifest
           bin/completions --locked
           sudo apt-get update
           sudo apt-get install --yes pandoc


### PR DESCRIPTION
The release PR metadata step currently replaces both the assembly version and the XML declaration version, producing an invalid Windows side-by-side manifest.

Restrict the replacement to the indented assembly identity version so the XML declaration remains at 1.0. Once merged, release-plz will refresh the pending release PR and rerun its checks.