### PR TITLE
ci: set publish = false for test-socketfd in release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,6 +17,7 @@ semver_check = false
 
 [[package]]
 name = "test-socketfd"
+publish = false
 release = false
 
 [changelog]


### PR DESCRIPTION
`release-plz release` has failed on every push to main since #1075 landed (runs on 8b57d1a, f29ce3f, 2277834 and others). `release-pr` is unaffected, so #1078 looks healthy while nothing can publish.

release-plz reads the `publish` field of every package that has a `[[package]]` block, without regard for `release = false`, and errors when that resolves to `publish = true` while the crate's Cargo.toml has `publish = false`. `crates/test-socketfd/Cargo.toml` sets `publish = false`.

Reproduced locally with release-plz 0.3.160, the version pinned by release-plz/action v0.5.131:

- before: `Error: Package 'test-socketfd' has 'publish = false' or 'publish = []' in the Cargo.toml, but it has 'publish = true' in the release-plz configuration.`
- after: the run gets past the check and stops at the missing git token, which CI provides.

Deleting the `[[package]]` block clears the error too, but that puts test-socketfd back under release-plz's update and release-pr handling, so this keeps `release = false` and sets the field release-plz reads.

No changelog entry: cliff.toml skips `ci` commits.

Limitation: without the release token I could not run the publish step end to end, so this verifies the config check only.

Disclosure per CONTRIBUTING: prepared with AI assistance (Claude Code).
