### PR TITLE
fix(ci): build cargo-deb from source

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -174,12 +174,6 @@ jobs:
         run: sudo apt install -y gcc-powerpc64le-linux-gnu
         if: startsWith(matrix.target, 'powerpc64le-unknown-linux-gnu')
 
-      - name: Install cargo-deb
-        if: startsWith(matrix.name, 'linux-')
-        uses: taiki-e/install-action@v2.85.13
-        with:
-          tool: cargo-deb
-
       - name: Install cargo-generate-rpm
         if: startsWith(matrix.name, 'linux-')
         uses: taiki-e/install-action@v2.85.13
@@ -192,6 +186,10 @@ jobs:
           rustup default stable
           rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deb
+        if: startsWith(matrix.name, 'linux-')
+        run: cargo install cargo-deb --version 3.7.0 --locked
 
       - name: Install cross
         if: matrix.cross


### PR DESCRIPTION
## Summary

- build `cargo-deb` 3.7.0 from source after configuring Rust
- avoid the upstream prebuilt binary that requires glibc 2.39
- retain Ubuntu 22.04 as the GNU release compatibility baseline

The [CLI release job](https://github.com/watchexec/watchexec/actions/runs/32559812879/job/96999585394) failed because `taiki-e/install-action` selected the `cargo-deb` 3.7.0 Debian asset, which cannot run against Ubuntu 22.04's glibc 2.35. Compiling the pinned tool on the runner links it against the runner's libc instead.

Upstream context: https://github.com/kornelski/cargo-deb/issues/208

## Verification

- `git diff --check`
- parsed `.github/workflows/release-cli.yml` with Ruby Psych
- Ubuntu 22.04 container smoke test not run locally (container execution unavailable)
- `actionlint` not run locally (not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
