### PR TITLE
test(supervisor): remove restart test races

### DIFF
--- a/crates/supervisor/tests/programs.rs
+++ b/crates/supervisor/tests/programs.rs
@@ -86,39 +86,41 @@ async fn unix_shell_alternate_shopts() -> Result<(), std::io::Error> {
 
 /// Regression test for https://github.com/watchexec/watchexec/issues/960
 ///
-/// The command here is a *script*, invoked via `sh -c "/path/to/script"` - a single simple
-/// invocation, same shape as `watchexec -- ./script.sh`. Before the fix, that outer `sh` forks
-/// the script as its own child instead of exec-ing into it; the outer `sh` has no signal handler
-/// of its own, so sending the graceful-stop signal to the process group kills it immediately.
-/// Since that outer `sh` is the direct child the job waits on, the job would consider the
-/// command finished and start a new one right away - even though the actual script (a trapped,
-/// still-running child of that wrapper) hadn't exited yet. With the fix, the outer shell `exec`s
-/// into the script instead of forking it, so there's no separate un-trapped wrapper to kill
-/// early, and the job correctly waits for the script's own trap-driven shutdown.
+/// The command here runs a script through `sh`, wrapped by the `sh -c` created for
+/// [`Program::Shell`]. Before the fix, that outer `sh` forks the script interpreter as its own
+/// child instead of exec-ing into it; the outer `sh` has no signal handler of its own, so sending
+/// the graceful-stop signal to the process group kills it immediately. Since that outer `sh` is
+/// the direct child the job waits on, the job would consider the command finished and start a new
+/// one right away - even though the actual script (a trapped, still-running child of that wrapper)
+/// hadn't exited yet. With the fix, the outer shell `exec`s into the script interpreter instead of
+/// forking it, so there's no separate un-trapped wrapper to kill early, and the job correctly waits
+/// for the script's own trap-driven shutdown.
 #[tokio::test]
 #[cfg(unix)]
 async fn restart_with_signal_waits_for_the_actual_command_to_exit() {
-	use std::os::unix::fs::PermissionsExt;
-
 	let unique = std::time::SystemTime::now()
 		.duration_since(std::time::UNIX_EPOCH)
 		.expect("system time")
 		.as_nanos();
-	let script =
-		std::env::temp_dir().join(format!("watchexec-test-trap-{}-{unique}.sh", std::process::id()));
+	let script = std::env::temp_dir().join(format!(
+		"watchexec-test-trap-{}-{unique}.sh",
+		std::process::id()
+	));
+	let ready = script.with_extension("ready");
 	std::fs::write(
 		&script,
-		"#!/bin/sh\ntrap 'sleep 1; exit 0' TERM\nsleep 30\n",
+		"#!/bin/sh\ntrap 'sleep 1; exit 0' TERM\n: > \"$1\"\nsleep 30\n",
 	)
 	.expect("write test script");
-	std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
-		.expect("chmod test script");
 
 	let (job, task) = start_job(Arc::new(Command {
 		program: Program::Shell {
 			shell: Shell::new("sh"),
-			command: script.to_string_lossy().into_owned(),
-			args: Vec::new(),
+			command: r#"sh "$0" "$1""#.into(),
+			args: vec![
+				script.to_string_lossy().into_owned(),
+				ready.to_string_lossy().into_owned(),
+			],
 		},
 		options: SpawnOptions {
 			grouped: true,
@@ -128,8 +130,14 @@ async fn restart_with_signal_waits_for_the_actual_command_to_exit() {
 
 	job.start().await;
 
-	// give the shell a moment to exec into the script and install the trap before signalling
-	tokio::time::sleep(Duration::from_millis(300)).await;
+	// Wait until the script has installed its trap before signalling it.
+	tokio::time::timeout(Duration::from_secs(5), async {
+		while !ready.exists() {
+			tokio::time::sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await
+	.expect("script did not become ready");
 
 	let began = std::time::Instant::now();
 	job.restart_with_signal(Signal::Terminate, Duration::from_secs(5))
@@ -139,6 +147,7 @@ async fn restart_with_signal_waits_for_the_actual_command_to_exit() {
 	job.stop().await;
 	task.abort();
 	let _ = std::fs::remove_file(&script);
+	let _ = std::fs::remove_file(&ready);
 
 	// the trap sleeps for 1s before exiting; if the restart didn't actually wait for it,
 	// this would resolve almost instantly instead


### PR DESCRIPTION
## Summary

- run the generated signal-trap script through `sh` instead of executing the freshly written file directly
- replace the fixed 300 ms startup delay with a bounded readiness marker written after the trap is installed
- keep the regression test parallel and preserve coverage of the outer shell's `exec` behavior

## Background

The intermittent Ubuntu failure in [run 32552246579](https://github.com/watchexec/watchexec/actions/runs/32552246579/job/96980792508) was:

```
exec: /tmp/watchexec-test-trap-….sh: Text file busy
```

The test writes an executable script while sibling tests are spawning processes. On Linux, a sibling child can briefly inherit the writable descriptor before its own `exec`, causing `execve()` of the script to fail with `ETXTBSY`. Invoking the script through an interpreter avoids executing that inode while retaining the regression scenario.

The previous sleep also assumed that the script had installed its signal trap after 300 ms. The readiness marker makes that condition explicit.

## Validation

- `cargo clippy -p watchexec-supervisor --all-targets --locked`
- `cargo test --locked --workspace --exclude watchexec-cli --exclude watchexec-events`
- 50 consecutive runs of `cargo test -q -p watchexec-supervisor --test programs --locked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
