### PR TITLE
fix(fs): drop events gracefully when channel is full (#920)

### DIFF
--- a/crates/lib/src/sources/fs.rs
+++ b/crates/lib/src/sources/fs.rs
@@ -296,12 +296,79 @@ fn process_event(
 	let ev = Event { tags, metadata };
 
 	trace!(event = ?ev, "processed notify event into watchexec event");
-	n_events
-		.try_send(ev, Priority::Normal)
-		.map_err(|err| RuntimeError::EventChannelTrySend {
-			ctx: "fs watcher",
-			err,
-		})?;
+	match n_events.try_send(ev, Priority::Normal) {
+		Ok(()) => {}
+		Err(priority::TrySendError::Full(_)) => {
+			// The bounded event channel is at capacity. This happens under bursty
+			// filesystem activity (e.g. building a large project with high parallelism).
+			// Backpressure is not possible from the synchronous notify callback, so the
+			// event is dropped. This is documented behaviour (see Handler docs in
+			// crate::action::handler): rather than surfacing a non-fatal error to the
+			// user for every dropped event, log at debug and continue. The channel size
+			// is tunable via Config::event_channel_size.
+			debug!(
+				"fs watcher event channel is full; dropping event \
+				 (tune Config::event_channel_size if this happens often)"
+			);
+		}
+		Err(priority::TrySendError::Closed(ev)) => {
+			// The receiver has been dropped (Watchexec is shutting down). Propagate as
+			// a real error so downstream handlers can react; this is swallowed by the
+			// `n_errors.try_send(...).ok()` in the worker callback if the error channel
+			// is also closed.
+			return Err(RuntimeError::EventChannelSend {
+				ctx: "fs watcher",
+				err: priority::SendError(ev),
+			});
+		}
+	}
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::process_event;
+	use crate::error::RuntimeError;
+	use async_priority_channel as priority;
+	use notify::EventKind;
+	use watchexec_events::Priority;
+
+	// Regression test for issue #920: when the bounded event channel is full,
+	// `process_event` used to propagate `RuntimeError::EventChannelTrySend`,
+	// surfacing "cannot send event from fs watcher: sending into a full channel"
+	// to the user as a non-fatal error for every dropped event. It should instead
+	// drop the event gracefully and return `Ok(())`.
+	#[test]
+	fn process_event_drops_when_channel_full() {
+		let (ev_s, _ev_r) = priority::bounded::<watchexec_events::Event, Priority>(1);
+		let nev = Ok(notify::Event::new(EventKind::Any));
+
+		// First event fills the channel (capacity 1).
+		assert!(process_event(nev, super::Watcher::default(), &ev_s).is_ok());
+
+		// Second event would overflow: must be dropped gracefully, not surfaced as an error.
+		let nev = Ok(notify::Event::new(EventKind::Any));
+		let res = process_event(nev, super::Watcher::default(), &ev_s);
+		assert!(
+			res.is_ok(),
+			"full channel should drop the event silently, not return a RuntimeError (got {res:?})",
+		);
+	}
+
+	// When the receiver is dropped (Watchexec is shutting down), the send fails with
+	// `Closed`; `process_event` should propagate that as `EventChannelSend`, matching
+	// the signal worker's behaviour and preserving real-error semantics.
+	#[test]
+	fn process_event_propagates_when_channel_closed() {
+		let (ev_s, ev_r) = priority::bounded::<watchexec_events::Event, Priority>(1);
+		drop(ev_r);
+
+		let nev = Ok(notify::Event::new(EventKind::Any));
+		let res = process_event(nev, super::Watcher::default(), &ev_s);
+		assert!(
+			matches!(res, Err(RuntimeError::EventChannelSend { .. })),
+			"closed channel should propagate as EventChannelSend, got {res:?}",
+		);
+	}
 }


### PR DESCRIPTION
Closes #920.

## Root cause

The filesystem watcher emits events into a bounded priority channel from a synchronous `notify` callback (`crates/lib/src/sources/fs.rs::process_event`). When the channel is at capacity — e.g. bursty filesystem activity such as building the Linux kernel with `make -sj100` — `try_send` returns `TrySendError::Full` and the error was propagated as `RuntimeError::EventChannelTrySend`, surfacing:

```
[[Error (not fatal)]]
cannot send event from fs watcher: sending into a full channel
```

to the user for *every* dropped event. The event is necessarily lost (backpressure is not possible from a synchronous notify callback), so the noisy non-fatal error is not actionable and the drops are already documented behaviour (see `Handler` docs in `crate::action::handler`):

> "That will cause events to accumulate and then get dropped once the channel reaches capacity [...] may spew `EventChannelTrySend` errors. If you want to do something long-running, you should either ignore that error, and accept events may be dropped, or preferrably spawn a task [...]."

## Fix

Distinguish the two `TrySendError` variants in `process_event`:

- **`Full`**: log at `debug` and drop the event silently, instead of surfacing a non-fatal `RuntimeError` to the user-facing error handler. The channel size remains tunable via `Config::event_channel_size` (default 4096).
- **`Closed`**: propagate as `RuntimeError::EventChannelSend` (matching the signal worker in `crates/lib/src/sources/signal.rs`), preserving real-error semantics for the shutdown case where the receiver has been dropped.

The `RuntimeError::EventChannelTrySend` variant is kept in the public `RuntimeError` enum (it is `#[non_exhaustive]`); it is simply no longer produced from the fs watcher path.

## Verification

- `cargo build -p watchexec` — ok
- `cargo test -p watchexec` (lib + doc-tests) — ok (16 + 11 passing)
- `cargo test --workspace` — ok (all crates, including the 2 new regression tests)
- `cargo fmt --check -p watchexec` — clean
- `cargo clippy -p watchexec --all-targets` — no new warnings (37 baseline = 37 with change)
- New regression tests `process_event_drops_when_channel_full` and `process_event_propagates_when_channel_closed` use a capacity-1 channel for determinism (the `Full` path is reached after the first event fills the channel; the `Closed` path by dropping the receiver). Tested on macOS only.

## AI disclosure

This PR was prepared with AI assistance (Claude). Per CONTRIBUTING.md, disclosed via the `Co-authored-by` trailer on the commit.

## Notes

- No workflow files touched.
- No version number or Cargo.toml metadata changed.
- The CLI does not currently expose `event_channel_size` as a flag; that is intentionally out of scope for this fix.