### PR TITLE
fix(cli): --stop-signal overrides --signal in on-busy-update=signal mode

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -555,7 +555,7 @@ pub fn make_config(args: &Args, state: &State) -> Result<Config> {
 										job.signal(if cfg!(windows) {
 											Signal::ForceStop
 										} else {
-											stop_signal.or(signal).unwrap_or(Signal::Terminate)
+											on_busy_signal(signal, stop_signal)
 										});
 									}
 									OnBusyUpdate::Restart if cfg!(windows) => {
@@ -673,6 +673,17 @@ pub fn make_config(args: &Args, state: &State) -> Result<Config> {
 	Ok(config)
 }
 
+/// The signal to send in the `signal` mode of `--on-busy-update`.
+///
+/// `--stop-signal` documents that it's used by the `signal` mode "unless `--signal` is provided",
+/// so `--signal` wins when both are given, and `--stop-signal` is only the fallback.
+const fn on_busy_signal(signal: Option<Signal>, stop_signal: Option<Signal>) -> Signal {
+	match (signal, stop_signal) {
+		(Some(sig), _) | (None, Some(sig)) => sig,
+		(None, None) => Signal::Terminate,
+	}
+}
+
 /// `$SHELL` as set inside Git Bash / MSYS2 (and a plain `--shell=/usr/bin/bash`)
 /// is a POSIX-style path. Windows process creation doesn't understand those,
 /// so spawning would fail with "the system cannot find the path specified"
@@ -726,6 +737,42 @@ fn resolve_shell_prog_in(
 #[cfg(not(windows))]
 fn resolve_shell_prog(prog: &str) -> String {
 	prog.to_string()
+}
+
+#[cfg(test)]
+mod on_busy_signal_tests {
+	use super::on_busy_signal;
+	use watchexec_signals::Signal;
+
+	/// '--stop-signal' documents that it is used by the 'signal' mode of '--on-busy-update'
+	/// "(unless '--signal' is provided)", and '--signal' documents that the signal it names is the
+	/// one sent "when it's still running". So '--signal' has to win over '--stop-signal'.
+	#[test]
+	fn signal_wins_over_stop_signal() {
+		assert_eq!(
+			on_busy_signal(Some(Signal::User1), Some(Signal::Hangup)),
+			Signal::User1
+		);
+	}
+
+	#[test]
+	fn stop_signal_is_the_fallback() {
+		assert_eq!(
+			on_busy_signal(None, Some(Signal::Hangup)),
+			Signal::Hangup,
+			"--stop-signal alone should still be honoured"
+		);
+		assert_eq!(
+			on_busy_signal(Some(Signal::User1), None),
+			Signal::User1,
+			"--signal alone should be used"
+		);
+		assert_eq!(
+			on_busy_signal(None, None),
+			Signal::Terminate,
+			"neither given means the default"
+		);
+	}
 }
 
 #[cfg(all(test, windows))]


### PR DESCRIPTION
With `--on-busy-update=signal`, `--stop-signal` takes precedence over `--signal`, so the signal the user asked for is never sent.

```
$ watchexec -q -s USR1 --stop-signal HUP -- ./prog.sh
# touch a watched file
before: Hangup            -> GOT SIGHUP
after:  User defined signal 1 -> GOT SIGUSR1
```

That contradicts both flags' own help. `--stop-signal` says it is used by the `restart` and `signal` modes of `--on-busy-update` "(unless '--signal' is provided)", and `--signal` says it sends the named signal "when it's still running". The code was `stop_signal.or(signal)`, which is the opposite order.

The fix pulls the choice into a small `const fn` so the precedence is testable, with cases for all four flag combinations. `--stop-signal` alone still works, and shutdown still uses `--stop-signal` as before.

`cargo test --workspace` passes. `cargo clippy --all-targets -p watchexec-cli` emits the same warnings before and after.

AI-assisted: written with Claude Code, reviewed and tested by me before sending.
