### PR TITLE
release: watchexec-cli v2.6.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: |
   If you use this software, please cite it using these metadata.
 title: "Watchexec: a tool to react to filesystem changes, and a crate ecosystem to power it"
 
-version: "2.6.0"
+version: "2.6.1"
 date-released: 2026-08-22
 
 repository-code: https://github.com/watchexec/watchexec

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "watchexec-cli"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "argfile",
  "blake3",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "watchexec-cli"
-version = "2.6.0"
+version = "2.6.1"
 
 authors = ["Félix Saparelli <felix@passcod.name>", "Matt Green <mattgreenrocks@gmail.com>"]
 license = "Apache-2.0"

--- a/crates/cli/watchexec.exe.manifest
+++ b/crates/cli/watchexec.exe.manifest
@@ -3,7 +3,7 @@
 	<assemblyIdentity
 		type="win32"
 		name="Watchexec.Cli.watchexec"
-		version="2.6.0.0"
+		version="2.6.1.0"
 	/>
 
 	<trustInfo>

--- a/doc/watchexec.1
+++ b/doc/watchexec.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH watchexec 1  "watchexec 2.6.0" 
+.TH watchexec 1  "watchexec 2.6.1" 
 .SH NAME
 watchexec \- Execute commands when watched files change
 .SH SYNOPSIS
@@ -652,6 +652,6 @@ Use @argfile as first argument to load arguments from the file \*(Aqargfile\*(Aq
 
 Didn\*(Aqt expect this much output? Use the short \*(Aq\-h\*(Aq flag to get short help.
 .SH VERSION
-v2.6.0
+v2.6.1
 .SH AUTHORS
 Félix Saparelli <felix@passcod.name>, Matt Green <mattgreenrocks@gmail.com>

--- a/doc/watchexec.1.md
+++ b/doc/watchexec.1.md
@@ -1000,7 +1000,7 @@ Didnt expect this much output? Use the short -h flag to get short help.
 
 # VERSION
 
-v2.6.0
+v2.6.1
 
 # AUTHORS
 


### PR DESCRIPTION



## 🤖 New release

* `watchexec-cli`: 2.6.0 -> 2.6.1

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).