### PR TITLE
fix(cli): shell spec with surrounding whitespace panics

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -837,10 +837,8 @@ fn interpret_command_args(args: &Args) -> Result<Arc<Command>> {
 	let shell = if args.command.no_shell {
 		None
 	} else {
-		// Trim the shell spec before interpreting it: surrounding whitespace isn't part of
-		// the shell program nor a shell option (a value like "sh " or " /bin/bash" used to
-		// be split into an empty program plus an option, and panic), and a value that's
-		// only whitespace is an empty shell, handled below like an empty string.
+		// surrounding whitespace is part of neither the shell program nor its options, and
+		// a whitespace-only value is an empty shell, handled below like an empty string
 		let shell = args
 			.command
 			.shell
@@ -1042,9 +1040,6 @@ fn test_parse_path_resolves_before_validating() {
 	assert_eq!(options, ["--norc"]);
 }
 
-/// A `--shell` (or `$SHELL`) value with surrounding whitespace used to be split into an
-/// empty shell program plus an option, which panicked in `parse_path` on a `split_last()`
-/// of an empty list. Whitespace isn't part of the shell spec: trim it first.
 #[test]
 #[cfg(test)]
 fn test_shell_spec_whitespace_is_trimmed() {

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -837,7 +837,16 @@ fn interpret_command_args(args: &Args) -> Result<Arc<Command>> {
 	let shell = if args.command.no_shell {
 		None
 	} else {
-		let shell = args.command.shell.clone().or_else(|| var("SHELL").ok());
+		// Trim the shell spec before interpreting it: surrounding whitespace isn't part of
+		// the shell program nor a shell option (a value like "sh " or " /bin/bash" used to
+		// be split into an empty program plus an option, and panic), and a value that's
+		// only whitespace is an empty shell, handled below like an empty string.
+		let shell = args
+			.command
+			.shell
+			.clone()
+			.or_else(|| var("SHELL").ok())
+			.map(|shell| shell.trim().to_owned());
 		match shell
 			.as_deref()
 			.or_else(|| {
@@ -1031,6 +1040,40 @@ fn test_parse_path_resolves_before_validating() {
 	});
 	assert_eq!(path, native);
 	assert_eq!(options, ["--norc"]);
+}
+
+/// A `--shell` (or `$SHELL`) value with surrounding whitespace used to be split into an
+/// empty shell program plus an option, which panicked in `parse_path` on a `split_last()`
+/// of an empty list. Whitespace isn't part of the shell spec: trim it first.
+#[test]
+#[cfg(test)]
+fn test_shell_spec_whitespace_is_trimmed() {
+	use clap::Parser;
+
+	for spec in ["sh ", " sh", "  sh  "] {
+		let args = Args::parse_from(["watchexec", &format!("--shell={spec}"), "echo", "hi"]);
+		let cmd = interpret_command_args(&args)
+			.unwrap_or_else(|err| panic!("--shell={spec:?} should be usable, got {err:?}"));
+		let Program::Shell { shell, .. } = &cmd.program else {
+			panic!(
+				"--shell={spec:?} should give a shelled program, got {:?}",
+				cmd.program
+			);
+		};
+		assert_eq!(shell.prog, PathBuf::from("sh"), "for --shell={spec:?}");
+		assert!(
+			shell.options.is_empty(),
+			"for --shell={spec:?}: whitespace should not become a shell option, got {:?}",
+			shell.options
+		);
+	}
+
+	// A whitespace-only shell is an empty shell, not a program named "".
+	let args = Args::parse_from(["watchexec", "--shell=  ", "echo", "hi"]);
+	assert!(
+		interpret_command_args(&args).is_err(),
+		"a whitespace-only --shell should error like an empty one"
+	);
 }
 
 #[test]


### PR DESCRIPTION
A shell spec with surrounding whitespace panics on startup:

```
$ watchexec --shell='sh ' -1 -- echo hi
thread 'main' panicked at crates/cli/src/config.rs:952:91:
called `Option::unwrap()` on a `None` value

$ SHELL='sh ' watchexec -1 -- echo hi
same panic
```

`parse_path` splits the spec on whitespace, so `"sh "` becomes an empty program plus one option, and `split_last().unwrap()` fires on the empty list. It is reachable from `--shell`, from `$SHELL`, and from `@argfile` lines, where a trailing space is easy to introduce and hard to see.

The spec is trimmed before it is interpreted. Whitespace is not part of a shell program nor a shell option, so nothing is lost, and `bash --norc` still parses to a program plus its option. A whitespace-only value now reports `empty shell program` instead of panicking, which is what an empty string already did.

Test added in `config.rs` covering `"sh "`, `" sh"` and `"  sh  "`; removing the trim reproduces the panic inside the test. `cargo test -p watchexec-cli` passes, 31 plus 1, `cargo fmt --check` clean. The two unused-import warnings in that file are pre-existing.

AI disclosure per CONTRIBUTING: the commit carries a Co-authored-by trailer. I ran the binary before and after and checked the mutation myself.