### PR TITLE
feat: implement fs recursion ourselves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,7 @@ dependencies = [
  "nix",
  "normalize-path",
  "notify",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -3848,8 +3849,10 @@ dependencies = [
 name = "watchexec-filterer-globset"
 version = "8.0.1"
 dependencies = [
+ "dunce",
  "ignore",
  "ignore-files",
+ "normalize-path",
  "tempfile",
  "tokio",
  "tracing",
@@ -3863,10 +3866,8 @@ dependencies = [
 name = "watchexec-filterer-ignore"
 version = "7.0.1"
 dependencies = [
- "dunce",
  "ignore",
  "ignore-files",
- "normalize-path",
  "project-origins",
  "tokio",
  "tracing",

--- a/completions/elvish
+++ b/completions/elvish
@@ -85,7 +85,7 @@ set edit:completion:arg-completer[watchexec] = {|@words|
             cand --no-discover-ignore 'Don''t discover ignore files at all'
             cand --ignore-nothing 'Don''t ignore anything at all'
             cand --no-meta 'Don''t emit fs events for metadata changes'
-            cand --no-follow-symlinks 'Don''t follow symlinks when watching'
+            cand --no-follow-symlinks 'Don''t follow directory symlinks when watching'
             cand -v 'Set diagnostic log level'
             cand --verbose 'Set diagnostic log level'
             cand --print-events 'Print events that trigger actions'

--- a/completions/fish
+++ b/completions/fish
@@ -73,7 +73,7 @@ complete -c watchexec -l no-default-ignore -d 'Don\'t use internal default ignor
 complete -c watchexec -l no-discover-ignore -d 'Don\'t discover ignore files at all'
 complete -c watchexec -l ignore-nothing -d 'Don\'t ignore anything at all'
 complete -c watchexec -l no-meta -d 'Don\'t emit fs events for metadata changes'
-complete -c watchexec -l no-follow-symlinks -d 'Don\'t follow symlinks when watching'
+complete -c watchexec -l no-follow-symlinks -d 'Don\'t follow directory symlinks when watching'
 complete -c watchexec -s v -l verbose -d 'Set diagnostic log level'
 complete -c watchexec -l print-events -d 'Print events that trigger actions'
 complete -c watchexec -l timings -d 'Print how long the command took to run'

--- a/completions/nu
+++ b/completions/nu
@@ -80,7 +80,7 @@ module completions {
     --ignore-file: path       # Files to load ignores from
     --fs-events: string@"nu-complete watchexec filter_fs_events" # Filesystem events to filter to
     --no-meta                 # Don't emit fs events for metadata changes
-    --no-follow-symlinks      # Don't follow symlinks when watching
+    --no-follow-symlinks      # Don't follow directory symlinks when watching
     --verbose(-v)             # Set diagnostic log level
     --log-file: path          # Write diagnostic logs to a file
     --print-events            # Print events that trigger actions

--- a/completions/powershell
+++ b/completions/powershell
@@ -88,7 +88,7 @@ Register-ArgumentCompleter -Native -CommandName 'watchexec' -ScriptBlock {
             [CompletionResult]::new('--no-discover-ignore', '--no-discover-ignore', [CompletionResultType]::ParameterName, 'Don''t discover ignore files at all')
             [CompletionResult]::new('--ignore-nothing', '--ignore-nothing', [CompletionResultType]::ParameterName, 'Don''t ignore anything at all')
             [CompletionResult]::new('--no-meta', '--no-meta', [CompletionResultType]::ParameterName, 'Don''t emit fs events for metadata changes')
-            [CompletionResult]::new('--no-follow-symlinks', '--no-follow-symlinks', [CompletionResultType]::ParameterName, 'Don''t follow symlinks when watching')
+            [CompletionResult]::new('--no-follow-symlinks', '--no-follow-symlinks', [CompletionResultType]::ParameterName, 'Don''t follow directory symlinks when watching')
             [CompletionResult]::new('-v', '-v', [CompletionResultType]::ParameterName, 'Set diagnostic log level')
             [CompletionResult]::new('--verbose', '--verbose', [CompletionResultType]::ParameterName, 'Set diagnostic log level')
             [CompletionResult]::new('--print-events', '--print-events', [CompletionResultType]::ParameterName, 'Print events that trigger actions')

--- a/completions/zsh
+++ b/completions/zsh
@@ -86,7 +86,7 @@ end\:"Notify only when the command ends"))' \
 '--no-discover-ignore[Don'\''t discover ignore files at all]' \
 '--ignore-nothing[Don'\''t ignore anything at all]' \
 '(--fs-events)--no-meta[Don'\''t emit fs events for metadata changes]' \
-'--no-follow-symlinks[Don'\''t follow symlinks when watching]' \
+'--no-follow-symlinks[Don'\''t follow directory symlinks when watching]' \
 '*-v[Set diagnostic log level]' \
 '*--verbose[Set diagnostic log level]' \
 '--print-events[Print events that trigger actions]' \

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -39,28 +39,6 @@ Example use cases:
 
     This can be disabled with `--emit-events=none` or changed to JSON events on STDIN with `--emit-events=json-stdio`.
 
-### Ignore pruning and watcher backends
-
-When Notify selects Inotify (Linux and Android), Windows ReadDirectoryChanges, or polling,
-Watchexec uses ignore files, built-in ignores, and `--ignore` patterns while walking the watched
-tree. Ignored directories are not scanned or watched. Positive `--filter` patterns, `--exts`,
-`--fs-events`, and `--filter-prog` remain event filters and do not reduce the source tree.
-
-Every `--watch` or `--watch-non-recursive` path is kept at its exact root even if an ignore matches
-it; descendants still obey ignores. CLI events for that exact root also bypass ignore rules. Ignore
-files are discovered and read at startup, not monitored: restart Watchexec to load edits or newly
-created ignore files.
-
-Native FSEvents (macOS) and Kqueue (BSD) retain Notify's own recursion in this release, so ignored
-directories are filtered from emitted events but are not physically pruned. FSEvents may observe a
-broader OS stream internally before callback filtering, while Kqueue needs hidden per-entry
-recursion to observe child changes. `--poll` is the explicit workaround when physical pruning is
-more important than native watching.
-
-Polling registers each accepted directory separately, so its work scales with directory count.
-Initial traversal reads one directory synchronously at a time; Watchexec yields between directories,
-but one very large or slow directory can still delay startup.
-
 ## Anti-Features
 
 * Not tied to any particular language or ecosystem

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -39,6 +39,28 @@ Example use cases:
 
     This can be disabled with `--emit-events=none` or changed to JSON events on STDIN with `--emit-events=json-stdio`.
 
+### Ignore pruning and watcher backends
+
+When Notify selects Inotify (Linux and Android), Windows ReadDirectoryChanges, or polling,
+Watchexec uses ignore files, built-in ignores, and `--ignore` patterns while walking the watched
+tree. Ignored directories are not scanned or watched. Positive `--filter` patterns, `--exts`,
+`--fs-events`, and `--filter-prog` remain event filters and do not reduce the source tree.
+
+Every `--watch` or `--watch-non-recursive` path is kept at its exact root even if an ignore matches
+it; descendants still obey ignores. CLI events for that exact root also bypass ignore rules. Ignore
+files are discovered and read at startup, not monitored: restart Watchexec to load edits or newly
+created ignore files.
+
+Native FSEvents (macOS) and Kqueue (BSD) retain Notify's own recursion in this release, so ignored
+directories are filtered from emitted events but are not physically pruned. FSEvents may observe a
+broader OS stream internally before callback filtering, while Kqueue needs hidden per-entry
+recursion to observe child changes. `--poll` is the explicit workaround when physical pruning is
+more important than native watching.
+
+Polling registers each accepted directory separately, so its work scales with directory count.
+Initial traversal reads one directory synchronously at a time; Watchexec yields between directories,
+but one very large or slow directory can still delay startup.
+
 ## Anti-Features
 
 * Not tied to any particular language or ecosystem

--- a/crates/cli/src/args/events.rs
+++ b/crates/cli/src/args/events.rs
@@ -178,7 +178,12 @@ pub struct EventsArgs {
 	/// By default, and where available, Watchexec uses the operating system's native file system
 	/// watching capabilities. This option disables that and instead uses a polling mechanism, which
 	/// is less efficient but can work around issues with some file systems (like network shares) or
-	/// edge cases.
+	/// edge cases. It also forces physical ignore pruning on platforms whose native FSEvents or Kqueue
+	/// backends retain Notify-owned recursion.
+	///
+	/// Polling registers each accepted directory separately, so work scales with directory count.
+	/// Initial traversal reads one directory synchronously at a time; it yields between directories,
+	/// but one exceptionally large or slow directory can still delay startup.
 	///
 	/// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms",
 	/// to use as the polling interval. If not specified, the default is 30 seconds.

--- a/crates/cli/src/args/events.rs
+++ b/crates/cli/src/args/events.rs
@@ -178,12 +178,7 @@ pub struct EventsArgs {
 	/// By default, and where available, Watchexec uses the operating system's native file system
 	/// watching capabilities. This option disables that and instead uses a polling mechanism, which
 	/// is less efficient but can work around issues with some file systems (like network shares) or
-	/// edge cases. It also forces physical ignore pruning on platforms whose native FSEvents or Kqueue
-	/// backends retain Notify-owned recursion.
-	///
-	/// Polling registers each accepted directory separately, so work scales with directory count.
-	/// Initial traversal reads one directory synchronously at a time; it yields between directories,
-	/// but one exceptionally large or slow directory can still delay startup.
+	/// edge cases.
 	///
 	/// Optionally takes a unit-less value in milliseconds, or a time span value such as "2s 500ms",
 	/// to use as the polling interval. If not specified, the default is 30 seconds.

--- a/crates/cli/src/args/filtering.rs
+++ b/crates/cli/src/args/filtering.rs
@@ -36,6 +36,10 @@ pub struct FilteringArgs {
 	///
 	/// This option can be specified multiple times to watch multiple files or directories.
 	///
+	/// Every specified path is an exact watch root. The root itself is retained even if it matches an
+	/// ignore rule, while descendants of a recursive directory still obey ignores. Filesystem events
+	/// for the exact root also bypass CLI ignore rules.
+	///
 	/// The special value '/dev/null', provided as the only path watched, will cause Watchexec to
 	/// not watch any paths. Other event sources (like signals or key events) may still be used.
 	#[arg(
@@ -51,6 +55,9 @@ pub struct FilteringArgs {
 	/// Watch a specific directory, non-recursively
 	///
 	/// Unlike '-w', folders watched with this option are not recursed into.
+	///
+	/// The exact path is retained even if it matches an ignore rule, and filesystem events for that
+	/// root bypass CLI ignore rules.
 	///
 	/// This option can be specified multiple times to watch multiple directories non-recursively.
 	#[arg(
@@ -325,6 +332,16 @@ pub struct FilteringArgs {
 	/// Provide a glob-like filter pattern, and events for files matching the pattern will be
 	/// excluded. Multiple patterns can be given by repeating the option. Events that are not from
 	/// files (e.g. signals, keyboard events) will pass through untouched.
+	///
+	/// When the actual watcher backend is Inotify, Windows ReadDirectoryChanges, or Poll, ignore
+	/// files, built-in ignores, '--ignore', and '--ignore-file' also prune matching directories from
+	/// the watched source tree. Positive filters, extension filters, filesystem event kinds, and
+	/// filter programs only filter events after they are observed; they do not prune sources.
+	///
+	/// Native FSEvents and Kqueue retain Notify's recursion, so ignores filter their events without
+	/// physically pruning ignored directories. Use '--poll' to force source pruning on those
+	/// platforms. Ignore files are discovered and read once at startup; edits and newly created ignore
+	/// files are not loaded while Watchexec is running.
 	#[arg(
 		long = "ignore",
 		short = 'i',
@@ -393,6 +410,11 @@ pub struct FilteringArgs {
 	///
 	/// This can be useful when ignored paths are reachable via symlinks, or when watching a
 	/// directory that contains symlinks pointing outside the project (e.g. Bazel output symlinks).
+	///
+	/// Watchexec enforces this across every path component for Inotify, Windows
+	/// ReadDirectoryChanges, and Poll. On those backends it also guards a missing root from its nearest
+	/// safe existing ancestor, so the root can be watched if it appears later. Other native backends
+	/// delegate symlink handling to Notify and may behave differently.
 	#[arg(
 		long = "no-follow-symlinks",
 		help_heading = OPTSET_FILTERING,

--- a/crates/cli/src/args/filtering.rs
+++ b/crates/cli/src/args/filtering.rs
@@ -36,10 +36,6 @@ pub struct FilteringArgs {
 	///
 	/// This option can be specified multiple times to watch multiple files or directories.
 	///
-	/// Every specified path is an exact watch root. The root itself is retained even if it matches an
-	/// ignore rule, while descendants of a recursive directory still obey ignores. Filesystem events
-	/// for the exact root also bypass CLI ignore rules.
-	///
 	/// The special value '/dev/null', provided as the only path watched, will cause Watchexec to
 	/// not watch any paths. Other event sources (like signals or key events) may still be used.
 	#[arg(
@@ -55,9 +51,6 @@ pub struct FilteringArgs {
 	/// Watch a specific directory, non-recursively
 	///
 	/// Unlike '-w', folders watched with this option are not recursed into.
-	///
-	/// The exact path is retained even if it matches an ignore rule, and filesystem events for that
-	/// root bypass CLI ignore rules.
 	///
 	/// This option can be specified multiple times to watch multiple directories non-recursively.
 	#[arg(
@@ -332,16 +325,6 @@ pub struct FilteringArgs {
 	/// Provide a glob-like filter pattern, and events for files matching the pattern will be
 	/// excluded. Multiple patterns can be given by repeating the option. Events that are not from
 	/// files (e.g. signals, keyboard events) will pass through untouched.
-	///
-	/// When the actual watcher backend is Inotify, Windows ReadDirectoryChanges, or Poll, ignore
-	/// files, built-in ignores, '--ignore', and '--ignore-file' also prune matching directories from
-	/// the watched source tree. Positive filters, extension filters, filesystem event kinds, and
-	/// filter programs only filter events after they are observed; they do not prune sources.
-	///
-	/// Native FSEvents and Kqueue retain Notify's recursion, so ignores filter their events without
-	/// physically pruning ignored directories. Use '--poll' to force source pruning on those
-	/// platforms. Ignore files are discovered and read once at startup; edits and newly created ignore
-	/// files are not loaded while Watchexec is running.
 	#[arg(
 		long = "ignore",
 		short = 'i',
@@ -410,11 +393,6 @@ pub struct FilteringArgs {
 	///
 	/// This can be useful when ignored paths are reachable via symlinks, or when watching a
 	/// directory that contains symlinks pointing outside the project (e.g. Bazel output symlinks).
-	///
-	/// Watchexec enforces this across every path component for Inotify, Windows
-	/// ReadDirectoryChanges, and Poll. On those backends it also guards a missing root from its nearest
-	/// safe existing ancestor, so the root can be watched if it appears later. Other native backends
-	/// delegate symlink handling to Notify and may behave differently.
 	#[arg(
 		long = "no-follow-symlinks",
 		help_heading = OPTSET_FILTERING,

--- a/crates/cli/src/args/filtering.rs
+++ b/crates/cli/src/args/filtering.rs
@@ -384,15 +384,14 @@ pub struct FilteringArgs {
 	)]
 	pub filter_fs_meta: bool,
 
-	/// Don't follow symlinks when watching
+	/// Don't follow directory symlinks when watching
 	///
-	/// By default, Watchexec will follow symbolic links when setting up filesystem watches, which
-	/// means events from the symlink target are reported using the symlink path. With this option,
-	/// symlinks are not followed: the symlink itself may still produce events, but its target will
-	/// not be watched through the link.
+	/// By default, Watchexec follows directory symlinks while constructing recursive watches. With
+	/// this option, their targets are not included; changes to the symlinks themselves may still
+	/// produce events.
 	///
-	/// This can be useful when ignored paths are reachable via symlinks, or when watching a
-	/// directory that contains symlinks pointing outside the project (e.g. Bazel output symlinks).
+	/// The native macOS watcher does not follow directory symlinks outside the watched hierarchy,
+	/// even without this option.
 	#[arg(
 		long = "no-follow-symlinks",
 		help_heading = OPTSET_FILTERING,

--- a/crates/cli/src/filterer.rs
+++ b/crates/cli/src/filterer.rs
@@ -196,13 +196,9 @@ mod tests {
 
 	#[tokio::test]
 	async fn normalised_watch_root_whitelist_overrides_event_ignore() {
-		let origin = std::fs::canonicalize(".").unwrap();
+		let origin = dunce::canonicalize(".").unwrap();
 		let emitted_root = origin.join("ignored");
-		let mut configured_root = origin.as_os_str().to_os_string();
-		configured_root.push(format!(
-			"{MAIN_SEPARATOR}intermediate{MAIN_SEPARATOR}..{MAIN_SEPARATOR}ignored"
-		));
-		let configured_root = PathBuf::from(configured_root);
+		let configured_root = origin.join("intermediate").join("..").join("ignored");
 		assert!(configured_root.is_absolute());
 		assert_ne!(configured_root, emitted_root);
 

--- a/crates/cli/src/filterer.rs
+++ b/crates/cli/src/filterer.rs
@@ -198,7 +198,11 @@ mod tests {
 	async fn normalised_watch_root_whitelist_overrides_event_ignore() {
 		let origin = std::fs::canonicalize(".").unwrap();
 		let emitted_root = origin.join("ignored");
-		let configured_root = origin.join("intermediate").join("..").join("ignored");
+		let mut configured_root = origin.as_os_str().to_os_string();
+		configured_root.push(format!(
+			"{MAIN_SEPARATOR}intermediate{MAIN_SEPARATOR}..{MAIN_SEPARATOR}ignored"
+		));
+		let configured_root = PathBuf::from(configured_root);
 		assert!(configured_root.is_absolute());
 		assert_ne!(configured_root, emitted_root);
 

--- a/crates/cli/src/filterer.rs
+++ b/crates/cli/src/filterer.rs
@@ -4,6 +4,7 @@ use std::{
 	sync::Arc,
 };
 
+use ignore_files::VCS_DIR_NAMES;
 use miette::{IntoDiagnostic, Result};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::{info, trace, trace_span};
@@ -30,6 +31,10 @@ pub struct WatchexecFilterer {
 }
 
 impl Filterer for WatchexecFilterer {
+	fn check_dir(&self, path: &Path) -> Result<bool, RuntimeError> {
+		self.inner.check_dir(path)
+	}
+
 	#[tracing::instrument(level = "trace", skip(self))]
 	fn check_event(&self, event: &Event, priority: Priority) -> Result<bool, RuntimeError> {
 		for tag in &event.tags {
@@ -92,25 +97,19 @@ impl WatchexecFilterer {
 				(String::from(".*.kate-swp"), None),
 				(String::from(".*.sw?"), None),
 				(String::from(".*.sw?x"), None),
-				(format!("**{MAIN_SEPARATOR}.bzr{MAIN_SEPARATOR}**"), None),
-				(format!("**{MAIN_SEPARATOR}_darcs{MAIN_SEPARATOR}**"), None),
-				(
-					format!("**{MAIN_SEPARATOR}.fossil-settings{MAIN_SEPARATOR}**"),
-					None,
-				),
-				(format!("**{MAIN_SEPARATOR}.git{MAIN_SEPARATOR}**"), None),
-				(format!("**{MAIN_SEPARATOR}.hg{MAIN_SEPARATOR}**"), None),
-				(format!("**{MAIN_SEPARATOR}.pijul{MAIN_SEPARATOR}**"), None),
-				(format!("**{MAIN_SEPARATOR}.svn{MAIN_SEPARATOR}**"), None),
 			]);
+			for directory in VCS_DIR_NAMES {
+				ignores.extend([
+					(format!("**{MAIN_SEPARATOR}{directory}"), None),
+					(
+						format!("**{MAIN_SEPARATOR}{directory}{MAIN_SEPARATOR}**"),
+						None,
+					),
+				]);
+			}
 		}
 
-		let whitelist = args
-			.filtering
-			.paths
-			.iter()
-			.map(std::convert::Into::into)
-			.filter(|p: &PathBuf| p.is_file());
+		let whitelist = args.filtering.paths.iter().map(std::convert::Into::into);
 
 		let mut filters = args
 			.filtering
@@ -166,8 +165,7 @@ async fn read_filter_file(path: &Path) -> Result<Vec<(String, Option<PathBuf>)>>
 	let metadata_len = file
 		.metadata()
 		.await
-		.map(|m| usize::try_from(m.len()))
-		.unwrap_or(Ok(0))
+		.map_or(Ok(0), |metadata| usize::try_from(metadata.len()))
 		.into_diagnostic()?;
 	let filter_capacity = if metadata_len == 0 {
 		0
@@ -189,4 +187,45 @@ async fn read_filter_file(path: &Path) -> Result<Vec<(String, Option<PathBuf>)>>
 	}
 
 	Ok(filters)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use watchexec_events::FileType;
+
+	#[tokio::test]
+	async fn normalised_watch_root_whitelist_overrides_event_ignore() {
+		let origin = std::fs::canonicalize(".").unwrap();
+		let emitted_root = origin.join("ignored");
+		let configured_root = origin.join("intermediate").join("..").join("ignored");
+		assert!(configured_root.is_absolute());
+		assert_ne!(configured_root, emitted_root);
+
+		let inner = GlobsetFilterer::new(
+			&origin,
+			Vec::<(String, Option<PathBuf>)>::new(),
+			vec![(String::from("**/ignored"), None)],
+			vec![configured_root],
+			Vec::<ignore_files::IgnoreFile>::new(),
+			Vec::<OsString>::new(),
+		)
+		.await
+		.unwrap();
+		let filterer = WatchexecFilterer {
+			inner,
+			fs_events: Vec::new(),
+			progs: None,
+		};
+		let event = Event {
+			tags: vec![Tag::Path {
+				path: emitted_root.clone(),
+				file_type: Some(FileType::Dir),
+			}],
+			metadata: Default::default(),
+		};
+
+		assert!(filterer.check_event(&event, Priority::Normal).unwrap());
+		assert!(!filterer.check_dir(&emitted_root).unwrap());
+	}
 }

--- a/crates/filterer/globset/CHANGELOG.md
+++ b/crates/filterer/globset/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+
+- Add source-directory filtering from ignore files and ignore globs, with top-down ancestor semantics suitable for pruning recursive walks.
+- Keep positive filters, extension filters, and exact-path whitelists event-only so they do not prune possible matching descendants.
+
 ## v8.0.1 (2026-08-22)
 
 - adopt release-plz

--- a/crates/filterer/globset/Cargo.toml
+++ b/crates/filterer/globset/Cargo.toml
@@ -16,7 +16,9 @@ rust-version = "1.61.0"
 edition = "2021"
 
 [dependencies]
+dunce = "1.0.4"
 ignore = "0.4.18"
+normalize-path = "0.2.1"
 tracing = "0.1.40"
 
 [dependencies.ignore-files]

--- a/crates/filterer/globset/src/lib.rs
+++ b/crates/filterer/globset/src/lib.rs
@@ -10,25 +10,35 @@
 #![deny(rust_2018_idioms)]
 
 use std::{
+	collections::HashSet,
 	ffi::OsString,
 	path::{Path, PathBuf},
 };
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore_files::{Error, IgnoreFile, IgnoreFilter};
+use normalize_path::NormalizePath;
 use tracing::{debug, trace, trace_span};
 use watchexec::{error::RuntimeError, filter::Filterer};
-use watchexec_events::{Event, FileType, Priority};
+use watchexec_events::{Event, FileType, Priority, Tag};
 use watchexec_filterer_ignore::IgnoreFilterer;
 
+fn simplify_path(path: &Path) -> PathBuf {
+	dunce::simplified(path).normalize()
+}
+
 /// A simple filterer in the style of the watchexec v1.17 filter.
+///
+/// Its source-directory check uses ignore files and ignore globs only. Positive filters, extension
+/// filters, and the exact-path whitelist remain event-only so they cannot prune directories which
+/// may contain matching events.
 #[cfg_attr(feature = "full_debug", derive(Debug))]
 pub struct GlobsetFilterer {
 	#[cfg_attr(not(unix), allow(dead_code))]
 	origin: PathBuf,
 	filters: Gitignore,
 	ignores: Gitignore,
-	whitelist: Vec<PathBuf>,
+	whitelist: HashSet<PathBuf>,
 	ignore_files: IgnoreFilterer,
 	extensions: Vec<OsString>,
 }
@@ -62,6 +72,9 @@ impl GlobsetFilterer {
 	/// The extensions list is used to filter files by extension.
 	///
 	/// Non-path events are always passed.
+	///
+	/// Ignore files are read during construction and are not monitored for later edits. Build a new
+	/// filterer to load changed or newly discovered files.
 	#[allow(clippy::future_not_send)]
 	pub async fn new(
 		origin: impl AsRef<Path>,
@@ -71,9 +84,14 @@ impl GlobsetFilterer {
 		ignore_files: impl IntoIterator<Item = IgnoreFile>,
 		extensions: impl IntoIterator<Item = OsString>,
 	) -> Result<Self, Error> {
-		let origin = origin.as_ref();
-		let mut filters_builder = GitignoreBuilder::new(origin);
-		let mut ignores_builder = GitignoreBuilder::new(origin);
+		let requested_origin = origin.as_ref();
+		let origin = dunce::canonicalize(requested_origin).map_err(|err| Error::Canonicalize {
+			path: requested_origin.to_owned(),
+			err,
+		})?;
+		let origin = simplify_path(&origin);
+		let mut filters_builder = GitignoreBuilder::new(&origin);
+		let mut ignores_builder = GitignoreBuilder::new(&origin);
 
 		for (filter, in_path) in filters {
 			trace!(filter=?&filter, "add filter to globset filterer");
@@ -98,12 +116,19 @@ impl GlobsetFilterer {
 
 		let extensions: Vec<OsString> = extensions.into_iter().collect();
 
-		let mut ignore_files =
-			IgnoreFilter::new(origin, &ignore_files.into_iter().collect::<Vec<_>>()).await?;
+		let ignore_files = ignore_files.into_iter().collect::<Vec<_>>();
+		let mut ignore_files = if ignore_files.is_empty() {
+			IgnoreFilter::empty(&origin)
+		} else {
+			IgnoreFilter::new(&origin, &ignore_files).await?
+		};
 		ignore_files.finish();
 		let ignore_files = IgnoreFilterer(ignore_files);
 
-		let whitelist = whitelist.into_iter().collect::<Vec<_>>();
+		let whitelist = whitelist
+			.into_iter()
+			.map(|path| simplify_path(&path))
+			.collect::<HashSet<_>>();
 
 		debug!(
 			?origin,
@@ -116,7 +141,7 @@ impl GlobsetFilterer {
 		"globset filterer built");
 
 		Ok(Self {
-			origin: origin.into(),
+			origin,
 			filters,
 			ignores,
 			whitelist,
@@ -124,22 +149,82 @@ impl GlobsetFilterer {
 			extensions,
 		})
 	}
+
+	/// Return whether an ignore glob rejects this path or an ancestor directory.
+	///
+	/// Ancestors are checked from the top down, as they would be during a filesystem walk. Once an
+	/// ancestor is ignored, a negation matching only a descendant cannot reopen the pruned subtree.
+	/// Paths outside the project origin are matched exactly, since this filterer does not know their
+	/// traversal root and must not apply project-relative globs to arbitrary filesystem ancestors.
+	fn ignored_by_globs(&self, path: &Path, is_dir: bool) -> bool {
+		let ancestors = path
+			.strip_prefix(&self.origin)
+			.ok()
+			.map(|_| {
+				path.ancestors()
+					.skip(1)
+					.take_while(|ancestor| ancestor.starts_with(&self.origin))
+					.collect::<Vec<_>>()
+			})
+			.unwrap_or_default();
+
+		for ancestor in ancestors.into_iter().rev() {
+			if self.ignores.matched(ancestor, true).is_ignore() {
+				trace!(?path, ?ancestor, "ignored by ancestor globset ignore");
+				return true;
+			}
+		}
+
+		self.ignores.matched(path, is_dir).is_ignore()
+	}
 }
 
 impl Filterer for GlobsetFilterer {
+	/// Filter a source directory using ignore files and ignore globs.
+	///
+	/// Positive filters, extension filters, and the exact-path whitelist are event-only and do not
+	/// affect this check.
+	fn check_dir(&self, path: &Path) -> Result<bool, RuntimeError> {
+		let path = simplify_path(path);
+		let path = path.as_path();
+		let _span = trace_span!("filterer_check_dir", ?path).entered();
+
+		trace!("checking internal ignore filterer");
+		if !self.ignore_files.check_dir(path)? {
+			trace!("internal ignore filterer matched (fail)");
+			return Ok(false);
+		}
+
+		if self.ignored_by_globs(path, true) {
+			trace!("ignored by globset ignore");
+			Ok(false)
+		} else {
+			Ok(true)
+		}
+	}
+
 	/// Filter an event.
 	///
 	/// This implementation never errors.
 	fn check_event(&self, event: &Event, priority: Priority) -> Result<bool, RuntimeError> {
 		let _span = trace_span!("filterer_check").entered();
+		let mut event = Event {
+			tags: event.tags.clone(),
+			metadata: Default::default(),
+		};
+		for tag in &mut event.tags {
+			if let Tag::Path { path, .. } = tag {
+				*path = simplify_path(path);
+			}
+		}
+		let event = &event;
 
 		{
 			trace!("checking internal whitelist");
 			// Ideally check path equality backwards for better perf
 			// There could be long matching prefixes so we will exit late
-			if event
-				.paths()
-				.any(|(p, _)| self.whitelist.iter().any(|w| w == p))
+			if !self.whitelist.is_empty()
+				&& event.paths().any(|(path, _)| self.whitelist.contains(path))
 			{
 				trace!("internal whitelist filterer matched (success)");
 				return Ok(true);
@@ -167,7 +252,7 @@ impl Filterer for GlobsetFilterer {
 				let _span = trace_span!("path", ?path).entered();
 				let is_dir = file_type.map_or(false, |t| matches!(t, FileType::Dir));
 
-				if self.ignores.matched(path, is_dir).is_ignore() {
+				if self.ignored_by_globs(path, is_dir) {
 					trace!("ignored by globset ignore");
 					return false;
 				}

--- a/crates/filterer/globset/tests/filtering.rs
+++ b/crates/filterer/globset/tests/filtering.rs
@@ -1,6 +1,49 @@
 mod helpers;
 use helpers::globset::*;
-use std::io::Write;
+use ignore_files::IgnoreFile;
+use std::{
+	ffi::OsString,
+	io::Write,
+	path::{Path, PathBuf},
+};
+use watchexec::filter::Filterer;
+use watchexec_filterer_globset::GlobsetFilterer;
+
+fn assert_source_dir(filterer: &impl Filterer, path: &str, pass: bool) {
+	let origin = std::fs::canonicalize(".").unwrap();
+	assert_eq!(
+		filterer.check_dir(&origin.join(path)).unwrap(),
+		pass,
+		"source directory {path:?} (expected {})",
+		if pass { "pass" } else { "fail" }
+	);
+}
+
+async fn direct_filt(
+	origin: &Path,
+	ignores: &[&str],
+	whitelist: impl IntoIterator<Item = PathBuf>,
+) -> GlobsetFilterer {
+	direct_full_filt(origin, &[], ignores, whitelist).await
+}
+
+async fn direct_full_filt(
+	origin: &Path,
+	filters: &[&str],
+	ignores: &[&str],
+	whitelist: impl IntoIterator<Item = PathBuf>,
+) -> GlobsetFilterer {
+	GlobsetFilterer::new(
+		origin,
+		filters.iter().map(|filter| ((*filter).to_owned(), None)),
+		ignores.iter().map(|ignore| ((*ignore).to_owned(), None)),
+		whitelist,
+		std::iter::empty::<IgnoreFile>(),
+		std::iter::empty::<OsString>(),
+	)
+	.await
+	.unwrap()
+}
 
 #[tokio::test]
 async fn empty_filter_passes_everything() {
@@ -20,6 +63,170 @@ async fn empty_filter_passes_everything() {
 	filterer.dir_does_pass("apples/carrots/cauliflowers/oranges");
 	filterer.dir_does_pass("apples/carrots/cauliflowers/artichokes/oranges");
 	filterer.dir_does_pass("apples/oranges/bananas");
+}
+
+#[tokio::test]
+async fn source_checks_manual_ignore_boundary_parent_and_negation() {
+	let filterer = filt(&[], &["**/prunes"], &[], &[], &[]).await;
+	assert_source_dir(&filterer, "apples", true);
+	assert_source_dir(&filterer, "prunes", false);
+	assert_source_dir(&filterer, "prunes/nested", false);
+
+	let filterer = filt(&[], &["**/keep", "!**/keep"], &[], &[], &[]).await;
+	assert_source_dir(&filterer, "keep", true);
+}
+
+#[tokio::test]
+async fn source_checks_ignore_files() {
+	let mut ignore_file = tempfile::NamedTempFile::new().unwrap();
+	ignore_file.write_all(b"ignored\n").unwrap();
+	let filterer = filt(&[], &[], &[], &[], &[ignore_file.path().to_path_buf()]).await;
+
+	assert_source_dir(&filterer, "allowed", true);
+	assert_source_dir(&filterer, "ignored", false);
+	assert_source_dir(&filterer, "ignored/nested", false);
+}
+
+#[tokio::test]
+async fn source_checks_git_boundary_and_descendants() {
+	let filterer = filt(&[], &["**/.git", "**/.git/**"], &[], &[], &[]).await;
+	assert_source_dir(&filterer, ".github", true);
+	assert_source_dir(&filterer, ".git", false);
+	assert_source_dir(&filterer, ".git/objects", false);
+	assert_source_dir(&filterer, "project/.git", false);
+	assert_source_dir(&filterer, "project/.git/objects", false);
+}
+
+#[tokio::test]
+async fn source_checks_do_not_use_positive_filters_or_extensions() {
+	let filterer = filt(&["**/*.rs"], &[], &[], &["rs"], &[]).await;
+
+	filterer.dir_doesnt_pass("build");
+	assert_source_dir(&filterer, "build", true);
+	assert_source_dir(&filterer, "src", true);
+}
+
+#[tokio::test]
+async fn exact_whitelist_is_event_only_for_source_checks() {
+	let origin = std::fs::canonicalize(".").unwrap();
+	let whitelist = origin.join(".git").display().to_string();
+	let filterer = filt(&[], &["**/.git", "**/.git/**"], &[&whitelist], &[], &[]).await;
+
+	filterer.dir_does_pass(".git");
+	assert_source_dir(&filterer, ".git", false);
+}
+
+#[tokio::test]
+async fn relative_origin_stops_ancestor_matching_at_project_boundary() {
+	let sandbox = tempfile::tempdir_in(".").unwrap();
+	let project = sandbox.path().join("rust").join("project");
+	std::fs::create_dir_all(&project).unwrap();
+	let origin = std::fs::canonicalize(&project).unwrap();
+	let cwd = std::fs::canonicalize(".").unwrap();
+	let relative_origin = origin.strip_prefix(cwd).unwrap().to_owned();
+	let filterer = direct_filt(&relative_origin, &["rust"], Vec::new()).await;
+
+	assert!(filterer.check_dir(&origin.join("src")).unwrap());
+	assert!(!filterer.check_dir(&origin.join("rust")).unwrap());
+}
+
+#[tokio::test]
+async fn out_of_origin_paths_do_not_match_external_ancestors() {
+	let sandbox = tempfile::tempdir().unwrap();
+	let origin = sandbox.path().join("project");
+	let external = sandbox.path().join("rust").join("watched");
+	std::fs::create_dir_all(&origin).unwrap();
+	std::fs::create_dir_all(&external).unwrap();
+	let filterer = direct_filt(&origin, &["rust"], Vec::new()).await;
+
+	assert!(filterer.check_dir(&external.join("child")).unwrap());
+	assert!(!filterer
+		.check_dir(&origin.join("rust").join("child"))
+		.unwrap());
+}
+
+#[tokio::test]
+async fn direct_whitelist_normalises_constructor_and_event_aliases() {
+	use watchexec_events::{Event, FileType, Tag};
+
+	let origin = std::fs::canonicalize(".").unwrap();
+	let whitelisted = origin.join("first").join("..").join("watched");
+	let emitted = origin.join("second").join("..").join("watched");
+	let filterer = direct_filt(&origin, &["watched"], vec![whitelisted]).await;
+	let event = Event {
+		tags: vec![Tag::Path {
+			path: emitted.clone(),
+			file_type: Some(FileType::Dir),
+		}],
+		metadata: Default::default(),
+	};
+
+	assert!(filterer.check_event(&event, Priority::Normal).unwrap());
+	assert!(!filterer.check_dir(&emitted).unwrap());
+}
+
+#[tokio::test]
+async fn direct_positive_filter_normalises_lexical_event_alias() {
+	use watchexec_events::{Event, FileType, Tag};
+
+	let origin = dunce::canonicalize(".").unwrap();
+	let emitted = origin
+		.join("alias")
+		.join("..")
+		.join("watched")
+		.join("main.rs");
+	let filterer =
+		direct_full_filt(&origin, &["watched/main.rs"], &[], Vec::<PathBuf>::new()).await;
+	let event = Event {
+		tags: vec![Tag::Path {
+			path: emitted,
+			file_type: Some(FileType::File),
+		}],
+		metadata: Default::default(),
+	};
+
+	assert!(filterer.check_event(&event, Priority::Normal).unwrap());
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn direct_whitelist_simplifies_verbatim_windows_path() {
+	use watchexec_events::{Event, FileType, Tag};
+
+	let origin = dunce::canonicalize(".").unwrap();
+	let emitted = origin.join("watched");
+	let verbatim = PathBuf::from(format!(r"\\?\{}", emitted.display()));
+	let filterer = direct_filt(&origin, &["watched"], vec![verbatim]).await;
+	let event = Event {
+		tags: vec![Tag::Path {
+			path: emitted,
+			file_type: Some(FileType::Dir),
+		}],
+		metadata: Default::default(),
+	};
+
+	assert!(filterer.check_event(&event, Priority::Normal).unwrap());
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn direct_positive_filter_simplifies_verbatim_windows_path() {
+	use watchexec_events::{Event, FileType, Tag};
+
+	let origin = dunce::canonicalize(".").unwrap();
+	let emitted = origin.join("watched").join("main.rs");
+	let verbatim = PathBuf::from(format!(r"\\?\{}", emitted.display()));
+	let filterer =
+		direct_full_filt(&origin, &["watched/main.rs"], &[], Vec::<PathBuf>::new()).await;
+	let event = Event {
+		tags: vec![Tag::Path {
+			path: verbatim,
+			file_type: Some(FileType::File),
+		}],
+		metadata: Default::default(),
+	};
+
+	assert!(filterer.check_event(&event, Priority::Normal).unwrap());
 }
 
 #[tokio::test]
@@ -316,11 +523,11 @@ async fn ignore_glob_middle_double_star() {
 	filterer.file_doesnt_pass("apples/carrots/oranges");
 	filterer.file_doesnt_pass("apples/carrots/cauliflowers/oranges");
 	filterer.file_doesnt_pass("apples/carrots/cauliflowers/artichokes/oranges");
-	filterer.file_does_pass("apples/oranges/bananas");
+	filterer.file_doesnt_pass("apples/oranges/bananas");
 	filterer.dir_doesnt_pass("apples/carrots/oranges");
 	filterer.dir_doesnt_pass("apples/carrots/cauliflowers/oranges");
 	filterer.dir_doesnt_pass("apples/carrots/cauliflowers/artichokes/oranges");
-	filterer.dir_does_pass("apples/oranges/bananas");
+	filterer.dir_doesnt_pass("apples/oranges/bananas");
 }
 
 #[tokio::test]
@@ -331,11 +538,11 @@ async fn ignore_glob_double_star_trailing_slash() {
 	filterer.file_does_pass("apples/carrots/oranges");
 	filterer.file_does_pass("apples/carrots/cauliflowers/oranges");
 	filterer.file_does_pass("apples/carrots/cauliflowers/artichokes/oranges");
-	filterer.file_does_pass("apples/oranges/bananas");
+	filterer.file_doesnt_pass("apples/oranges/bananas");
 	filterer.dir_doesnt_pass("apples/carrots/oranges");
 	filterer.dir_doesnt_pass("apples/carrots/cauliflowers/oranges");
 	filterer.dir_doesnt_pass("apples/carrots/cauliflowers/artichokes/oranges");
-	filterer.dir_does_pass("apples/oranges/bananas");
+	filterer.dir_doesnt_pass("apples/oranges/bananas");
 	filterer.unk_does_pass("apples/carrots/oranges");
 	filterer.unk_does_pass("apples/carrots/cauliflowers/oranges");
 	filterer.unk_does_pass("apples/carrots/cauliflowers/artichokes/oranges");
@@ -474,10 +681,10 @@ async fn nonpath_event_passes() {
 		.unwrap());
 }
 
-// The following tests replicate the "buggy"/"confusing" watchexec v1 behaviour.
+// Folder ignore patterns reject descendant events when their source directory would be pruned.
 
 #[tokio::test]
-async fn ignore_folder_incorrectly_with_bare_match() {
+async fn ignore_folder_with_bare_match() {
 	let filterer = filt(&[], &["prunes"], &[], &[], &[]).await;
 
 	filterer.file_does_pass("apples");
@@ -499,16 +706,15 @@ async fn ignore_folder_incorrectly_with_bare_match() {
 	filterer.file_doesnt_pass("prunes");
 	filterer.dir_doesnt_pass("prunes");
 
-	// buggy behaviour (should be doesnt):
-	filterer.file_does_pass("prunes/carrots/cauliflowers/oranges");
-	filterer.file_does_pass("prunes/carrots/cauliflowers/artichokes/oranges");
-	filterer.file_does_pass("prunes/oranges/bananas");
-	filterer.dir_does_pass("prunes/carrots/cauliflowers/oranges");
-	filterer.dir_does_pass("prunes/carrots/cauliflowers/artichokes/oranges");
+	filterer.file_doesnt_pass("prunes/carrots/cauliflowers/oranges");
+	filterer.file_doesnt_pass("prunes/carrots/cauliflowers/artichokes/oranges");
+	filterer.file_doesnt_pass("prunes/oranges/bananas");
+	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/oranges");
+	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/artichokes/oranges");
 }
 
 #[tokio::test]
-async fn ignore_folder_incorrectly_with_bare_and_leading_slash() {
+async fn ignore_folder_with_bare_and_leading_slash() {
 	let filterer = filt(&[], &["/prunes"], &[], &[], &[]).await;
 
 	filterer.file_does_pass("apples");
@@ -530,16 +736,15 @@ async fn ignore_folder_incorrectly_with_bare_and_leading_slash() {
 	filterer.file_doesnt_pass("prunes");
 	filterer.dir_doesnt_pass("prunes");
 
-	// buggy behaviour (should be doesnt):
-	filterer.file_does_pass("prunes/carrots/cauliflowers/oranges");
-	filterer.file_does_pass("prunes/carrots/cauliflowers/artichokes/oranges");
-	filterer.file_does_pass("prunes/oranges/bananas");
-	filterer.dir_does_pass("prunes/carrots/cauliflowers/oranges");
-	filterer.dir_does_pass("prunes/carrots/cauliflowers/artichokes/oranges");
+	filterer.file_doesnt_pass("prunes/carrots/cauliflowers/oranges");
+	filterer.file_doesnt_pass("prunes/carrots/cauliflowers/artichokes/oranges");
+	filterer.file_doesnt_pass("prunes/oranges/bananas");
+	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/oranges");
+	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/artichokes/oranges");
 }
 
 #[tokio::test]
-async fn ignore_folder_incorrectly_with_bare_and_trailing_slash() {
+async fn ignore_folder_with_bare_and_trailing_slash() {
 	let filterer = filt(&[], &["prunes/"], &[], &[], &[]).await;
 
 	filterer.file_does_pass("apples");
@@ -560,17 +765,17 @@ async fn ignore_folder_incorrectly_with_bare_and_trailing_slash() {
 
 	filterer.dir_doesnt_pass("prunes");
 
-	// buggy behaviour (should be doesnt):
+	// The directory-only glob does not ignore a file at the boundary.
 	filterer.file_does_pass("prunes");
-	filterer.file_does_pass("prunes/carrots/cauliflowers/oranges");
-	filterer.file_does_pass("prunes/carrots/cauliflowers/artichokes/oranges");
-	filterer.file_does_pass("prunes/oranges/bananas");
-	filterer.dir_does_pass("prunes/carrots/cauliflowers/oranges");
-	filterer.dir_does_pass("prunes/carrots/cauliflowers/artichokes/oranges");
+	filterer.file_doesnt_pass("prunes/carrots/cauliflowers/oranges");
+	filterer.file_doesnt_pass("prunes/carrots/cauliflowers/artichokes/oranges");
+	filterer.file_doesnt_pass("prunes/oranges/bananas");
+	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/oranges");
+	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/artichokes/oranges");
 }
 
 #[tokio::test]
-async fn ignore_folder_incorrectly_with_only_double_double_glob() {
+async fn ignore_folder_with_only_double_double_glob() {
 	let filterer = filt(&[], &["**/prunes/**"], &[], &[], &[]).await;
 
 	filterer.file_does_pass("apples");
@@ -595,7 +800,7 @@ async fn ignore_folder_incorrectly_with_only_double_double_glob() {
 	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/oranges");
 	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/artichokes/oranges");
 
-	// buggy behaviour (should be doesnt):
+	// A trailing `/**` does not match the directory boundary, so traversal remains possible.
 	filterer.file_does_pass("prunes");
 	filterer.dir_does_pass("prunes");
 }
@@ -627,6 +832,35 @@ async fn ignore_folder_correctly_with_double_and_double_double_globs() {
 	filterer.dir_doesnt_pass("prunes");
 	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/oranges");
 	filterer.dir_doesnt_pass("prunes/carrots/cauliflowers/artichokes/oranges");
+}
+
+#[tokio::test]
+async fn descendant_negation_does_not_reopen_ignored_parent() {
+	let filterer = filt(&[], &["parent/", "!parent/child"], &[], &[], &[]).await;
+
+	filterer.dir_doesnt_pass("parent");
+	filterer.file_doesnt_pass("parent/child");
+	assert_source_dir(&filterer, "parent", false);
+	assert_source_dir(&filterer, "parent/child", false);
+}
+
+#[tokio::test]
+async fn explicitly_unignored_parent_allows_descendant_negation() {
+	let filterer = filt(
+		&[],
+		&["parent/", "!parent/", "parent/*", "!parent/child"],
+		&[],
+		&[],
+		&[],
+	)
+	.await;
+
+	filterer.dir_does_pass("parent");
+	filterer.file_does_pass("parent/child");
+	filterer.file_doesnt_pass("parent/sibling");
+	assert_source_dir(&filterer, "parent", true);
+	assert_source_dir(&filterer, "parent/child", true);
+	assert_source_dir(&filterer, "parent/sibling", false);
 }
 
 #[tokio::test]

--- a/crates/filterer/globset/tests/filtering.rs
+++ b/crates/filterer/globset/tests/filtering.rs
@@ -133,8 +133,9 @@ async fn relative_origin_stops_ancestor_matching_at_project_boundary() {
 #[tokio::test]
 async fn out_of_origin_paths_do_not_match_external_ancestors() {
 	let sandbox = tempfile::tempdir().unwrap();
-	let origin = sandbox.path().join("project");
-	let external = sandbox.path().join("rust").join("watched");
+	let sandbox_path = dunce::canonicalize(sandbox.path()).unwrap();
+	let origin = sandbox_path.join("project");
+	let external = sandbox_path.join("rust").join("watched");
 	std::fs::create_dir_all(&origin).unwrap();
 	std::fs::create_dir_all(&external).unwrap();
 	let filterer = direct_filt(&origin, &["rust"], Vec::new()).await;

--- a/crates/filterer/ignore/CHANGELOG.md
+++ b/crates/filterer/ignore/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+
+- Implement `Filterer::check_dir` with top-down ignore-file semantics for recursive source pruning.
+
 ## v7.0.1 (2026-08-22)
 
 - adopt release-plz

--- a/crates/filterer/ignore/Cargo.toml
+++ b/crates/filterer/ignore/Cargo.toml
@@ -17,8 +17,6 @@ edition = "2021"
 
 [dependencies]
 ignore = "0.4.18"
-dunce = "1.0.4"
-normalize-path = "0.2.1"
 tracing = "0.1.40"
 
 [dependencies.ignore-files]

--- a/crates/filterer/ignore/src/lib.rs
+++ b/crates/filterer/ignore/src/lib.rs
@@ -12,18 +12,30 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(rust_2018_idioms)]
 
+use std::path::Path;
+
 use ignore::Match;
 use ignore_files::IgnoreFilter;
-use normalize_path::NormalizePath;
 use tracing::{trace, trace_span};
 use watchexec::{error::RuntimeError, filter::Filterer};
 use watchexec_events::{Event, FileType, Priority};
 
 /// A Watchexec [`Filterer`] implementation for [`IgnoreFilter`].
+///
+/// It applies the same top-down ignore semantics to source directories and events. Ignore files are
+/// not monitored or rediscovered by this wrapper; update or replace the inner filter explicitly.
 #[derive(Clone, Debug)]
 pub struct IgnoreFilterer(pub IgnoreFilter);
 
 impl Filterer for IgnoreFilterer {
+	/// Filter a source directory.
+	///
+	/// This implementation never errors. It returns `Ok(false)` if the directory is ignored
+	/// according to the ignore files, and `Ok(true)` otherwise.
+	fn check_dir(&self, path: &Path) -> Result<bool, RuntimeError> {
+		Ok(self.0.check_dir(path))
+	}
+
 	/// Filter an event.
 	///
 	/// This implementation never errors. It returns `Ok(false)` if the event is ignored according
@@ -33,23 +45,14 @@ impl Filterer for IgnoreFilterer {
 		let mut pass = true;
 
 		for (path, file_type) in event.paths() {
-			let path = dunce::simplified(path).normalize();
-			let path = path.as_path();
 			let _span = trace_span!("checking_against_compiled", ?path, ?file_type).entered();
 			let is_dir = file_type.map_or(false, |t| matches!(t, FileType::Dir));
 
-			match self.0.match_path(path, is_dir) {
-				Match::None => {
-					trace!("no match (pass)");
-					pass &= true;
-				}
+			match self.0.match_path_or_ancestors(path, is_dir) {
+				Match::None => trace!("no match (pass)"),
 				Match::Ignore(glob) => {
-					if glob.from().map_or(true, |f| path.strip_prefix(f).is_ok()) {
-						trace!(?glob, "positive match (fail)");
-						pass &= false;
-					} else {
-						trace!(?glob, "positive match, but not in scope (ignore)");
-					}
+					trace!(?glob, "positive match (fail)");
+					pass = false;
 				}
 				Match::Whitelist(glob) => {
 					trace!(?glob, "negative match (pass)");

--- a/crates/filterer/ignore/tests/filtering.rs
+++ b/crates/filterer/ignore/tests/filtering.rs
@@ -1,8 +1,19 @@
 use ignore_files::IgnoreFilter;
+use watchexec::filter::Filterer;
 use watchexec_filterer_ignore::IgnoreFilterer;
 
 mod helpers;
 use helpers::ignore::*;
+
+fn assert_source_dir(filterer: &IgnoreFilterer, path: &str, pass: bool) {
+	let origin = std::fs::canonicalize(".").unwrap();
+	assert_eq!(
+		filterer.check_dir(&origin.join(path)).unwrap(),
+		pass,
+		"source directory {path:?} (expected {})",
+		if pass { "pass" } else { "fail" }
+	);
+}
 
 #[tokio::test]
 async fn folders() {
@@ -247,6 +258,61 @@ async fn scopes() {
 
 	filterer.file_doesnt_pass("tests/child/child.txt");
 	filterer.file_doesnt_pass("tests/child/grandchild/grandchild.c");
+}
+
+#[tokio::test]
+async fn source_checks_boundary_parent_and_negation() {
+	let filterer = filt("", &[file("folders")]).await;
+	assert_source_dir(&filterer, "apples", true);
+	assert_source_dir(&filterer, "prunes", false);
+	assert_source_dir(&filterer, "prunes/nested", false);
+
+	let filterer = filt("", &[file("negate")]).await;
+	assert_source_dir(&filterer, "nah", false);
+	assert_source_dir(&filterer, "nah.yeah", true);
+}
+
+#[tokio::test]
+async fn source_checks_scoped_ignores_after_normalising() {
+	let filterer = filt("", &[file("scopes-sublocal").applies_in("tests")]).await;
+	assert_source_dir(&filterer, "sublocal.dir", true);
+	assert_source_dir(&filterer, "tests/sublocal.dir", false);
+	assert_source_dir(&filterer, "elsewhere/../tests/sublocal.dir", false);
+}
+
+#[tokio::test]
+async fn descendant_negation_does_not_reopen_ignored_parent() {
+	let origin = std::fs::canonicalize(".").unwrap();
+	let mut ignore_filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+	ignore_filter
+		.add_globs(&["parent/", "!parent/child"], Some(&origin))
+		.unwrap();
+	let filterer = IgnoreFilterer(ignore_filter);
+
+	filterer.dir_doesnt_pass("parent");
+	filterer.file_doesnt_pass("parent/child");
+	assert_source_dir(&filterer, "parent", false);
+	assert_source_dir(&filterer, "parent/child", false);
+}
+
+#[tokio::test]
+async fn explicitly_unignored_parent_allows_descendant_negation() {
+	let origin = std::fs::canonicalize(".").unwrap();
+	let mut ignore_filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+	ignore_filter
+		.add_globs(
+			&["parent/", "!parent/", "parent/*", "!parent/child"],
+			Some(&origin),
+		)
+		.unwrap();
+	let filterer = IgnoreFilterer(ignore_filter);
+
+	filterer.dir_does_pass("parent");
+	filterer.file_does_pass("parent/child");
+	filterer.file_doesnt_pass("parent/sibling");
+	assert_source_dir(&filterer, "parent", true);
+	assert_source_dir(&filterer, "parent/child", true);
+	assert_source_dir(&filterer, "parent/sibling", false);
 }
 
 #[tokio::test]

--- a/crates/ignore-files/CHANGELOG.md
+++ b/crates/ignore-files/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+
+- Add `IgnoreFilter::match_path_or_ancestors` and `IgnoreFilter::check_dir` for top-down recursive source filtering. An ignored ancestor prunes its subtree; a descendant negation cannot reopen it.
+- Expose `VCS_DIR_NAMES` so ignore discovery and clients can share the same metadata-directory list.
+
 ## v3.0.6 (2026-08-22)
 
 - adapt ignore-files to gix-config 0.59

--- a/crates/ignore-files/src/discover.rs
+++ b/crates/ignore-files/src/discover.rs
@@ -13,7 +13,7 @@ use project_origins::ProjectType;
 use tokio::fs::{canonicalize, metadata, read_dir};
 use tracing::{trace, trace_span};
 
-use crate::{IgnoreFile, IgnoreFilter};
+use crate::{IgnoreFile, IgnoreFilter, VCS_DIR_NAMES};
 
 /// Arguments for finding ignored files in a given directory and subdirectories
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -503,19 +503,13 @@ impl DirTourist {
 			.await
 			.map_err(|err| Error::new(ErrorKind::Other, err))?;
 
+		let vcs_ignores: Vec<_> = VCS_DIR_NAMES
+			.iter()
+			.map(|directory| format!("/{directory}"))
+			.collect();
+		let vcs_ignores: Vec<_> = vcs_ignores.iter().map(String::as_str).collect();
 		filter
-			.add_globs(
-				&[
-					"/.git",
-					"/.hg",
-					"/.bzr",
-					"/_darcs",
-					"/.fossil-settings",
-					"/.svn",
-					"/.pijul",
-				],
-				Some(&base),
-			)
+			.add_globs(&vcs_ignores, Some(&base))
 			.map_err(|err| Error::new(ErrorKind::Other, err))?;
 
 		Ok(Self {

--- a/crates/ignore-files/src/filter.rs
+++ b/crates/ignore-files/src/filter.rs
@@ -33,6 +33,9 @@ impl std::fmt::Debug for Ignore {
 /// This reads and compiles ignore files, and should be used for handling ignore files. It's created
 /// with a project origin and a list of ignore files, and new ignore files can be added later
 /// (unless [`finish`](IgnoreFilter::finish()) is called).
+///
+/// Files are read only when construction or a mutation method is called. The filter does not monitor
+/// loaded files for edits or automatically discover new ignore files.
 #[derive(Clone, Debug)]
 pub struct IgnoreFilter {
 	origin: PathBuf,
@@ -44,21 +47,21 @@ impl IgnoreFilter {
 	///
 	/// Prefer [`new()`](IgnoreFilter::new()) if you have ignore files ready to use.
 	pub fn empty(origin: impl AsRef<Path>) -> Self {
-		let origin = origin.as_ref();
+		let requested_origin = origin.as_ref();
+		let origin = std::path::absolute(requested_origin)
+			.expect("failed to make empty ignore filter origin absolute");
+		let origin = simplify_path(&origin);
 
 		let mut ignores = Trie::new();
 		ignores.insert(
 			origin.display().to_string(),
 			Ignore {
 				gitignore: Gitignore::empty(),
-				builder: Some(GitignoreBuilder::new(origin)),
+				builder: Some(GitignoreBuilder::new(&origin)),
 			},
 		);
 
-		Self {
-			origin: origin.to_owned(),
-			ignores,
-		}
+		Self { origin, ignores }
 	}
 
 	/// Read ignore files from disk and load them for filtering.
@@ -336,11 +339,12 @@ impl IgnoreFilter {
 		Ok(())
 	}
 
-	/// Match a particular path against the ignore set.
-	pub fn match_path(&self, path: &Path, is_dir: bool) -> Match<&Glob> {
-		let path = simplify_path(path);
-		let path = path.as_path();
-
+	fn match_path_in_scopes(
+		&self,
+		path: &Path,
+		is_dir: bool,
+		include_parents: bool,
+	) -> Match<&Glob> {
 		let mut search_path = path;
 		loop {
 			let Some(trie_node) = self
@@ -354,7 +358,7 @@ impl IgnoreFilter {
 			// Unwrap will always succeed because every node has an entry.
 			let ignores = trie_node.value().unwrap();
 
-			let match_ = if path.strip_prefix(&self.origin).is_ok() {
+			let match_ = if include_parents && path.strip_prefix(&self.origin).is_ok() {
 				trace!(?path, ?search_path, "checking against path or parents");
 				ignores.gitignore.matched_path_or_any_parents(path, is_dir)
 			} else {
@@ -369,19 +373,80 @@ impl IgnoreFilter {
 						?search_path,
 						"no match found, searching for parent ignores"
 					);
-					// Unwrap will always succeed because every node has an entry.
-					let trie_path = Path::new(trie_node.key().unwrap());
-					if let Some(trie_parent) = trie_path.parent() {
-						trace!(?path, ?search_path, "checking parent ignore");
-						search_path = trie_parent;
-					} else {
-						trace!(?path, ?search_path, "no parent ignore found");
-						return Match::None;
-					}
 				}
-				_ => return match_,
+				Match::Ignore(glob) => {
+					if glob
+						.from()
+						.map_or(true, |from| path.strip_prefix(from).is_ok())
+					{
+						return Match::Ignore(glob);
+					}
+					trace!(?path, ?search_path, ?glob, "ignore match is outside scope");
+				}
+				Match::Whitelist(glob) => {
+					if glob
+						.from()
+						.map_or(true, |from| path.strip_prefix(from).is_ok())
+					{
+						return Match::Whitelist(glob);
+					}
+					trace!(
+						?path,
+						?search_path,
+						?glob,
+						"whitelist match is outside scope"
+					);
+				}
+			}
+
+			// Unwrap will always succeed because every node has an entry.
+			let trie_path = Path::new(trie_node.key().unwrap());
+			if let Some(trie_parent) = trie_path.parent() {
+				trace!(?path, ?search_path, "checking parent ignore");
+				search_path = trie_parent;
+			} else {
+				trace!(?path, ?search_path, "no parent ignore found");
+				return Match::None;
 			}
 		}
+	}
+
+	/// Match a particular path against the ignore set.
+	#[must_use]
+	pub fn match_path(&self, path: &Path, is_dir: bool) -> Match<&Glob> {
+		let path = simplify_path(path);
+		self.match_path_in_scopes(&path, is_dir, true)
+	}
+
+	/// Match a path using the same top-down ancestor semantics as a filesystem walk.
+	///
+	/// An ignored ancestor is returned before matches on its descendants. Therefore, a descendant
+	/// negation cannot reopen a subtree that would already have been pruned. An explicit negation on
+	/// the ancestor itself allows matching to continue below it. Paths outside the filter origin are
+	/// matched exactly so project and global patterns are not applied to unrelated filesystem
+	/// ancestors.
+	#[must_use]
+	pub fn match_path_or_ancestors(&self, path: &Path, is_dir: bool) -> Match<&Glob> {
+		let path = simplify_path(path);
+		let ancestors = path
+			.strip_prefix(&self.origin)
+			.ok()
+			.map(|_| {
+				path.ancestors()
+					.skip(1)
+					.take_while(|ancestor| ancestor.starts_with(&self.origin))
+					.collect::<Vec<_>>()
+			})
+			.unwrap_or_default();
+
+		for ancestor in ancestors.into_iter().rev() {
+			if let Match::Ignore(glob) = self.match_path_in_scopes(ancestor, true, false) {
+				trace!(?path, ?ancestor, ?glob, "ancestor is ignored");
+				return Match::Ignore(glob);
+			}
+		}
+
+		self.match_path_in_scopes(&path, is_dir, false)
 	}
 
 	/// Check a particular folder path against the ignore set.
@@ -394,19 +459,14 @@ impl IgnoreFilter {
 		let _span = trace_span!("check_dir", ?path).entered();
 
 		trace!("checking against compiled ignore files");
-		match self.match_path(path, true) {
+		match self.match_path_or_ancestors(path, true) {
 			Match::None => {
 				trace!("no match (pass)");
 				true
 			}
 			Match::Ignore(glob) => {
-				if glob.from().map_or(true, |f| path.strip_prefix(f).is_ok()) {
-					trace!(?glob, "positive match (fail)");
-					false
-				} else {
-					trace!(?glob, "positive match, but not in scope (pass)");
-					true
-				}
+				trace!(?glob, "positive match (fail)");
+				false
 			}
 			Match::Whitelist(glob) => {
 				trace!(?glob, "negative match (pass)");
@@ -450,5 +510,15 @@ mod tests {
 	async fn handle_relative_paths() {
 		let ignore = IgnoreFilter::new(".", &[]).await.unwrap();
 		assert!(ignore.origin.is_absolute());
+	}
+
+	#[test]
+	fn empty_normalises_relative_origin() {
+		let ignore = IgnoreFilter::empty("relative/../origin");
+		assert!(ignore.origin.is_absolute());
+		assert_eq!(
+			ignore.origin,
+			std::env::current_dir().unwrap().join("origin")
+		);
 	}
 }

--- a/crates/ignore-files/src/lib.rs
+++ b/crates/ignore-files/src/lib.rs
@@ -29,10 +29,10 @@ mod error;
 pub use filter::*;
 mod filter;
 
-/// Directory names used for version-control metadata.
+/// Directory names treated as version-control metadata.
 ///
-/// These names are shared by ignore-file discovery and clients which provide matching default
-/// ignore rules.
+/// Used internally for ignore-file discovery. Reuse this list when ignoring VCS metadata to
+/// automatically follow additions to the crate's discovery support.
 pub const VCS_DIR_NAMES: &[&str] = &[
 	".bzr",
 	"_darcs",

--- a/crates/ignore-files/src/lib.rs
+++ b/crates/ignore-files/src/lib.rs
@@ -5,6 +5,10 @@
 //! ignore files, which apply to a specific folder and its subfolders. Furthermore, there may be
 //! more ignore files in _these_ subfolders, and so on. Discovering and interpreting all of these in
 //! a single context is not a simple task: this is what this crate provides.
+//!
+//! Discovery and loading are explicit snapshots. This crate does not watch ignore files for edits or
+//! automatically rediscover files created later; call the discovery/loading APIs again, or update an
+//! unfinished [`IgnoreFilter`] with its mutation methods.
 
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
@@ -24,6 +28,20 @@ mod error;
 #[doc(inline)]
 pub use filter::*;
 mod filter;
+
+/// Directory names used for version-control metadata.
+///
+/// These names are shared by ignore-file discovery and clients which provide matching default
+/// ignore rules.
+pub const VCS_DIR_NAMES: &[&str] = &[
+	".bzr",
+	"_darcs",
+	".fossil-settings",
+	".git",
+	".hg",
+	".pijul",
+	".svn",
+];
 
 /// An ignore file.
 ///

--- a/crates/ignore-files/tests/filtering.rs
+++ b/crates/ignore-files/tests/filtering.rs
@@ -1,6 +1,17 @@
 mod helpers;
 
+use std::path::Path;
+
 use helpers::ignore_tests::*;
+use ignore::Match;
+use ignore_files::IgnoreFilter;
+
+fn path_is_ignored(filter: &IgnoreFilter, path: &Path, is_dir: bool) -> bool {
+	matches!(
+		filter.match_path_or_ancestors(path, is_dir),
+		Match::Ignore(glob) if glob.from().map_or(true, |from| path.starts_with(from))
+	)
+}
 
 #[tokio::test]
 async fn globals() {
@@ -66,4 +77,88 @@ async fn tree() {
 	filter.agnostic_fail("tree/branch/bananas/pears");
 	filter.agnostic_pass("tree/branch/inner/bananas/pears");
 	filter.agnostic_pass("tree/other/bananas/pears");
+}
+
+#[tokio::test]
+async fn nested_negation_does_not_reopen_ignored_parent() {
+	let origin = std::fs::canonicalize("tests/tree").unwrap();
+	let branch = origin.join("branch");
+	let mut filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+	filter
+		.add_globs(&["branch/parent/"], Some(&origin))
+		.unwrap();
+	filter.add_globs(&["!parent/child"], Some(&branch)).unwrap();
+
+	let parent = branch.join("parent");
+	let child = parent.join("child");
+	assert!(!filter.check_dir(&parent));
+	assert!(path_is_ignored(&filter, &child, false));
+	assert!(!filter.check_dir(&child));
+}
+
+#[tokio::test]
+async fn nested_negation_works_when_parent_is_explicitly_unignored() {
+	let origin = std::fs::canonicalize("tests/tree").unwrap();
+	let branch = origin.join("branch");
+	let mut filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+	filter
+		.add_globs(&["branch/parent/"], Some(&origin))
+		.unwrap();
+	filter
+		.add_globs(&["!parent/", "parent/*", "!parent/child"], Some(&branch))
+		.unwrap();
+
+	let parent = branch.join("parent");
+	let child = parent.join("child");
+	let sibling = parent.join("sibling");
+	assert!(filter.check_dir(&parent));
+	assert!(!path_is_ignored(&filter, &child, false));
+	assert!(filter.check_dir(&child));
+	assert!(path_is_ignored(&filter, &sibling, false));
+	assert!(!filter.check_dir(&sibling));
+}
+
+#[tokio::test]
+async fn scoped_ignores_respect_path_component_boundaries() {
+	let origin = std::fs::canonicalize("tests/tree").unwrap();
+	let scoped = origin.join("tests");
+	let mut filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+	filter
+		.add_globs(&["item", "!allowed"], Some(&origin))
+		.unwrap();
+	filter
+		.add_globs(&["!item", "allowed"], Some(&scoped))
+		.unwrap();
+
+	assert!(!path_is_ignored(&filter, &scoped.join("item"), false));
+	assert!(path_is_ignored(&filter, &scoped.join("allowed"), false));
+	assert!(path_is_ignored(
+		&filter,
+		&origin.join("tests2").join("item"),
+		false
+	));
+	assert!(!path_is_ignored(
+		&filter,
+		&origin.join("tests2").join("allowed"),
+		false
+	));
+}
+
+#[tokio::test]
+async fn out_of_origin_paths_do_not_match_external_ancestors() {
+	let origin = std::fs::canonicalize("tests/tree").unwrap();
+	let mut filter = IgnoreFilter::new(&origin, &[]).await.unwrap();
+	filter.add_globs(&["rust"], None).unwrap();
+
+	let external = origin
+		.parent()
+		.unwrap()
+		.join("rust")
+		.join("watched")
+		.join("child");
+	let internal = origin.join("rust").join("child");
+	assert!(!path_is_ignored(&filter, &external, false));
+	assert!(filter.check_dir(&external));
+	assert!(path_is_ignored(&filter, &internal, false));
+	assert!(!filter.check_dir(&internal));
 }

--- a/crates/ignore-files/tests/filtering.rs
+++ b/crates/ignore-files/tests/filtering.rs
@@ -9,7 +9,7 @@ use ignore_files::IgnoreFilter;
 fn path_is_ignored(filter: &IgnoreFilter, path: &Path, is_dir: bool) -> bool {
 	matches!(
 		filter.match_path_or_ancestors(path, is_dir),
-		Match::Ignore(glob) if glob.from().map_or(true, |from| path.starts_with(from))
+		Match::Ignore(_)
 	)
 }
 

--- a/crates/lib/CHANGELOG.md
+++ b/crates/lib/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Next (YYYY-MM-DD)
 
-- Add `Filterer::check_dir` and Watchexec-owned, source-filtered recursion for Inotify, Windows ReadDirectoryChanges, and Poll backends. Exact configured roots bypass source filtering; their descendants do not.
+- Add `Filterer::check_dir` and Watchexec-owned, source-filtered recursion for Inotify, Windows ReadDirectoryChanges, and Poll backends.
 - Reconcile managed filesystem sources when roots, watcher selection, symlink policy, or the live filterer changes. `fs_ready` now reports settled reconciliation and may signal after partial nonfatal failures.
-- Continue independent sibling traversal after path-local scan or watch failures, report them through the runtime error hook, classify and latch watch/handle exhaustion, and guard missing roots on managed backends.
-- Keep native FSEvents and Kqueue on Notify-owned recursion for this release: per-directory updates would repeatedly rebuild FSEvents' shared stream at its since-now history boundary, while Kqueue needs internal per-entry recursion. Use Poll when physical source pruning is required.
+- Continue traversing independent sibling paths after a scan or watch failure, reporting the failure through the runtime error hook.
+- Classify and latch watch or handle exhaustion so it is reported once per reconciliation rather than once per path.
+- For managed recursion, watch the nearest safe existing ancestor of a missing root so the root can be watched when it is created.
+- We keep native FSEvents and Kqueue on Notify-owned recursion for this release: per-directory updates would repeatedly rebuild FSEvents' shared stream at its since-now history boundary, while Kqueue needs internal per-entry recursion. Use Poll when physical source pruning is required on these platforms.
 
 ## v8.3.0 (2026-08-22)
 

--- a/crates/lib/CHANGELOG.md
+++ b/crates/lib/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+
+- Add `Filterer::check_dir` and Watchexec-owned, source-filtered recursion for Inotify, Windows ReadDirectoryChanges, and Poll backends. Exact configured roots bypass source filtering; their descendants do not.
+- Reconcile managed filesystem sources when roots, watcher selection, symlink policy, or the live filterer changes. `fs_ready` now reports settled reconciliation and may signal after partial nonfatal failures.
+- Continue independent sibling traversal after path-local scan or watch failures, report them through the runtime error hook, classify and latch watch/handle exhaustion, and guard missing roots on managed backends.
+- Keep native FSEvents and Kqueue on Notify-owned recursion for this release: per-directory updates would repeatedly rebuild FSEvents' shared stream at its since-now history boundary, while Kqueue needs internal per-entry recursion. Use Poll when physical source pruning is required.
+
 ## v8.3.0 (2026-08-22)
 
 - propagate Unix job-control signals

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -59,6 +59,10 @@ libc = "0.2.74"
 version = ">= 0.59.0, < 0.62.0"
 features = ["Win32_System_Console", "Win32_Foundation"]
 
+[dev-dependencies]
+tempfile = "3.16.0"
+tokio = { version = "1.33.0", features = ["macros", "time"] }
+
 [dev-dependencies.tracing-subscriber]
 version = "0.3.6"
 features = ["env-filter"]

--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -165,34 +165,6 @@ Other examples:
 - [Restart `cargo run` only when `cargo build` succeeds](./examples/restart_run_on_successful_build.rs)
 
 
-## Filesystem recursion and source filtering
-
-`Filterer::check_dir` can reject a directory before it becomes an event source. This source pruning
-is separate from `Filterer::check_event`: custom filterers accept every source directory by default,
-and accepted events are still filtered normally. Every configured watch path bypasses source
-filtering at that exact root; descendants of recursive roots obey it.
-
-Watchexec owns per-directory recursion when Notify reports Inotify, Windows
-ReadDirectoryChanges, or Poll (including a `Watcher::Native` fallback to Poll). Native FSEvents and
-Kqueue retain Notify's recursive watches in this release, so they do not physically prune ignored
-directories or use Watchexec's missing-root guards. Per-directory updates would repeatedly rebuild
-Notify's shared FSEvents stream at its since-now history boundary, while Kqueue needs internal
-per-entry recursion to observe child changes. FSEvents may observe broader streams internally even
-when callback events are limited to configured roots. Use `Watcher::Poll` when physical pruning is
-required, bearing in mind that polling work scales with the number of accepted directories.
-
-Replacing the live filterer through `Config::filterer` reconciles managed sources. It does not reread
-or rediscover ignore files; rebuild the filterer first. `Config::fs_ready` is notified once the latest
-root, filter, watcher, and symlink reconciliation settles, even when nonfatal path-local failures left
-partial coverage. Those failures reach the error hook and independent sibling paths continue; watch
-or handle exhaustion is classified and latched instead of producing a cascade of path errors.
-
-Managed recursion honours `Config::follow_symlinks` and watches a safe existing ancestor when a root
-is missing, so it can pick the root up if it appears later. Its traversal reads one directory
-synchronously per step: it yields between directories, but one exceptionally large or slow directory
-can still delay readiness.
-
-
 ## Kitchen sink
 
 Though not its primary usecase, the library exposes most of its relatively standalone components,

--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -165,6 +165,34 @@ Other examples:
 - [Restart `cargo run` only when `cargo build` succeeds](./examples/restart_run_on_successful_build.rs)
 
 
+## Filesystem recursion and source filtering
+
+`Filterer::check_dir` can reject a directory before it becomes an event source. This source pruning
+is separate from `Filterer::check_event`: custom filterers accept every source directory by default,
+and accepted events are still filtered normally. Every configured watch path bypasses source
+filtering at that exact root; descendants of recursive roots obey it.
+
+Watchexec owns per-directory recursion when Notify reports Inotify, Windows
+ReadDirectoryChanges, or Poll (including a `Watcher::Native` fallback to Poll). Native FSEvents and
+Kqueue retain Notify's recursive watches in this release, so they do not physically prune ignored
+directories or use Watchexec's missing-root guards. Per-directory updates would repeatedly rebuild
+Notify's shared FSEvents stream at its since-now history boundary, while Kqueue needs internal
+per-entry recursion to observe child changes. FSEvents may observe broader streams internally even
+when callback events are limited to configured roots. Use `Watcher::Poll` when physical pruning is
+required, bearing in mind that polling work scales with the number of accepted directories.
+
+Replacing the live filterer through `Config::filterer` reconciles managed sources. It does not reread
+or rediscover ignore files; rebuild the filterer first. `Config::fs_ready` is notified once the latest
+root, filter, watcher, and symlink reconciliation settles, even when nonfatal path-local failures left
+partial coverage. Those failures reach the error hook and independent sibling paths continue; watch
+or handle exhaustion is classified and latched instead of producing a cascade of path errors.
+
+Managed recursion honours `Config::follow_symlinks` and watches a safe existing ancestor when a root
+is missing, so it can pick the root up if it appears later. Its traversal reads one directory
+synchronously per step: it yields between directories, but one exceptionally large or slow directory
+can still delay readiness.
+
+
 ## Kitchen sink
 
 Though not its primary usecase, the library exposes most of its relatively standalone components,

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1,8 +1,8 @@
 //! Configuration and builders for [`crate::Watchexec`].
 
-use std::{future::Future, pin::pin, sync::Arc, time::Duration};
+use std::{future::Future, time::Duration};
 
-use tokio::sync::{watch, Notify};
+use tokio::sync::watch;
 use tracing::{debug, trace};
 
 use crate::{
@@ -30,9 +30,9 @@ use crate::{
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Config {
-	/// This is set by the change methods whenever they're called, and notifies Watchexec that it
-	/// should read the configuration again.
-	pub(crate) change_signal: Arc<Notify>,
+	/// This monotonic revision is incremented by the change methods whenever they're called, and
+	/// notifies Watchexec that it should read the configuration again.
+	pub(crate) change_signal: watch::Sender<u64>,
 
 	/// The main handler to define: what to do when an action is triggered.
 	///
@@ -110,6 +110,10 @@ pub struct Config {
 	///
 	/// If this is non-empty, the filesystem event source is started and configured to provide
 	/// events for these paths. If it becomes empty, the filesystem event source is shut down.
+	///
+	/// Every configured path is retained as an exact source root even when the configured
+	/// [`Filterer::check_dir`] would reject it. Source filtering applies to descendants of recursive
+	/// roots; event filtering remains separate.
 	pub pathset: Changeable<Vec<WatchedPath>>,
 
 	/// The kind of filesystem watcher to be used.
@@ -117,11 +121,13 @@ pub struct Config {
 
 	/// Whether to follow symlinks when watching paths.
 	///
-	/// When `true` (the default), the filesystem watcher will follow symbolic links and watch the
-	/// targets. When `false`, symlinks are not followed: events for the symlink itself may still
-	/// occur, but the symlink target will not be watched.
+	/// When `true` (the default), the filesystem watcher follows symbolic links and watches their
+	/// targets. When `false`, symlinks are not followed: events for a symlink itself may still occur,
+	/// but its target is not watched through that link.
 	///
-	/// This maps directly to [`notify::Config::with_follow_symlinks`].
+	/// Watchexec enforces this while traversing backends for which it manages recursion, and also
+	/// passes the value to Notify. Native backends which retain Notify-owned recursion may have
+	/// backend-specific behaviour; see [`crate::sources::fs`].
 	pub follow_symlinks: Changeable<bool>,
 
 	/// Listen for Unix job-control signals (`SIGTSTP` and `SIGCONT`).
@@ -154,9 +160,12 @@ pub struct Config {
 	/// Default is 50ms.
 	pub throttle: Changeable<Duration>,
 
-	/// The filterer implementation to use when filtering events.
+	/// The filterer implementation used for event and source-directory filtering.
 	///
-	/// The default is a no-op, which will always pass every event.
+	/// The default is a no-op, which passes every event and directory. Replacing the filterer through
+	/// [`Config::filterer()`] reconciles directory sources on backends for which Watchexec manages
+	/// recursion. It does not discover or reread ignore files: applications must rebuild and replace
+	/// an ignore-based filterer when those files change.
 	pub filterer: ChangeableFilterer,
 
 	/// The buffer size of the channel which carries runtime errors.
@@ -175,16 +184,16 @@ pub struct Config {
 	/// This is unchangeable at runtime and must be set before Watchexec instantiation.
 	pub event_channel_size: usize,
 
-	/// Signalled by the filesystem worker after it finishes applying a pathset change
-	/// (registering/unregistering OS watches). Subscribe via [`Config::fs_ready()`] **before**
-	/// calling [`Config::pathset()`] to avoid missing the notification.
+	/// Signalled by the filesystem worker after it settles reconciliation for an observed config
+	/// revision. Subscribe via [`Config::fs_ready()`] before changing filesystem configuration to
+	/// avoid missing or misattributing the notification.
 	pub(crate) fs_ready: watch::Sender<()>,
 }
 
 impl Default for Config {
 	fn default() -> Self {
 		Self {
-			change_signal: Default::default(),
+			change_signal: watch::channel(0).0,
 			action_handler: ChangeableFn::new(ActionReturn::Sync),
 			error_handler: Default::default(),
 			pathset: Default::default(),
@@ -204,6 +213,9 @@ impl Default for Config {
 impl Config {
 	/// Signal that the configuration has changed.
 	///
+	/// This increments a monotonic revision, so a change remains observable by config workers even
+	/// if it is signalled while they are busy. Multiple changes may be coalesced into one wakeup.
+	///
 	/// This is called automatically by all other methods here, so most of the time calling this
 	/// isn't needed, but it can be useful for some advanced uses.
 	#[allow(
@@ -211,26 +223,36 @@ impl Config {
 		reason = "this return can explicitly be ignored"
 	)]
 	pub fn signal_change(&self) -> &Self {
-		self.change_signal.notify_waiters();
+		self.change_signal.send_modify(|revision| {
+			*revision = revision
+				.checked_add(1)
+				.expect("configuration revision overflow");
+		});
 		self
 	}
 
-	/// Watch the config for a change, but run once first.
+	/// Watch the config for changes, running once immediately.
 	///
-	/// This returns a Stream where the first value is available immediately, and then every
-	/// subsequent one is from a change signal for this Config.
+	/// The first call to [`ConfigWatched::next()`] returns immediately. Later calls wait until the
+	/// revision changes; changes that occur between calls remain observable, and multiple changes
+	/// before a call are coalesced.
 	#[must_use]
 	pub(crate) fn watch(&self) -> ConfigWatched {
-		ConfigWatched::new(self.change_signal.clone())
+		ConfigWatched::new(self.change_signal.subscribe())
 	}
 
 	/// Subscribe to filesystem worker readiness notifications.
 	///
-	/// Returns a [`watch::Receiver`] that is notified each time the filesystem worker finishes
-	/// applying a pathset change (i.e. OS watches are registered/unregistered). Signals readiness
-	/// even if some paths failed to register; check the error handler for failures. To avoid
-	/// missing a notification, subscribe **before** calling [`Config::pathset()`], then
-	/// `.changed().await`.
+	/// The receiver is notified after the worker settles the most recently observed configuration,
+	/// including root, filterer, watcher, and symlink-policy reconciliation and any topology work
+	/// accepted during that reconciliation. Readiness means that this work has quiesced, not that
+	/// every path succeeded: best-effort failures are reported separately through the error handler
+	/// and the notification may represent partial filesystem coverage.
+	///
+	/// Notifications carry no revision value and concurrent or rapid changes may be coalesced. To
+	/// wait for a particular change without another caller racing it, subscribe before making the
+	/// change, then call `.changed().await`.
+	#[must_use]
 	pub fn fs_ready(&self) -> watch::Receiver<()> {
 		self.fs_ready.subscribe()
 	}
@@ -276,7 +298,12 @@ impl Config {
 		self.signal_change()
 	}
 
-	/// Set the filterer implementation to use.
+	/// Set the filterer implementation used for events and source directories.
+	///
+	/// On managed recursive backends, replacing the filterer triggers source reconciliation: newly
+	/// accepted directories can be added and newly rejected descendants can be removed. Replacing an
+	/// ignore-based filterer does not itself reread or rediscover ignore files; construct the new
+	/// filterer from the desired files first.
 	pub fn filterer(&self, filterer: impl Filterer + 'static) -> &Self {
 		debug!(?filterer, "Config: filterer");
 		self.filterer.replace(filterer);
@@ -319,33 +346,78 @@ impl Config {
 #[derive(Debug)]
 pub(crate) struct ConfigWatched {
 	first_run: bool,
-	notify: Arc<Notify>,
+	revision: watch::Receiver<u64>,
 }
 
 impl ConfigWatched {
-	fn new(notify: Arc<Notify>) -> Self {
-		let notified = notify.notified();
-		pin!(notified).as_mut().enable();
-
+	const fn new(revision: watch::Receiver<u64>) -> Self {
 		Self {
 			first_run: true,
-			notify,
+			revision,
 		}
 	}
 
-	pub async fn next(&mut self) {
-		let notified = self.notify.notified();
-		let mut notified = pin!(notified);
-		notified.as_mut().enable();
-
+	pub async fn next(&mut self) -> u64 {
 		if self.first_run {
-			trace!("ConfigWatched: first run");
+			let revision = *self.revision.borrow_and_update();
+			trace!(revision, "ConfigWatched: first run");
 			self.first_run = false;
+			revision
 		} else {
-			trace!(?notified, "ConfigWatched: waiting for change");
-			// there's a bit of a gotcha where any config changes made after a Notified resolves
-			// but before a new one is issued will not be caught. not sure how to fix that yet.
-			notified.await;
+			trace!("ConfigWatched: waiting for change");
+			self.revision
+				.changed()
+				.await
+				.expect("configuration change sender dropped");
+			let revision = *self.revision.borrow_and_update();
+			trace!(revision, "ConfigWatched: changed");
+			revision
 		}
+	}
+
+	/// Whether a revision is already waiting to be observed.
+	///
+	/// Filesystem recursion uses this before every bounded state-machine step so
+	/// an obsolete reconciliation cannot advance into its destructive sweep.
+	pub fn pending(&self) -> bool {
+		self.first_run
+			|| self
+				.revision
+				.has_changed()
+				.expect("configuration change sender dropped")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use futures::FutureExt as _;
+
+	use super::Config;
+
+	#[test]
+	fn config_watch_first_run_is_immediate() {
+		let config = Config::default();
+		let mut watched = config.watch();
+
+		assert_eq!(watched.next().now_or_never(), Some(0));
+	}
+
+	#[test]
+	fn config_watch_waits_after_first_run() {
+		let config = Config::default();
+		let mut watched = config.watch();
+
+		assert!(watched.next().now_or_never().is_some());
+		assert!(watched.next().now_or_never().is_none());
+	}
+
+	#[test]
+	fn config_watch_observes_change_between_calls() {
+		let config = Config::default();
+		let mut watched = config.watch();
+
+		assert_eq!(watched.next().now_or_never(), Some(0));
+		config.signal_change();
+		assert_eq!(watched.next().now_or_never(), Some(1));
 	}
 }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -117,11 +117,11 @@ pub struct Config {
 	/// The kind of filesystem watcher to be used.
 	pub file_watcher: Changeable<Watcher>,
 
-	/// Whether to follow symlinks when watching paths.
+	/// Whether to follow directory symlinks when watching paths.
 	///
-	/// When `true` (the default), the filesystem watcher follows symbolic links and watches their
-	/// targets. When `false`, symlinks are not followed: events for a symlink itself may still occur,
-	/// but its target is not watched through that link.
+	/// When enabled, directory symlink targets are included in recursive watches where supported.
+	/// Native macOS filesystem watching does not follow directory symlinks outside the watched
+	/// hierarchy.
 	pub follow_symlinks: Changeable<bool>,
 
 	/// Listen for Unix job-control signals (`SIGTSTP` and `SIGCONT`).

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -111,9 +111,7 @@ pub struct Config {
 	/// If this is non-empty, the filesystem event source is started and configured to provide
 	/// events for these paths. If it becomes empty, the filesystem event source is shut down.
 	///
-	/// Every configured path is retained as an exact source root even when the configured
-	/// [`Filterer::check_dir`] would reject it. Source filtering applies to descendants of recursive
-	/// roots; event filtering remains separate.
+	/// Watched paths are themselves never filtered.
 	pub pathset: Changeable<Vec<WatchedPath>>,
 
 	/// The kind of filesystem watcher to be used.
@@ -124,10 +122,6 @@ pub struct Config {
 	/// When `true` (the default), the filesystem watcher follows symbolic links and watches their
 	/// targets. When `false`, symlinks are not followed: events for a symlink itself may still occur,
 	/// but its target is not watched through that link.
-	///
-	/// Watchexec enforces this while traversing backends for which it manages recursion, and also
-	/// passes the value to Notify. Native backends which retain Notify-owned recursion may have
-	/// backend-specific behaviour; see [`crate::sources::fs`].
 	pub follow_symlinks: Changeable<bool>,
 
 	/// Listen for Unix job-control signals (`SIGTSTP` and `SIGCONT`).
@@ -162,10 +156,7 @@ pub struct Config {
 
 	/// The filterer implementation used for event and source-directory filtering.
 	///
-	/// The default is a no-op, which passes every event and directory. Replacing the filterer through
-	/// [`Config::filterer()`] reconciles directory sources on backends for which Watchexec manages
-	/// recursion. It does not discover or reread ignore files: applications must rebuild and replace
-	/// an ignore-based filterer when those files change.
+	/// The default is a no-op, which passes every event and directory.
 	pub filterer: ChangeableFilterer,
 
 	/// The buffer size of the channel which carries runtime errors.
@@ -213,9 +204,6 @@ impl Default for Config {
 impl Config {
 	/// Signal that the configuration has changed.
 	///
-	/// This increments a monotonic revision, so a change remains observable by config workers even
-	/// if it is signalled while they are busy. Multiple changes may be coalesced into one wakeup.
-	///
 	/// This is called automatically by all other methods here, so most of the time calling this
 	/// isn't needed, but it can be useful for some advanced uses.
 	#[allow(
@@ -231,11 +219,10 @@ impl Config {
 		self
 	}
 
-	/// Watch the config for changes, running once immediately.
+	/// Watch the config for a change, but run once first.
 	///
-	/// The first call to [`ConfigWatched::next()`] returns immediately. Later calls wait until the
-	/// revision changes; changes that occur between calls remain observable, and multiple changes
-	/// before a call are coalesced.
+	/// This returns a Stream where the first value is available immediately, and then every
+	/// subsequent one is from a change signal for this Config.
 	#[must_use]
 	pub(crate) fn watch(&self) -> ConfigWatched {
 		ConfigWatched::new(self.change_signal.subscribe())
@@ -243,15 +230,13 @@ impl Config {
 
 	/// Subscribe to filesystem worker readiness notifications.
 	///
-	/// The receiver is notified after the worker settles the most recently observed configuration,
-	/// including root, filterer, watcher, and symlink-policy reconciliation and any topology work
-	/// accepted during that reconciliation. Readiness means that this work has quiesced, not that
-	/// every path succeeded: best-effort failures are reported separately through the error handler
-	/// and the notification may represent partial filesystem coverage.
+	/// The receiver is notified after the filesystem worker finishes applying the latest observed
+	/// configuration.
 	///
-	/// Notifications carry no revision value and concurrent or rapid changes may be coalesced. To
-	/// wait for a particular change without another caller racing it, subscribe before making the
-	/// change, then call `.changed().await`.
+	/// Path-specific failures are reported through the error handler and do not prevent readiness.
+	///
+	/// Notifications carry no configuration revision and may be coalesced. To wait for a change,
+	/// subscribe before making it, then call `.changed().await`.
 	#[must_use]
 	pub fn fs_ready(&self) -> watch::Receiver<()> {
 		self.fs_ready.subscribe()
@@ -298,12 +283,7 @@ impl Config {
 		self.signal_change()
 	}
 
-	/// Set the filterer implementation used for events and source directories.
-	///
-	/// On managed recursive backends, replacing the filterer triggers source reconciliation: newly
-	/// accepted directories can be added and newly rejected descendants can be removed. Replacing an
-	/// ignore-based filterer does not itself reread or rediscover ignore files; construct the new
-	/// filterer from the desired files first.
+	/// Set the filterer implementation to use.
 	pub fn filterer(&self, filterer: impl Filterer + 'static) -> &Self {
 		debug!(?filterer, "Config: filterer");
 		self.filterer.replace(filterer);

--- a/crates/lib/src/error/specialised.rs
+++ b/crates/lib/src/error/specialised.rs
@@ -51,6 +51,17 @@ pub enum FsWatcherError {
 		err: notify::Error,
 	},
 
+	/// Error received while traversing a filesystem path for recursive watching.
+	#[error("while scanning {path:?}")]
+	PathScan {
+		/// The path that was being inspected or read.
+		path: PathBuf,
+
+		/// The underlying I/O error.
+		#[source]
+		err: std::io::Error,
+	},
+
 	/// Error received when removing from the pathset for the filesystem watcher fails.
 	#[error("while removing {path:?}")]
 	PathRemove {

--- a/crates/lib/src/filter.rs
+++ b/crates/lib/src/filter.rs
@@ -24,8 +24,7 @@ pub trait Filterer: std::fmt::Debug + Send + Sync {
 	/// Like event filtering, source-directory filtering is synchronous, should be fast, and must not
 	/// block the thread.
 	///
-	/// The default implementation accepts every directory, preserving the behaviour of custom
-	/// filterers which only implement event filtering.
+	/// The default implementation accepts every directory.
 	fn check_dir(&self, _path: &Path) -> Result<bool, RuntimeError> {
 		Ok(true)
 	}

--- a/crates/lib/src/filter.rs
+++ b/crates/lib/src/filter.rs
@@ -1,6 +1,6 @@
 //! The `Filterer` trait for event filtering.
 
-use std::{fmt, sync::Arc};
+use std::{fmt, path::Path, sync::Arc};
 
 use watchexec_events::{Event, Priority};
 
@@ -8,6 +8,28 @@ use crate::{changeable::Changeable, error::RuntimeError};
 
 /// An interface for filtering events.
 pub trait Filterer: std::fmt::Debug + Send + Sync {
+	/// Called while reconciling filesystem event sources to decide whether a directory should be
+	/// watched.
+	///
+	/// This is source filtering, which is separate from [`Filterer::check_event`]. Returning `false`
+	/// excludes the directory as an event source, including its descendants; `check_event` still
+	/// filters events which are observed from accepted sources. Implementations should therefore
+	/// reject a directory only when every event beneath it can safely be ignored.
+	///
+	/// An exact configured watch root is never passed to this method. The root remains an event
+	/// source even if this method would reject it, while its descendants are checked normally.
+	/// Watchexec only calls this method on filesystem backends for which it manages recursion; see
+	/// [`crate::sources::fs`] for the backend-specific behaviour.
+	///
+	/// Like event filtering, source-directory filtering is synchronous, should be fast, and must not
+	/// block the thread.
+	///
+	/// The default implementation accepts every directory, preserving the behaviour of custom
+	/// filterers which only implement event filtering.
+	fn check_dir(&self, _path: &Path) -> Result<bool, RuntimeError> {
+		Ok(true)
+	}
+
 	/// Called on (almost) every event, and should return `false` if the event is to be discarded.
 	///
 	/// Checking whether an event passes a filter is synchronous, should be fast, and must not block
@@ -22,12 +44,20 @@ pub trait Filterer: std::fmt::Debug + Send + Sync {
 }
 
 impl Filterer for () {
+	fn check_dir(&self, _path: &Path) -> Result<bool, RuntimeError> {
+		Ok(true)
+	}
+
 	fn check_event(&self, _event: &Event, _priority: Priority) -> Result<bool, RuntimeError> {
 		Ok(true)
 	}
 }
 
-impl<T: Filterer> Filterer for Arc<T> {
+impl<T: Filterer + ?Sized> Filterer for Arc<T> {
+	fn check_dir(&self, path: &Path) -> Result<bool, RuntimeError> {
+		Self::as_ref(self).check_dir(path)
+	}
+
 	fn check_event(&self, event: &Event, priority: Priority) -> Result<bool, RuntimeError> {
 		Self::as_ref(self).check_event(event, priority)
 	}
@@ -40,15 +70,34 @@ pub struct ChangeableFilterer(Changeable<Arc<dyn Filterer>>);
 impl ChangeableFilterer {
 	/// Replace the filterer with a new one.
 	///
+	/// This type does not know whether it belongs to a [`Config`](crate::Config), so calling this on
+	/// `Config::filterer` does not emit the config change signal by itself. Prefer
+	/// [`Config::filterer`](crate::Config::filterer), or call
+	/// [`Config::signal_change`](crate::Config::signal_change) after direct replacement so filesystem
+	/// sources are reconciled.
+	///
 	/// Panics if the lock was poisoned.
 	pub fn replace(&self, new: impl Filterer + 'static) {
 		self.0.replace(Arc::new(new));
 	}
+
+	/// Get a stable snapshot of the current filterer.
+	///
+	/// The snapshot remains valid if the configured filterer is replaced, and its pointer identity
+	/// can be compared with later snapshots to detect a replacement.
+	#[must_use]
+	pub(crate) fn snapshot(&self) -> Arc<dyn Filterer> {
+		self.0.get()
+	}
 }
 
 impl Filterer for ChangeableFilterer {
+	fn check_dir(&self, path: &Path) -> Result<bool, RuntimeError> {
+		self.snapshot().check_dir(path)
+	}
+
 	fn check_event(&self, event: &Event, priority: Priority) -> Result<bool, RuntimeError> {
-		Arc::as_ref(&self.0.get()).check_event(event, priority)
+		self.snapshot().check_event(event, priority)
 	}
 }
 

--- a/crates/lib/src/sources/fs.rs
+++ b/crates/lib/src/sources/fs.rs
@@ -959,7 +959,7 @@ mod tests {
 
 		dispatch_callback_event(
 			1,
-			Watcher::Native,
+			Watcher::Poll(std::time::Duration::from_secs(1)),
 			&control,
 			&ordinary,
 			&fence,
@@ -969,7 +969,7 @@ mod tests {
 		);
 		dispatch_callback_event(
 			1,
-			Watcher::Native,
+			Watcher::Poll(std::time::Duration::from_secs(1)),
 			&control,
 			&ordinary,
 			&fence,

--- a/crates/lib/src/sources/fs.rs
+++ b/crates/lib/src/sources/fs.rs
@@ -1,28 +1,90 @@
 //! Event source for changes to files and directories.
+//!
+//! # Recursive source filtering
+//!
+//! Watchexec owns recursive traversal when the actual Notify backend kind is Inotify, Windows
+//! `ReadDirectoryChanges`, or Poll. This includes [`Watcher::Poll`] and [`Watcher::Native`] on a
+//! platform where Notify's recommended watcher falls back to Poll. Each accepted directory is
+//! registered non-recursively, and [`Filterer::check_dir`] is consulted before a descendant
+//! directory is scanned or watched.
+//!
+//! Every configured [`WatchedPath`] bypasses source filtering at its exact root. Descendants of a
+//! recursive root still obey `check_dir`. If an ignored descendant is separately configured as a
+//! root, that exact path is retained for the second root while its own descendants are checked
+//! normally. Source filtering is separate from event filtering: [`Filterer::check_event`] still
+//! decides whether observed events are delivered, and custom filterers which do not override
+//! `check_dir` accept every directory by default.
+//!
+//! Native `FSEvents` and Kqueue deliberately retain Notify-owned recursion in this release. Watchexec
+//! does not call `check_dir`, physically prune ignored directories, or install its managed
+//! missing-root guards for those backend kinds. Per-directory changes would repeatedly rebuild
+//! Notify's shared `FSEvents` stream at its since-now history boundary, while Kqueue needs Notify's
+//! internal per-entry recursion to observe changes below a directory. Notify's `FSEvents` callback
+//! limits delivered paths, but the underlying `FSEvents` stream may still observe a broader part of
+//! the filesystem internally. Select [`Watcher::Poll`] when physical source pruning is required on
+//! those platforms.
+//!
+//! # Reconciliation and failures
+//!
+//! Changes to roots, watcher selection, symlink policy, or the live [`Config::filterer`] are
+//! reconciled on managed backends. [`Config::fs_ready`] reports when the current reconciliation has
+//! settled; it can report readiness after nonfatal path-local failures, so applications should also
+//! observe their [`ErrorHook`](crate::ErrorHook). Replacing a filterer does not automatically reread
+//! or rediscover ignore files.
+//!
+//! Managed traversal honours [`Config::follow_symlinks`] and watches a safe existing ancestor of a
+//! missing root so that the root can be picked up if it appears later. Non-resource scan and watch
+//! failures are reported as runtime errors while traversal continues with independent sibling
+//! paths. Resource exhaustion is classified as too many watches or handles, reported once for the
+//! reconciliation, and stops further additions during that pass.
+//!
+//! Polling has per-directory cost because every accepted directory is registered separately.
+//! Traversal yields between directories, but each individual directory is read synchronously; one
+//! exceptionally large or slow directory can therefore delay filesystem-worker progress.
+
+mod backend;
+mod recursor;
 
 use std::{
-	collections::{HashMap, HashSet},
+	collections::{HashMap, VecDeque},
 	fs::metadata,
 	mem::take,
-	sync::Arc,
+	path::PathBuf,
+	sync::{
+		atomic::{AtomicU64, Ordering},
+		Arc, Mutex,
+	},
 	time::Duration,
 };
 
 use async_priority_channel as priority;
 use normalize_path::NormalizePath;
+use notify::{
+	event::{ModifyKind, RenameMode},
+	EventKind,
+};
 use tokio::sync::mpsc;
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 use watchexec_events::{Event, Priority, Source, Tag};
 
 use crate::{
 	error::{CriticalError, FsWatcherError, RuntimeError},
+	filter::Filterer,
 	Config,
+};
+
+use self::{
+	backend::{classify_resource_error, create_notify, Backend},
+	recursor::{FsScanner, Recursor},
 };
 
 // re-export for compatibility, until next major version
 pub use crate::WatchedPath;
 
 /// What kind of filesystem watcher to use.
+///
+/// The actual Notify backend kind determines whether Watchexec owns recursion and applies physical
+/// source pruning. See this module's documentation for backend behaviour and costs.
 ///
 /// For now only native and poll watchers are supported. In the future there may be additional
 /// watchers available on some platforms.
@@ -31,12 +93,17 @@ pub use crate::WatchedPath;
 pub enum Watcher {
 	/// The Notify-recommended watcher on the platform.
 	///
-	/// For platforms Notify supports, that's a [native implementation][notify::RecommendedWatcher],
-	/// for others it's polling with a default interval.
+	/// For platforms Notify supports, that's a [native implementation][notify::RecommendedWatcher];
+	/// for others it is polling with a default interval. Watchexec's recursion strategy follows the
+	/// actual backend kind, so a native fallback to Poll receives managed source filtering while
+	/// native `FSEvents` and Kqueue retain Notify-owned recursion.
 	#[default]
 	Native,
 
 	/// Notify’s [poll watcher][notify::PollWatcher] with a custom interval.
+	///
+	/// Poll always uses Watchexec-owned per-directory recursion. This enables physical source pruning
+	/// on every platform, at a polling cost which scales with the number of accepted directories.
 	Poll(Duration),
 }
 
@@ -45,38 +112,463 @@ impl Watcher {
 		self,
 		follow_symlinks: bool,
 		f: impl notify::EventHandler,
-	) -> Result<Box<dyn notify::Watcher + Send>, CriticalError> {
-		use notify::{Config, Watcher as _};
-
-		match self {
-			Self::Native => notify::RecommendedWatcher::new(
-				f,
-				Config::default().with_follow_symlinks(follow_symlinks),
-			)
-			.map(|w| Box::new(w) as _),
-			Self::Poll(delay) => notify::PollWatcher::new(
-				f,
-				Config::default()
-					.with_poll_interval(delay)
-					.with_follow_symlinks(follow_symlinks),
-			)
-			.map(|w| Box::new(w) as _),
-		}
-		.map_err(|err| CriticalError::FsWatcherInit {
+	) -> Result<Box<dyn Backend>, CriticalError> {
+		create_notify(self, follow_symlinks, f).map_err(|error| CriticalError::FsWatcherInit {
 			kind: self,
-			err: if cfg!(target_os = "linux")
-				&& (matches!(err.kind, notify::ErrorKind::MaxFilesWatch)
-					|| matches!(err.kind, notify::ErrorKind::Io(ref ioerr) if ioerr.raw_os_error() == Some(28)))
-			{
-				FsWatcherError::TooManyWatches(err)
-			} else if cfg!(target_os = "linux")
-				&& matches!(err.kind, notify::ErrorKind::Io(ref ioerr) if ioerr.raw_os_error() == Some(24))
-			{
-				FsWatcherError::TooManyHandles(err)
-			} else {
-				FsWatcherError::Create(err)
+			err: match classify_resource_error(&error) {
+				Some(resource) => resource.into_fs_error(error),
+				None => FsWatcherError::Create(error),
 			},
 		})
+	}
+
+	fn backend_kind(self) -> notify::WatcherKind {
+		match self {
+			Self::Native => <notify::RecommendedWatcher as notify::Watcher>::kind(),
+			Self::Poll(_) => <notify::PollWatcher as notify::Watcher>::kind(),
+		}
+	}
+
+	/// Only actual backends with reliable independent non-recursive
+	/// registrations use Watchexec-owned recursion.
+	fn managed(self) -> bool {
+		managed_backend(self.backend_kind())
+	}
+}
+
+const fn managed_backend(kind: notify::WatcherKind) -> bool {
+	matches!(
+		kind,
+		notify::WatcherKind::Inotify
+			| notify::WatcherKind::ReadDirectoryChangesWatcher
+			| notify::WatcherKind::PollWatcher
+	)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Topology {
+	Create(PathBuf),
+	Remove(PathBuf),
+	Rename { from: PathBuf, to: PathBuf },
+	Ambiguous(PathBuf),
+	Rescan,
+}
+
+#[derive(Debug)]
+enum ControlMessage {
+	Topology {
+		generation: u64,
+		sequence: u64,
+		changes: Vec<Topology>,
+	},
+	Error {
+		watcher: Watcher,
+		error: notify::Error,
+	},
+}
+
+#[derive(Debug)]
+struct OrdinaryMessage {
+	generation: u64,
+	topology_sequence: u64,
+	event: notify::Event,
+}
+
+#[derive(Default)]
+struct CallbackFence {
+	generation: AtomicU64,
+	topology_enqueued: AtomicU64,
+	serial: Mutex<()>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PendingReady {
+	topology_fence: Option<u64>,
+}
+
+fn dispatch_callback_event(
+	generation: u64,
+	watcher: Watcher,
+	control: &mpsc::UnboundedSender<ControlMessage>,
+	ordinary: &mpsc::Sender<OrdinaryMessage>,
+	callback_fence: &CallbackFence,
+	event: Result<notify::Event, notify::Error>,
+) {
+	if callback_fence.generation.load(Ordering::Acquire) != generation {
+		return;
+	}
+	trace!(?event, "receiving possible event from watcher");
+	let changes = if watcher.managed() {
+		event.as_ref().ok().map(topology_messages)
+	} else {
+		None
+	};
+	let Ok(_serial) = callback_fence.serial.lock() else {
+		return;
+	};
+	if callback_fence.generation.load(Ordering::Acquire) != generation {
+		return;
+	}
+
+	match event {
+		Ok(event) => {
+			let changes = changes.unwrap_or_default();
+			let topology_sequence = if changes.is_empty() {
+				callback_fence.topology_enqueued.load(Ordering::Acquire)
+			} else {
+				let sequence = callback_fence
+					.topology_enqueued
+					.fetch_add(1, Ordering::AcqRel)
+					.wrapping_add(1);
+				if control
+					.send(ControlMessage::Topology {
+						generation,
+						sequence,
+						changes,
+					})
+					.is_err()
+				{
+					return;
+				}
+				sequence
+			};
+			match ordinary.try_send(OrdinaryMessage {
+				generation,
+				topology_sequence,
+				event,
+			}) {
+				Err(mpsc::error::TrySendError::Full(_)) => {
+					debug!("filesystem callback event lane is full; dropping ordinary event");
+				}
+				Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+			}
+		}
+		Err(error) => {
+			let _ = control.send(ControlMessage::Error { watcher, error });
+		}
+	}
+}
+
+struct AppliedConfig {
+	pathset: Vec<WatchedPath>,
+	watcher: Watcher,
+	follow_symlinks: bool,
+	filter: Arc<dyn Filterer>,
+}
+
+struct WorkerState {
+	recursor: Option<Recursor>,
+	applied: Option<AppliedConfig>,
+	generation: u64,
+	cwd: PathBuf,
+	control: mpsc::UnboundedSender<ControlMessage>,
+	ordinary: mpsc::Sender<OrdinaryMessage>,
+	callback_fence: Arc<CallbackFence>,
+	events: priority::Sender<Event, Priority>,
+	processed_topology: u64,
+	pending_ready: Option<PendingReady>,
+}
+
+impl WorkerState {
+	const fn new(
+		cwd: PathBuf,
+		control: mpsc::UnboundedSender<ControlMessage>,
+		ordinary: mpsc::Sender<OrdinaryMessage>,
+		callback_fence: Arc<CallbackFence>,
+		events: priority::Sender<Event, Priority>,
+	) -> Self {
+		Self {
+			recursor: None,
+			applied: None,
+			generation: 0,
+			cwd,
+			control,
+			ordinary,
+			callback_fence,
+			events,
+			processed_topology: 0,
+			pending_ready: None,
+		}
+	}
+
+	fn apply_config(&mut self, config: &Config) -> Result<(), CriticalError> {
+		let pathset = config.pathset.get();
+		let watcher = config.file_watcher.get();
+		let follow_symlinks = config.follow_symlinks.get();
+		let filter = config.filterer.snapshot();
+
+		let roots_changed = self
+			.applied
+			.as_ref()
+			.map_or(true, |applied| applied.pathset != pathset);
+		let filter_changed = self
+			.applied
+			.as_ref()
+			.map_or(true, |applied| !Arc::ptr_eq(&applied.filter, &filter));
+		let needs_retry = self.recursor.as_ref().map_or(false, Recursor::needs_retry);
+		let recreate = self.applied.as_ref().map_or(true, |applied| {
+			applied.watcher != watcher
+				|| applied.follow_symlinks != follow_symlinks
+				|| (!watcher.managed() && (roots_changed || needs_retry))
+		});
+
+		self.applied = Some(AppliedConfig {
+			pathset: pathset.clone(),
+			watcher,
+			follow_symlinks,
+			filter: filter.clone(),
+		});
+
+		if pathset.is_empty() {
+			let was_active = self.recursor.take().is_some();
+			if was_active {
+				trace!("no more watched paths, dropping watcher");
+			} else {
+				trace!("no watched paths, no watcher needed");
+			}
+			self.bump_generation();
+			return Ok(());
+		}
+
+		if recreate || self.recursor.is_none() {
+			debug!(kind=?watcher, follow_symlinks, "creating new watcher");
+			// Release the old backend before creating the replacement, especially
+			// when watcher handles themselves are the exhausted resource.
+			self.recursor.take();
+			let backend = self.create_backend(watcher, follow_symlinks)?;
+			let mut recursor = Recursor::new(
+				backend,
+				Box::new(FsScanner),
+				watcher,
+				watcher.backend_kind(),
+				follow_symlinks,
+				self.cwd.clone(),
+				filter.clone(),
+			);
+			recursor.reconcile(&pathset, filter);
+			self.recursor = Some(recursor);
+		} else if watcher.managed() && (roots_changed || filter_changed || needs_retry) {
+			trace!(
+				roots_changed,
+				filter_changed,
+				"reconciling filesystem sources"
+			);
+			if let Some(recursor) = self.recursor.as_mut() {
+				recursor.reconcile(&pathset, filter);
+			}
+		}
+
+		Ok(())
+	}
+
+	fn request_ready(&mut self, revision: u64) {
+		if revision > 0 {
+			self.pending_ready = Some(PendingReady {
+				topology_fence: None,
+			});
+		}
+	}
+
+	fn capture_ready_fence(&mut self) {
+		if !matches!(
+			self.pending_ready,
+			Some(PendingReady {
+				topology_fence: None,
+				..
+			})
+		) {
+			return;
+		}
+		let fence = {
+			let _serial = self
+				.callback_fence
+				.serial
+				.lock()
+				.unwrap_or_else(std::sync::PoisonError::into_inner);
+			self.callback_fence
+				.topology_enqueued
+				.load(Ordering::Acquire)
+		};
+		if let Some(ready) = self.pending_ready.as_mut() {
+			ready.topology_fence = Some(fence);
+		}
+	}
+
+	fn bump_generation(&mut self) -> u64 {
+		self.generation = self.generation.wrapping_add(1);
+		self.callback_fence
+			.generation
+			.store(self.generation, Ordering::Release);
+		self.generation
+	}
+
+	fn create_backend(
+		&mut self,
+		watcher: Watcher,
+		follow_symlinks: bool,
+	) -> Result<Box<dyn Backend>, CriticalError> {
+		let generation = self.bump_generation();
+		let control = self.control.clone();
+		let ordinary = self.ordinary.clone();
+		let callback_fence = self.callback_fence.clone();
+
+		watcher.create(follow_symlinks, move |event| {
+			dispatch_callback_event(
+				generation,
+				watcher,
+				&control,
+				&ordinary,
+				&callback_fence,
+				event,
+			);
+		})
+	}
+
+	fn rebuild_backend(
+		&mut self,
+		runtime_errors: &mut VecDeque<RuntimeError>,
+	) -> Result<(), CriticalError> {
+		let Some((watcher, follow_symlinks)) = self
+			.applied
+			.as_ref()
+			.map(|applied| (applied.watcher, applied.follow_symlinks))
+		else {
+			return Ok(());
+		};
+		let replay_limit = self
+			.recursor
+			.as_ref()
+			.map_or(1, |recursor| recursor.replay_count().saturating_add(2));
+		for _ in 0..replay_limit {
+			if let Some(recursor) = self.recursor.as_mut() {
+				recursor.prepare_backend_rebuild();
+			}
+			let backend = self.create_backend(watcher, follow_symlinks)?;
+			let Some(recursor) = self.recursor.as_mut() else {
+				return Ok(());
+			};
+			recursor.install_backend(backend);
+			let mut replay = recursor.replay_backend_snapshot();
+			runtime_errors.extend(replay.errors.drain(..));
+			if !replay.rebuild_backend {
+				return Ok(());
+			}
+		}
+
+		// Every replay path gets at most one fresh-backend retry. If backend
+		// failures make no progress beyond that finite guard, leave unresolved
+		// registrations pending for a later configuration retry rather than
+		// exposing asynchronous replay or recursing forever.
+		if let Some(recursor) = self.recursor.as_mut() {
+			recursor.defer_replay();
+		}
+		Ok(())
+	}
+
+	fn handle_topology(&mut self, change: Topology) {
+		let Some(recursor) = self.recursor.as_mut() else {
+			return;
+		};
+		if !recursor.is_managed() {
+			return;
+		}
+
+		match change {
+			Topology::Create(path) => recursor.topology_create(path),
+			Topology::Remove(path) => recursor.topology_remove(path),
+			Topology::Rename { from, to } => recursor.topology_rename(from, to),
+			Topology::Ambiguous(path) => recursor.topology_ambiguous(path),
+			Topology::Rescan => recursor.rescan(),
+		}
+	}
+
+	fn handle_control(&mut self, message: ControlMessage, errors: &mut VecDeque<RuntimeError>) {
+		match message {
+			ControlMessage::Topology {
+				generation,
+				sequence,
+				changes,
+			} => {
+				self.processed_topology = self.processed_topology.max(sequence);
+				if generation != self.generation {
+					trace!("ignoring topology from obsolete filesystem watcher");
+					return;
+				}
+				for change in changes {
+					self.handle_topology(change);
+				}
+			}
+			ControlMessage::Error { watcher, error } => {
+				// Callback-side generation fencing accepted this error. Once enqueued it
+				// remains observable even if reconfiguration wins the worker race.
+				if let Err(error) = process_event(Err(error), watcher, &self.events) {
+					errors.push_back(error);
+				}
+			}
+		}
+	}
+
+	fn recursor_has_work(&self) -> bool {
+		self.recursor.as_ref().map_or(false, Recursor::has_work)
+	}
+
+	fn control_allowed(&self) -> bool {
+		self.pending_ready.map_or(true, |ready| {
+			ready
+				.topology_fence
+				.map_or(true, |fence| self.processed_topology < fence)
+		})
+	}
+
+	fn ordinary_ready(&self, message: &OrdinaryMessage) -> bool {
+		message.topology_sequence <= self.processed_topology && !self.recursor_has_work()
+	}
+
+	fn handle_ordinary(&self, message: OrdinaryMessage, errors: &mut VecDeque<RuntimeError>) {
+		if message.generation != self.generation {
+			trace!("ignoring event from obsolete filesystem watcher");
+			return;
+		}
+
+		let public = self.recursor.as_ref().map_or(true, |recursor| {
+			!recursor.is_managed() || recursor.event_is_public(&message.event)
+		});
+		if !public {
+			return;
+		}
+		let watcher = self
+			.applied
+			.as_ref()
+			.map_or_else(Watcher::default, |applied| applied.watcher);
+		if let Err(error) = process_event(Ok(message.event), watcher, &self.events) {
+			errors.push_back(error);
+		}
+	}
+}
+
+fn deliver_errors_before_critical(
+	errors: &mpsc::Sender<RuntimeError>,
+	pending: &mut VecDeque<RuntimeError>,
+) {
+	while let Some(error) = pending.pop_front() {
+		match errors.try_send(error) {
+			Ok(()) => {}
+			Err(
+				mpsc::error::TrySendError::Full(error) | mpsc::error::TrySendError::Closed(error),
+			) => {
+				tracing::error!(
+					?error,
+					"runtime error preceding critical filesystem failure"
+				);
+				for error in pending.drain(..) {
+					tracing::error!(
+						?error,
+						"runtime error preceding critical filesystem failure"
+					);
+				}
+				break;
+			}
+		}
 	}
 }
 
@@ -117,126 +609,176 @@ pub async fn worker(
 	events: priority::Sender<Event, Priority>,
 ) -> Result<(), CriticalError> {
 	debug!("launching filesystem worker");
-
-	let mut watcher_type = Watcher::default();
-	let mut watcher = None;
-	let mut pathset = HashSet::new();
-	let mut follow_symlinks = true;
-
+	let cwd = std::env::current_dir().map_err(|err| CriticalError::IoError {
+		about: "obtaining current directory for filesystem watching",
+		err,
+	})?;
+	let (control_tx, mut control_rx) = mpsc::unbounded_channel();
+	let (ordinary_tx, mut ordinary_rx) = mpsc::channel(config.event_channel_size.max(1));
+	let callback_fence = Arc::new(CallbackFence::default());
+	let mut state = WorkerState::new(cwd, control_tx, ordinary_tx, callback_fence, events);
 	let mut config_watch = config.watch();
-	loop {
-		config_watch.next().await;
-		trace!("filesystem worker got a config change");
+	let mut runtime_errors = VecDeque::new();
+	let mut pending_ordinary = None;
 
-		if config.pathset.get().is_empty() {
-			trace!(
-				"{}",
-				if pathset.is_empty() {
-					"no watched paths, no watcher needed"
-				} else {
-					"no more watched paths, dropping watcher"
-				}
-			);
-			watcher.take();
-			pathset.clear();
-			let _ = config.fs_ready.send(());
+	let revision = config_watch.next().await;
+	state.apply_config(&config)?;
+	state.request_ready(revision);
+
+	loop {
+		if config_watch.pending() {
+			let revision = config_watch.next().await;
+			state.apply_config(&config)?;
+			state.request_ready(revision);
 			continue;
 		}
 
-		// now we know the watcher should be alive, so let's start it if it's not already:
-
-		let config_watcher = config.file_watcher.get();
-		let config_follow_symlinks = config.follow_symlinks.get();
-		if watcher.is_none()
-			|| watcher_type != config_watcher
-			|| follow_symlinks != config_follow_symlinks
+		if state
+			.pending_ready
+			.as_ref()
+			.map_or(false, |ready| ready.topology_fence.is_none())
+			&& !state.recursor_has_work()
 		{
-			debug!(kind=?config_watcher, follow_symlinks=?config_follow_symlinks, "creating new watcher");
-			let n_errors = errors.clone();
-			let n_events = events.clone();
-			watcher_type = config_watcher;
-			follow_symlinks = config_follow_symlinks;
-			watcher = config_watcher
-				.create(
-					follow_symlinks,
-					move |nev: Result<notify::Event, notify::Error>| {
-						trace!(event = ?nev, "receiving possible event from watcher");
-						if let Err(e) = process_event(nev, config_watcher, &n_events) {
-							n_errors.try_send(e).ok();
-						}
-					},
-				)
-				.map(Some)?;
-			pathset.clear();
+			state.capture_ready_fence();
 		}
 
-		// now let's calculate which paths we should add to the watch, and which we should drop:
-
-		let config_pathset = config.pathset.get();
-		tracing::info!(?config_pathset, "obtaining pathset");
-		let (to_watch, to_drop) = if pathset.is_empty() {
-			// if the current pathset is empty, we can take a shortcut
-			(config_pathset, Vec::new())
-		} else {
-			let mut to_watch = Vec::with_capacity(config_pathset.len());
-			let mut to_drop = Vec::with_capacity(pathset.len());
-
-			for path in &pathset {
-				if !config_pathset.contains(path) {
-					to_drop.push(path.clone()); // try dropping the clone?
+		let mut progressed = false;
+		let control_allowed = state.control_allowed();
+		if control_allowed {
+			match control_rx.try_recv() {
+				Ok(message) => {
+					state.handle_control(message, &mut runtime_errors);
+					progressed = true;
 				}
-			}
-
-			for path in config_pathset {
-				if !pathset.contains(&path) {
-					to_watch.push(path);
+				Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
 				}
-			}
-
-			(to_watch, to_drop)
-		};
-
-		// now apply it to the watcher
-
-		let Some(watcher) = watcher.as_mut() else {
-			panic!("BUG: watcher should exist at this point");
-		};
-
-		debug!(?to_watch, ?to_drop, "applying changes to the watcher");
-
-		for path in to_drop {
-			trace!(?path, "removing path from the watcher");
-			if let Err(err) = watcher.unwatch(path.path.as_ref()) {
-				error!(?err, "notify unwatch() error");
-				for e in notify_multi_path_errors(watcher_type, path, err, true) {
-					errors.send(e).await?;
-				}
-			} else {
-				pathset.remove(&path);
 			}
 		}
 
-		for path in to_watch {
-			trace!(?path, "adding path to the watcher");
-			if let Err(err) = watcher.watch(
-				path.path.as_ref(),
-				if path.recursive {
-					notify::RecursiveMode::Recursive
+		if state.recursor_has_work() {
+			let step = state
+				.recursor
+				.as_mut()
+				.expect("recursor disappeared")
+				.step();
+			progressed = true;
+			runtime_errors.extend(step.errors);
+			if step.rebuild_backend {
+				// Backend state and finite known-good replay must advance even while
+				// the bounded runtime-error channel is backpressured.
+				if let Err(critical) = state.rebuild_backend(&mut runtime_errors) {
+					deliver_errors_before_critical(&errors, &mut runtime_errors);
+					return Err(critical);
+				}
+			}
+		}
+
+		if config_watch.pending() {
+			continue;
+		}
+
+		if let Some(ready) = state.pending_ready {
+			if ready
+				.topology_fence
+				.map_or(false, |fence| state.processed_topology >= fence)
+				&& !state.recursor_has_work()
+			{
+				state.pending_ready = None;
+				let _ = config.fs_ready.send(());
+				progressed = true;
+			}
+		}
+
+		if state.pending_ready.is_none() {
+			if let Some(message) = pending_ordinary.take() {
+				if state.ordinary_ready(&message) {
+					state.handle_ordinary(message, &mut runtime_errors);
+					progressed = true;
 				} else {
-					notify::RecursiveMode::NonRecursive
-				},
-			) {
-				error!(?err, "notify watch() error");
-				for e in notify_multi_path_errors(watcher_type, path, err, false) {
-					errors.send(e).await?;
+					pending_ordinary = Some(message);
 				}
-			} else {
-				pathset.insert(path);
+			}
+			if pending_ordinary.is_none() {
+				match ordinary_rx.try_recv() {
+					Ok(message) => {
+						pending_ordinary = Some(message);
+						progressed = true;
+					}
+					Err(
+						mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected,
+					) => {}
+				}
 			}
 		}
 
-		let _ = config.fs_ready.send(());
+		if let Some(error) = runtime_errors.pop_front() {
+			match errors.try_send(error) {
+				Ok(()) => progressed = true,
+				Err(mpsc::error::TrySendError::Full(error)) => {
+					runtime_errors.push_front(error);
+				}
+				Err(mpsc::error::TrySendError::Closed(error)) => {
+					return Err(mpsc::error::SendError(error).into());
+				}
+			}
+		}
+
+		if progressed {
+			tokio::task::yield_now().await;
+			continue;
+		}
+
+		let control_allowed = state.control_allowed();
+		tokio::select! {
+			biased;
+			revision = config_watch.next() => {
+				state.apply_config(&config)?;
+				state.request_ready(revision);
+			}
+			Some(message) = control_rx.recv(), if control_allowed => {
+				state.handle_control(message, &mut runtime_errors);
+			}
+			Some(message) = ordinary_rx.recv(), if pending_ordinary.is_none() && state.pending_ready.is_none() => {
+				pending_ordinary = Some(message);
+			}
+			permit = errors.reserve(), if !runtime_errors.is_empty() => {
+				if let Ok(permit) = permit {
+					permit.send(runtime_errors.pop_front().expect("error queue emptied"));
+				} else {
+					let error = runtime_errors.pop_front().expect("error queue emptied");
+					return Err(mpsc::error::SendError(error).into());
+				}
+			}
+		}
 	}
+}
+
+fn topology_messages(event: &notify::Event) -> Vec<Topology> {
+	let mut changes = Vec::new();
+	if event.need_rescan() {
+		changes.push(Topology::Rescan);
+	}
+
+	match event.kind {
+		EventKind::Create(_) => changes.extend(event.paths.iter().cloned().map(Topology::Create)),
+		EventKind::Remove(_) => changes.extend(event.paths.iter().cloned().map(Topology::Remove)),
+		EventKind::Modify(ModifyKind::Name(RenameMode::Both)) if event.paths.len() >= 2 => {
+			changes.push(Topology::Rename {
+				from: event.paths[0].clone(),
+				to: event.paths[1].clone(),
+			});
+			changes.extend(event.paths.iter().skip(2).cloned().map(Topology::Ambiguous));
+		}
+		EventKind::Modify(ModifyKind::Name(RenameMode::From)) => {
+			changes.extend(event.paths.iter().cloned().map(Topology::Remove));
+		}
+		EventKind::Modify(ModifyKind::Name(_)) | EventKind::Any | EventKind::Other => {
+			changes.extend(event.paths.iter().cloned().map(Topology::Ambiguous));
+		}
+		_ => {}
+	}
+
+	changes
 }
 
 fn notify_multi_path_errors(
@@ -255,7 +797,7 @@ fn notify_multi_path_errors(
 
 	let mut errs = Vec::with_capacity(paths.len());
 	for path in paths {
-		let e = err
+		let error = err
 			.take()
 			.unwrap_or_else(|| notify::Error::generic(&generic))
 			.add_path(path.clone());
@@ -263,9 +805,9 @@ fn notify_multi_path_errors(
 		errs.push(RuntimeError::FsWatcher {
 			kind,
 			err: if rm {
-				FsWatcherError::PathRemove { path, err: e }
+				FsWatcherError::PathRemove { path, err: error }
 			} else {
-				FsWatcherError::PathAdd { path, err: e }
+				FsWatcherError::PathAdd { path, err: error }
 			},
 		});
 	}
@@ -288,9 +830,10 @@ fn process_event(
 	tags.push(Tag::FileEventKind(nev.kind));
 
 	for path in nev.paths {
-		// possibly pull file_type from whatever notify (or the native driver) returns?
 		tags.push(Tag::Path {
-			file_type: metadata(&path).ok().map(|m| m.file_type().into()),
+			file_type: metadata(&path)
+				.ok()
+				.map(|metadata| metadata.file_type().into()),
 			path: path.normalize(),
 		});
 	}
@@ -299,42 +842,34 @@ fn process_event(
 		tags.push(Tag::Process(pid));
 	}
 
-	let mut metadata = HashMap::new();
+	let mut event_metadata = HashMap::new();
 
 	if let Some(uid) = nev.attrs.info() {
-		metadata.insert("file-event-info".to_string(), vec![uid.to_string()]);
+		event_metadata.insert("file-event-info".to_string(), vec![uid.to_string()]);
 	}
 
 	if let Some(src) = nev.attrs.source() {
-		metadata.insert("notify-backend".to_string(), vec![src.to_string()]);
+		event_metadata.insert("notify-backend".to_string(), vec![src.to_string()]);
 	}
 
-	let ev = Event { tags, metadata };
+	let event = Event {
+		tags,
+		metadata: event_metadata,
+	};
 
-	trace!(event = ?ev, "processed notify event into watchexec event");
-	match n_events.try_send(ev, Priority::Normal) {
+	trace!(?event, "processed notify event into watchexec event");
+	match n_events.try_send(event, Priority::Normal) {
 		Ok(()) => {}
 		Err(priority::TrySendError::Full(_)) => {
-			// The bounded event channel is at capacity. This happens under bursty
-			// filesystem activity (e.g. building a large project with high parallelism).
-			// Backpressure is not possible from the synchronous notify callback, so the
-			// event is dropped. This is documented behaviour (see Handler docs in
-			// crate::action::handler): rather than surfacing a non-fatal error to the
-			// user for every dropped event, log at debug and continue. The channel size
-			// is tunable via Config::event_channel_size.
 			debug!(
 				"fs watcher event channel is full; dropping event \
 				 (tune Config::event_channel_size if this happens often)"
 			);
 		}
-		Err(priority::TrySendError::Closed(ev)) => {
-			// The receiver has been dropped (Watchexec is shutting down). Propagate as
-			// a real error so downstream handlers can react; this is swallowed by the
-			// `n_errors.try_send(...).ok()` in the worker callback if the error channel
-			// is also closed.
+		Err(priority::TrySendError::Closed(event)) => {
 			return Err(RuntimeError::EventChannelSend {
 				ctx: "fs watcher",
-				err: priority::SendError(ev),
+				err: priority::SendError(event),
 			});
 		}
 	}
@@ -344,10 +879,26 @@ fn process_event(
 
 #[cfg(test)]
 mod tests {
-	use super::process_event;
-	use crate::error::RuntimeError;
+	use super::{
+		dispatch_callback_event, managed_backend, process_event, topology_messages, worker,
+		CallbackFence, ControlMessage, OrdinaryMessage, Topology, Watcher, WorkerState,
+	};
+	use crate::{
+		error::{FsWatcherError, RuntimeError},
+		Config,
+	};
 	use async_priority_channel as priority;
-	use notify::EventKind;
+	use futures::FutureExt as _;
+	use notify::{
+		event::{Flag, ModifyKind, RenameMode},
+		EventKind,
+	};
+	use std::{
+		collections::VecDeque,
+		path::PathBuf,
+		sync::{atomic::Ordering, Arc},
+	};
+	use tokio::sync::mpsc;
 	use watchexec_events::Priority;
 
 	// Regression test for issue #920: when the bounded event channel is full,
@@ -356,14 +907,28 @@ mod tests {
 	// to the user as a non-fatal error for every dropped event. It should instead
 	// drop the event gracefully and return `Ok(())`.
 	#[test]
+	fn backend_strategy_matches_notify_capabilities() {
+		assert!(Watcher::Poll(std::time::Duration::from_secs(1)).managed());
+		assert!(managed_backend(notify::WatcherKind::Inotify));
+		assert!(managed_backend(
+			notify::WatcherKind::ReadDirectoryChangesWatcher
+		));
+		assert!(managed_backend(notify::WatcherKind::PollWatcher));
+		assert!(!managed_backend(notify::WatcherKind::Fsevent));
+		assert!(!managed_backend(notify::WatcherKind::Kqueue));
+		assert!(!managed_backend(notify::WatcherKind::NullWatcher));
+		let native_kind = <notify::RecommendedWatcher as notify::Watcher>::kind();
+		assert_eq!(Watcher::Native.backend_kind(), native_kind);
+		assert_eq!(Watcher::Native.managed(), managed_backend(native_kind));
+	}
+
+	#[test]
 	fn process_event_drops_when_channel_full() {
 		let (ev_s, _ev_r) = priority::bounded::<watchexec_events::Event, Priority>(1);
 		let nev = Ok(notify::Event::new(EventKind::Any));
 
-		// First event fills the channel (capacity 1).
 		assert!(process_event(nev, super::Watcher::default(), &ev_s).is_ok());
 
-		// Second event would overflow: must be dropped gracefully, not surfaced as an error.
 		let nev = Ok(notify::Event::new(EventKind::Any));
 		let res = process_event(nev, super::Watcher::default(), &ev_s);
 		assert!(
@@ -372,9 +937,6 @@ mod tests {
 		);
 	}
 
-	// When the receiver is dropped (Watchexec is shutting down), the send fails with
-	// `Closed`; `process_event` should propagate that as `EventChannelSend`, matching
-	// the signal worker's behaviour and preserving real-error semantics.
 	#[test]
 	fn process_event_propagates_when_channel_closed() {
 		let (ev_s, ev_r) = priority::bounded::<watchexec_events::Event, Priority>(1);
@@ -386,5 +948,302 @@ mod tests {
 			matches!(res, Err(RuntimeError::EventChannelSend { .. })),
 			"closed channel should propagate as EventChannelSend, got {res:?}",
 		);
+	}
+
+	#[test]
+	fn topology_lane_remains_lossless_when_ordinary_lane_is_full() {
+		let (control, mut control_rx) = mpsc::unbounded_channel();
+		let (ordinary, mut ordinary_rx) = mpsc::channel(1);
+		let fence = CallbackFence::default();
+		fence.generation.store(1, Ordering::Release);
+
+		dispatch_callback_event(
+			1,
+			Watcher::Native,
+			&control,
+			&ordinary,
+			&fence,
+			Ok(notify::Event::new(EventKind::Access(
+				notify::event::AccessKind::Any,
+			))),
+		);
+		dispatch_callback_event(
+			1,
+			Watcher::Native,
+			&control,
+			&ordinary,
+			&fence,
+			Ok(
+				notify::Event::new(EventKind::Create(notify::event::CreateKind::Folder))
+					.add_path("/root/new".into()),
+			),
+		);
+
+		assert!(ordinary_rx.try_recv().is_ok());
+		assert!(matches!(
+			ordinary_rx.try_recv(),
+			Err(mpsc::error::TryRecvError::Empty)
+		));
+		assert!(matches!(
+			control_rx.try_recv(),
+			Ok(ControlMessage::Topology {
+				generation: 1,
+				sequence: 1,
+				changes,
+			}) if changes == vec![Topology::Create(PathBuf::from("/root/new"))]
+		));
+	}
+
+	#[test]
+	fn callback_rejects_obsolete_generation_before_enqueue() {
+		let (control, mut control_rx) = mpsc::unbounded_channel();
+		let (ordinary, mut ordinary_rx) = mpsc::channel(1);
+		let fence = CallbackFence::default();
+		fence.generation.store(2, Ordering::Release);
+
+		dispatch_callback_event(
+			1,
+			Watcher::Native,
+			&control,
+			&ordinary,
+			&fence,
+			Ok(
+				notify::Event::new(EventKind::Create(notify::event::CreateKind::Folder))
+					.add_path("/obsolete".into()),
+			),
+		);
+
+		assert!(matches!(
+			control_rx.try_recv(),
+			Err(mpsc::error::TryRecvError::Empty)
+		));
+		assert!(matches!(
+			ordinary_rx.try_recv(),
+			Err(mpsc::error::TryRecvError::Empty)
+		));
+	}
+
+	#[test]
+	fn accepted_callback_error_survives_reconfiguration_race() {
+		let (control, mut control_rx) = mpsc::unbounded_channel();
+		let (ordinary, _ordinary_rx) = mpsc::channel(1);
+		let (events, _event_rx) = priority::bounded(1);
+		let callback_fence = Arc::new(CallbackFence::default());
+		callback_fence.generation.store(1, Ordering::Release);
+		let original = Watcher::Poll(std::time::Duration::from_secs(7));
+		dispatch_callback_event(
+			1,
+			original,
+			&control,
+			&ordinary,
+			&callback_fence,
+			Err(notify::Error::generic("accepted callback error")),
+		);
+
+		let mut state = WorkerState::new(
+			PathBuf::from("/work"),
+			control,
+			ordinary,
+			callback_fence,
+			events,
+		);
+		state.generation = 2;
+		let mut errors = VecDeque::new();
+		state.handle_control(control_rx.try_recv().unwrap(), &mut errors);
+
+		assert!(matches!(
+			errors.pop_front(),
+			Some(RuntimeError::FsWatcher {
+				kind,
+				err: FsWatcherError::Event(_),
+			}) if kind == original
+		));
+	}
+
+	#[test]
+	fn readiness_captures_topology_only_at_first_quiescence() {
+		let (control, _control_rx) = mpsc::unbounded_channel();
+		let (ordinary, _ordinary_rx) = mpsc::channel(1);
+		let (events, _event_rx) = priority::bounded(1);
+		let callback_fence = Arc::new(CallbackFence::default());
+		callback_fence.topology_enqueued.store(3, Ordering::Release);
+		let mut state = WorkerState::new(
+			PathBuf::from("/work"),
+			control,
+			ordinary,
+			callback_fence.clone(),
+			events,
+		);
+
+		state.request_ready(1);
+		assert_eq!(state.pending_ready.unwrap().topology_fence, None);
+		callback_fence.topology_enqueued.store(4, Ordering::Release);
+		state.capture_ready_fence();
+
+		assert_eq!(state.pending_ready.unwrap().topology_fence, Some(4));
+	}
+
+	#[test]
+	fn readiness_fence_waits_for_callback_holding_enqueue_gate() {
+		let (control, _control_rx) = mpsc::unbounded_channel();
+		let (ordinary, _ordinary_rx) = mpsc::channel(1);
+		let (events, _event_rx) = priority::bounded(1);
+		let callback_fence = Arc::new(CallbackFence::default());
+		let mut state = WorkerState::new(
+			PathBuf::from("/work"),
+			control.clone(),
+			ordinary,
+			callback_fence.clone(),
+			events,
+		);
+		state.request_ready(1);
+		let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+		let (release_tx, release_rx) = std::sync::mpsc::channel();
+
+		std::thread::scope(|scope| {
+			let gate = callback_fence.clone();
+			scope.spawn(move || {
+				let _serial = gate.serial.lock().unwrap();
+				acquired_tx.send(()).unwrap();
+				release_rx.recv().unwrap();
+				let sequence = gate.topology_enqueued.fetch_add(1, Ordering::AcqRel) + 1;
+				control
+					.send(ControlMessage::Topology {
+						generation: 0,
+						sequence,
+						changes: vec![Topology::Create("/during-reconcile".into())],
+					})
+					.unwrap();
+			});
+			acquired_rx.recv().unwrap();
+			release_tx.send(()).unwrap();
+			state.capture_ready_fence();
+		});
+
+		assert_eq!(state.pending_ready.unwrap().topology_fence, Some(1));
+	}
+
+	#[test]
+	fn paired_rename_preserves_from_to_order() {
+		let event = notify::Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Both)))
+			.add_path(PathBuf::from("from"))
+			.add_path(PathBuf::from("to"));
+		assert_eq!(
+			topology_messages(&event),
+			vec![Topology::Rename {
+				from: PathBuf::from("from"),
+				to: PathBuf::from("to"),
+			}]
+		);
+	}
+
+	#[test]
+	fn obsolete_generation_does_not_emit_ordinary_event() {
+		let (control, _control_rx) = mpsc::unbounded_channel();
+		let (ordinary, _ordinary_rx) = mpsc::channel(4);
+		let (events, event_rx) = priority::bounded(4);
+		let mut state = WorkerState::new(
+			PathBuf::from("/work"),
+			control,
+			ordinary,
+			Arc::new(CallbackFence::default()),
+			events,
+		);
+		state.generation = 2;
+		let mut errors = VecDeque::new();
+
+		state.handle_ordinary(
+			OrdinaryMessage {
+				generation: 1,
+				topology_sequence: 0,
+				event: notify::Event::new(EventKind::Any),
+			},
+			&mut errors,
+		);
+		assert!(errors.is_empty());
+		assert!(matches!(
+			event_rx.try_recv(),
+			Err(priority::TryRecvError::Empty)
+		));
+	}
+
+	#[test]
+	fn current_generation_closed_event_error_remains_reliable() {
+		let (control, _control_rx) = mpsc::unbounded_channel();
+		let (ordinary, _ordinary_rx) = mpsc::channel(4);
+		let (events, event_rx) = priority::bounded(4);
+		drop(event_rx);
+		let mut state = WorkerState::new(
+			PathBuf::from("/work"),
+			control,
+			ordinary,
+			Arc::new(CallbackFence::default()),
+			events,
+		);
+		state.generation = 1;
+		let mut errors = VecDeque::new();
+
+		state.handle_control(
+			ControlMessage::Topology {
+				generation: 1,
+				sequence: 1,
+				changes: vec![Topology::Rescan],
+			},
+			&mut errors,
+		);
+		state.handle_ordinary(
+			OrdinaryMessage {
+				generation: 1,
+				topology_sequence: 1,
+				event: notify::Event::new(EventKind::Any),
+			},
+			&mut errors,
+		);
+		assert!(matches!(
+			errors.pop_front(),
+			Some(RuntimeError::EventChannelSend { .. })
+		));
+	}
+
+	#[test]
+	fn worker_skips_revision_zero_ready_but_signals_same_value_revision() {
+		let runtime = tokio::runtime::Builder::new_current_thread()
+			.build()
+			.unwrap();
+		runtime.block_on(async {
+			let config = Arc::new(Config::default());
+			let mut ready = config.fs_ready();
+			let (events, _event_rx) = priority::bounded(4);
+			let (errors, _error_rx) = mpsc::channel(4);
+			let task = tokio::spawn(worker(config.clone(), errors, events));
+
+			for _ in 0..4 {
+				tokio::task::yield_now().await;
+			}
+			assert!(ready.changed().now_or_never().is_none());
+
+			config.pathset(Vec::<super::WatchedPath>::new());
+			ready.changed().await.unwrap();
+			task.abort();
+		});
+	}
+
+	#[test]
+	fn split_rename_and_rescan_produce_reliable_topology() {
+		let from = notify::Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::From)))
+			.add_path(PathBuf::from("old"));
+		let to = notify::Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::To)))
+			.add_path(PathBuf::from("new"));
+		let rescan = notify::Event::new(EventKind::Any).set_flag(Flag::Rescan);
+
+		assert_eq!(
+			topology_messages(&from),
+			vec![Topology::Remove(PathBuf::from("old"))]
+		);
+		assert_eq!(
+			topology_messages(&to),
+			vec![Topology::Ambiguous(PathBuf::from("new"))]
+		);
+		assert_eq!(topology_messages(&rescan), vec![Topology::Rescan]);
 	}
 }

--- a/crates/lib/src/sources/fs.rs
+++ b/crates/lib/src/sources/fs.rs
@@ -2,45 +2,20 @@
 //!
 //! # Recursive source filtering
 //!
-//! Watchexec owns recursive traversal when the actual Notify backend kind is Inotify, Windows
-//! `ReadDirectoryChanges`, or Poll. This includes [`Watcher::Poll`] and [`Watcher::Native`] on a
-//! platform where Notify's recommended watcher falls back to Poll. Each accepted directory is
-//! registered non-recursively, and [`Filterer::check_dir`] is consulted before a descendant
-//! directory is scanned or watched.
+//! Watchexec does its own recursive traversal, using non-recursive watches on supported backends
+//! and filtering the watch tree from the [`Filterer`] implementation.
 //!
-//! Every configured [`WatchedPath`] bypasses source filtering at its exact root. Descendants of a
-//! recursive root still obey `check_dir`. If an ignored descendant is separately configured as a
-//! root, that exact path is retained for the second root while its own descendants are checked
-//! normally. Source filtering is separate from event filtering: [`Filterer::check_event`] still
-//! decides whether observed events are delivered, and custom filterers which do not override
-//! `check_dir` accept every directory by default.
+//! Watched paths are themselves never filtered.
 //!
-//! Native `FSEvents` and Kqueue deliberately retain Notify-owned recursion in this release. Watchexec
-//! does not call `check_dir`, physically prune ignored directories, or install its managed
-//! missing-root guards for those backend kinds. Per-directory changes would repeatedly rebuild
-//! Notify's shared `FSEvents` stream at its since-now history boundary, while Kqueue needs Notify's
-//! internal per-entry recursion to observe changes below a directory. Notify's `FSEvents` callback
-//! limits delivered paths, but the underlying `FSEvents` stream may still observe a broader part of
-//! the filesystem internally. Select [`Watcher::Poll`] when physical source pruning is required on
-//! those platforms.
+//! Watch and scan failures are reported while traversal continues with independent paths,
+//! rebuilding the watcher from known registrations when a failed operation may have changed backend
+//! state.
 //!
-//! # Reconciliation and failures
-//!
-//! Changes to roots, watcher selection, symlink policy, or the live [`Config::filterer`] are
-//! reconciled on managed backends. [`Config::fs_ready`] reports when the current reconciliation has
-//! settled; it can report readiness after nonfatal path-local failures, so applications should also
-//! observe their [`ErrorHook`](crate::ErrorHook). Replacing a filterer does not automatically reread
-//! or rediscover ignore files.
-//!
-//! Managed traversal honours [`Config::follow_symlinks`] and watches a safe existing ancestor of a
-//! missing root so that the root can be picked up if it appears later. Non-resource scan and watch
-//! failures are reported as runtime errors while traversal continues with independent sibling
-//! paths. Resource exhaustion is classified as too many watches or handles, reported once for the
-//! reconciliation, and stops further additions during that pass.
-//!
-//! Polling has per-directory cost because every accepted directory is registered separately.
-//! Traversal yields between directories, but each individual directory is read synchronously; one
-//! exceptionally large or slow directory can therefore delay filesystem-worker progress.
+//! Filtered recursive traversal is not supported on FSEvents, because changing individual watches
+//! recreates Notify's shared stream from `SinceNow` and can lose intervening events, or Kqueue,
+//! because Notify recursively registers descendants even for non-recursive watches. On these
+//! backends, recursive watches traverse the entire directory tree; Watchexec delegates recursive
+//! traversal to [`notify`].
 
 mod backend;
 mod recursor;
@@ -83,9 +58,6 @@ pub use crate::WatchedPath;
 
 /// What kind of filesystem watcher to use.
 ///
-/// The actual Notify backend kind determines whether Watchexec owns recursion and applies physical
-/// source pruning. See this module's documentation for backend behaviour and costs.
-///
 /// For now only native and poll watchers are supported. In the future there may be additional
 /// watchers available on some platforms.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -94,16 +66,11 @@ pub enum Watcher {
 	/// The Notify-recommended watcher on the platform.
 	///
 	/// For platforms Notify supports, that's a [native implementation][notify::RecommendedWatcher];
-	/// for others it is polling with a default interval. Watchexec's recursion strategy follows the
-	/// actual backend kind, so a native fallback to Poll receives managed source filtering while
-	/// native `FSEvents` and Kqueue retain Notify-owned recursion.
+	/// for others it's polling with a default interval.
 	#[default]
 	Native,
 
 	/// Notify’s [poll watcher][notify::PollWatcher] with a custom interval.
-	///
-	/// Poll always uses Watchexec-owned per-directory recursion. This enables physical source pruning
-	/// on every platform, at a polling cost which scales with the number of accepted directories.
 	Poll(Duration),
 }
 

--- a/crates/lib/src/sources/fs.rs
+++ b/crates/lib/src/sources/fs.rs
@@ -65,7 +65,7 @@ pub use crate::WatchedPath;
 pub enum Watcher {
 	/// The Notify-recommended watcher on the platform.
 	///
-	/// For platforms Notify supports, that's a [native implementation][notify::RecommendedWatcher];
+	/// For platforms Notify supports, that's a [native implementation][notify::RecommendedWatcher],
 	/// for others it's polling with a default interval.
 	#[default]
 	Native,

--- a/crates/lib/src/sources/fs/backend.rs
+++ b/crates/lib/src/sources/fs/backend.rs
@@ -1,0 +1,141 @@
+use std::path::Path;
+
+use notify::{RecursiveMode, Watcher as _};
+
+use crate::error::FsWatcherError;
+
+use super::Watcher;
+
+/// The backend seam used by the recursor. Managed recursion must only pass
+/// `NonRecursive` to this interface.
+pub(super) trait Backend: Send {
+	fn watch(&mut self, path: &Path, mode: RecursiveMode) -> notify::Result<()>;
+	fn unwatch(&mut self, path: &Path) -> notify::Result<()>;
+}
+
+/// Temporary backend used only while the worker synchronously recreates a
+/// failed watcher. No recursor step is run while this is installed.
+pub(super) struct DisconnectedBackend;
+
+impl Backend for DisconnectedBackend {
+	fn watch(&mut self, _path: &Path, _mode: RecursiveMode) -> notify::Result<()> {
+		Err(notify::Error::generic("filesystem backend is disconnected"))
+	}
+
+	fn unwatch(&mut self, _path: &Path) -> notify::Result<()> {
+		Err(notify::Error::generic("filesystem backend is disconnected"))
+	}
+}
+
+impl<T> Backend for T
+where
+	T: notify::Watcher + Send,
+{
+	fn watch(&mut self, path: &Path, mode: RecursiveMode) -> notify::Result<()> {
+		notify::Watcher::watch(self, path, mode)
+	}
+
+	fn unwatch(&mut self, path: &Path) -> notify::Result<()> {
+		notify::Watcher::unwatch(self, path)
+	}
+}
+
+pub(super) fn create_notify(
+	kind: Watcher,
+	follow_symlinks: bool,
+	handler: impl notify::EventHandler,
+) -> notify::Result<Box<dyn Backend>> {
+	use notify::Config;
+
+	let config = Config::default().with_follow_symlinks(follow_symlinks);
+	match kind {
+		Watcher::Native => notify::RecommendedWatcher::new(handler, config)
+			.map(|watcher| Box::new(watcher) as Box<dyn Backend>),
+		Watcher::Poll(delay) => notify::PollWatcher::new(handler, config.with_poll_interval(delay))
+			.map(|watcher| Box::new(watcher) as Box<dyn Backend>),
+	}
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ResourceError {
+	Watches,
+	Handles,
+}
+
+impl ResourceError {
+	pub(super) const fn into_fs_error(self, error: notify::Error) -> FsWatcherError {
+		match self {
+			Self::Watches => FsWatcherError::TooManyWatches(error),
+			Self::Handles => FsWatcherError::TooManyHandles(error),
+		}
+	}
+}
+
+pub(super) fn classify_resource_error(error: &notify::Error) -> Option<ResourceError> {
+	if matches!(error.kind, notify::ErrorKind::MaxFilesWatch)
+		|| (cfg!(any(target_os = "linux", target_os = "android"))
+			&& matches!(error.kind, notify::ErrorKind::Io(ref error) if error.raw_os_error() == Some(28)))
+	{
+		Some(ResourceError::Watches)
+	} else if (cfg!(unix)
+		&& matches!(error.kind, notify::ErrorKind::Io(ref error) if matches!(error.raw_os_error(), Some(23 | 24))))
+		|| (cfg!(windows)
+			&& matches!(error.kind, notify::ErrorKind::Io(ref error) if error.raw_os_error() == Some(4)))
+	{
+		Some(ResourceError::Handles)
+	} else {
+		None
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#[cfg(any(unix, windows))]
+	use std::io;
+
+	use super::*;
+
+	#[test]
+	fn max_files_watch_is_always_a_resource_error() {
+		let error = notify::Error::new(notify::ErrorKind::MaxFilesWatch);
+		assert_eq!(
+			classify_resource_error(&error),
+			Some(ResourceError::Watches)
+		);
+	}
+
+	#[cfg(any(target_os = "linux", target_os = "android"))]
+	#[test]
+	fn linux_enospc_is_too_many_watches() {
+		let watches = notify::Error::io(io::Error::from_raw_os_error(28));
+		assert_eq!(
+			classify_resource_error(&watches),
+			Some(ResourceError::Watches)
+		);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn unix_handle_errno_values_are_classified() {
+		let process_handles = notify::Error::io(io::Error::from_raw_os_error(24));
+		let system_handles = notify::Error::io(io::Error::from_raw_os_error(23));
+		assert_eq!(
+			classify_resource_error(&process_handles),
+			Some(ResourceError::Handles)
+		);
+		assert_eq!(
+			classify_resource_error(&system_handles),
+			Some(ResourceError::Handles)
+		);
+	}
+
+	#[cfg(windows)]
+	#[test]
+	fn windows_error_four_is_too_many_handles() {
+		let error = notify::Error::io(io::Error::from_raw_os_error(4));
+		assert_eq!(
+			classify_resource_error(&error),
+			Some(ResourceError::Handles)
+		);
+	}
+}

--- a/crates/lib/src/sources/fs/recursor.rs
+++ b/crates/lib/src/sources/fs/recursor.rs
@@ -1,0 +1,3883 @@
+use std::{
+	cmp::Reverse,
+	collections::{HashMap, HashSet, VecDeque},
+	fs, io,
+	path::{Path, PathBuf},
+	sync::Arc,
+};
+
+use normalize_path::NormalizePath;
+use notify::RecursiveMode;
+
+use crate::{
+	error::{FsWatcherError, RuntimeError},
+	filter::Filterer,
+	WatchedPath,
+};
+
+use super::{
+	backend::{classify_resource_error, Backend, DisconnectedBackend},
+	managed_backend, notify_multi_path_errors, Watcher,
+};
+
+/// One-path-at-a-time filesystem seam. In particular, `scan` reads only one
+/// directory; the recursor owns the breadth-first work queue.
+pub(super) trait Scanner: Send {
+	fn classify(&self, path: &Path, follow_symlinks: bool) -> io::Result<EntryKind>;
+	fn scan(&self, path: &Path, visit: &mut dyn FnMut(io::Result<PathBuf>)) -> io::Result<()>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum EntryKind {
+	Directory(PathBuf),
+	NonFollowedSymlink,
+	Other,
+}
+
+pub(super) struct FsScanner;
+
+impl Scanner for FsScanner {
+	fn classify(&self, path: &Path, follow_symlinks: bool) -> io::Result<EntryKind> {
+		let link_metadata = fs::symlink_metadata(path)?;
+		if link_metadata.file_type().is_symlink() && !follow_symlinks {
+			return Ok(EntryKind::NonFollowedSymlink);
+		}
+
+		let metadata = if link_metadata.file_type().is_symlink() {
+			fs::metadata(path)?
+		} else {
+			link_metadata
+		};
+
+		if metadata.is_dir() {
+			Ok(EntryKind::Directory(fs::canonicalize(path)?))
+		} else {
+			Ok(EntryKind::Other)
+		}
+	}
+
+	fn scan(&self, path: &Path, visit: &mut dyn FnMut(io::Result<PathBuf>)) -> io::Result<()> {
+		for entry in fs::read_dir(path)? {
+			visit(entry.map(|entry| entry.path()));
+		}
+		Ok(())
+	}
+}
+
+type Root = WatchedPath;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum Identity {
+	Canonical(PathBuf),
+	Lexical(PathBuf),
+}
+
+#[derive(Debug)]
+struct LogicalWatch {
+	identity: Identity,
+	owners: HashMap<Root, u64>,
+}
+
+#[derive(Debug)]
+struct PhysicalWatch {
+	watch_path: PathBuf,
+	logicals: HashSet<PathBuf>,
+	guards: HashSet<PathBuf>,
+	mode: RecursiveMode,
+}
+
+#[derive(Debug)]
+struct ReplayWatch {
+	watch_path: PathBuf,
+	mode: RecursiveMode,
+	logicals: Vec<(PathBuf, LogicalWatch)>,
+}
+
+#[derive(Debug)]
+struct GuardWatch {
+	identity: Identity,
+	owners: HashSet<Root>,
+}
+
+#[derive(Debug)]
+enum Work {
+	Guard(Root),
+	Root(Root),
+	Candidate {
+		root: Root,
+		path: PathBuf,
+		transient_retries: u8,
+	},
+	Scan {
+		root: Root,
+		path: PathBuf,
+		transient_retries: u8,
+	},
+	Probe(PathBuf),
+}
+
+impl Work {
+	fn path(&self) -> &Path {
+		match self {
+			Self::Guard(root) => root.path.parent().unwrap_or(&root.path),
+			Self::Root(root) => &root.path,
+			Self::Candidate { path, .. } | Self::Scan { path, .. } | Self::Probe(path) => path,
+		}
+	}
+}
+
+#[derive(Debug)]
+struct SweepEntry {
+	path: PathBuf,
+	root: Root,
+	epoch: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Phase {
+	Traversing,
+	Sweeping,
+	Settled,
+}
+
+#[derive(Default)]
+pub(super) struct StepResult {
+	pub(super) errors: Vec<RuntimeError>,
+	pub(super) rebuild_backend: bool,
+}
+
+const TRANSIENT_RETRIES: u8 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AddResult {
+	Added,
+	Skipped,
+	Invalidated,
+	Rebuild,
+}
+
+enum ExplicitRootState {
+	Entry(EntryKind),
+	Missing { path: PathBuf, error: io::Error },
+	Unsafe,
+}
+
+const fn path_not_found(error: &notify::Error) -> bool {
+	matches!(error.kind, notify::ErrorKind::PathNotFound)
+}
+
+fn mode_satisfies(actual: RecursiveMode, requested: RecursiveMode) -> bool {
+	actual == requested
+		|| matches!(
+			(actual, requested),
+			(RecursiveMode::Recursive, RecursiveMode::NonRecursive)
+		)
+}
+
+/// Watchexec-owned recursive registration state.
+///
+/// Logical paths retain per-root ownership while physical registrations are
+/// shared by canonical identity. All backend mutations happen from `step`.
+pub(super) struct Recursor {
+	backend: Box<dyn Backend>,
+	scanner: Box<dyn Scanner>,
+	kind: Watcher,
+	backend_kind: notify::WatcherKind,
+	follow_symlinks: bool,
+	cwd: PathBuf,
+	filter: Arc<dyn Filterer>,
+	roots: HashSet<Root>,
+	epoch: u64,
+	logical: HashMap<PathBuf, LogicalWatch>,
+	physical: HashMap<Identity, PhysicalWatch>,
+	replay_desired: HashMap<Identity, ReplayWatch>,
+	replay_queue: VecDeque<Identity>,
+	rebuild_exclusions: HashSet<PathBuf>,
+	guards: HashMap<PathBuf, GuardWatch>,
+	root_guards: HashMap<Root, PathBuf>,
+	seen: HashMap<Root, HashSet<Identity>>,
+	work: VecDeque<Work>,
+	pending_removals: VecDeque<PathBuf>,
+	pending_removal_set: HashSet<PathBuf>,
+	pending_owner_removals: VecDeque<(PathBuf, Root)>,
+	sweep: VecDeque<SweepEntry>,
+	phase: Phase,
+	rebuild_requested: bool,
+	resource_latched: bool,
+	resource_reported: bool,
+	skipped_additions: HashSet<PathBuf>,
+	addition_failures: HashMap<PathBuf, u8>,
+	retry_candidates: HashSet<(Root, PathBuf)>,
+	retry_roots: HashSet<Root>,
+	removed_prefixes: HashSet<PathBuf>,
+	refresh_tombstones: bool,
+}
+
+impl Recursor {
+	pub(super) fn new(
+		backend: Box<dyn Backend>,
+		scanner: Box<dyn Scanner>,
+		kind: Watcher,
+		backend_kind: notify::WatcherKind,
+		follow_symlinks: bool,
+		cwd: PathBuf,
+		filter: Arc<dyn Filterer>,
+	) -> Self {
+		Self {
+			backend,
+			scanner,
+			kind,
+			backend_kind,
+			follow_symlinks,
+			cwd,
+			filter,
+			roots: HashSet::new(),
+			epoch: 0,
+			logical: HashMap::new(),
+			physical: HashMap::new(),
+			replay_desired: HashMap::new(),
+			replay_queue: VecDeque::new(),
+			rebuild_exclusions: HashSet::new(),
+			guards: HashMap::new(),
+			root_guards: HashMap::new(),
+			seen: HashMap::new(),
+			work: VecDeque::new(),
+			pending_removals: VecDeque::new(),
+			pending_removal_set: HashSet::new(),
+			pending_owner_removals: VecDeque::new(),
+			sweep: VecDeque::new(),
+			phase: Phase::Settled,
+			rebuild_requested: false,
+			resource_latched: false,
+			resource_reported: false,
+			skipped_additions: HashSet::new(),
+			addition_failures: HashMap::new(),
+			retry_candidates: HashSet::new(),
+			retry_roots: HashSet::new(),
+			removed_prefixes: HashSet::new(),
+			refresh_tombstones: false,
+		}
+	}
+
+	pub(super) const fn is_managed(&self) -> bool {
+		managed_backend(self.backend_kind)
+	}
+
+	pub(super) fn needs_retry(&self) -> bool {
+		!self.retry_roots.is_empty()
+			|| !self.retry_candidates.is_empty()
+			|| !self.replay_desired.is_empty()
+			|| self.resource_latched
+	}
+
+	pub(super) fn event_is_public(&self, event: &notify::Event) -> bool {
+		event.paths.is_empty()
+			|| event.paths.iter().any(|path| {
+				let path = self.absolute(path);
+				self.roots.iter().any(|root| {
+					path == root.path
+						|| (root.recursive && path.starts_with(&root.path))
+						|| (!root.recursive && path.parent() == Some(root.path.as_path()))
+				})
+			})
+	}
+
+	pub(super) fn has_work(&self) -> bool {
+		self.rebuild_requested
+			|| !self.replay_queue.is_empty()
+			|| !self.pending_removals.is_empty()
+			|| !self.pending_owner_removals.is_empty()
+			|| !self.work.is_empty()
+			|| !self.sweep.is_empty()
+			|| self.phase != Phase::Settled
+	}
+
+	pub(super) fn reconcile(&mut self, pathset: &[WatchedPath], filter: Arc<dyn Filterer>) {
+		self.filter = filter;
+		self.roots = pathset
+			.iter()
+			.map(|path| Root {
+				path: self.absolute(path.path.as_ref()),
+				recursive: path.recursive,
+			})
+			.collect();
+		self.begin_epoch();
+	}
+
+	pub(super) fn rescan(&mut self) {
+		self.begin_epoch();
+		if self.is_managed() {
+			self.rebuild_requested = true;
+		}
+	}
+
+	pub(super) fn prepare_backend_rebuild(&mut self) {
+		// Preserve every registration which was known-good before the uncertain
+		// mutation. Replay is performed directly on the fresh backend before a
+		// scanner failure can affect that coverage.
+		let mut desired = std::mem::take(&mut self.replay_desired);
+		let mut logical = std::mem::take(&mut self.logical);
+		for (identity, physical) in &self.physical {
+			let mut logicals: Vec<_> = physical
+				.logicals
+				.iter()
+				.filter(|path| !self.rebuild_exclusions.contains(*path))
+				.filter(|path| {
+					!self
+						.removed_prefixes
+						.iter()
+						.any(|prefix| path.starts_with(prefix))
+				})
+				.filter_map(|path| logical.remove(path).map(|watch| (path.clone(), watch)))
+				.collect();
+			if logicals.is_empty() {
+				continue;
+			}
+			logicals.sort_by(|(left, _), (right, _)| left.cmp(right));
+			let watch_path = if logicals
+				.iter()
+				.any(|(path, _)| path == &physical.watch_path)
+			{
+				physical.watch_path.clone()
+			} else {
+				logicals[0].0.clone()
+			};
+			desired.insert(
+				identity.clone(),
+				ReplayWatch {
+					watch_path,
+					mode: physical.mode,
+					logicals,
+				},
+			);
+		}
+		self.rebuild_exclusions.clear();
+
+		// Drop the uncertain watcher before trying to create its replacement. This
+		// also releases inotify handles/watches which may be the scarce resource.
+		self.backend = Box::new(DisconnectedBackend);
+		self.physical.clear();
+		self.sweep.clear();
+		self.resource_latched = false;
+		self.replay_desired = desired;
+		self.replay_queue.clear();
+		self.requeue_replay();
+		self.restart_epoch_work();
+	}
+
+	pub(super) fn install_backend(&mut self, backend: Box<dyn Backend>) {
+		self.backend = backend;
+	}
+
+	pub(super) fn replay_count(&self) -> usize {
+		self.replay_desired
+			.len()
+			.saturating_add(self.physical.len())
+			.saturating_add(self.guards.len())
+	}
+
+	pub(super) fn defer_replay(&mut self) {
+		self.replay_queue.clear();
+	}
+
+	pub(super) fn replay_backend_snapshot(&mut self) -> StepResult {
+		let mut combined = StepResult::default();
+		let budget = self.replay_queue.len();
+		for _ in 0..budget {
+			let Some(identity) = self.replay_queue.pop_front() else {
+				break;
+			};
+			let mut step = StepResult::default();
+			self.step_replay(identity, &mut step);
+			combined.errors.append(&mut step.errors);
+			combined.rebuild_backend |= step.rebuild_backend;
+			if combined.rebuild_backend || self.resource_latched {
+				return combined;
+			}
+		}
+
+		let guard_roots: Vec<_> = self.root_guards.keys().cloned().collect();
+		for root in guard_roots {
+			let mut step = StepResult::default();
+			self.ensure_guard(root, &mut step);
+			combined.errors.append(&mut step.errors);
+			combined.rebuild_backend |= step.rebuild_backend;
+			if combined.rebuild_backend || self.resource_latched {
+				break;
+			}
+		}
+		combined
+	}
+
+	#[cfg(test)]
+	fn replace_backend(&mut self, backend: Box<dyn Backend>) {
+		self.prepare_backend_rebuild();
+		self.install_backend(backend);
+	}
+
+	pub(super) fn topology_create(&mut self, path: PathBuf) {
+		if !self.is_managed() {
+			return;
+		}
+		let path = self.absolute(&path);
+		for path in self.projected_topology_paths(&path) {
+			self.topology_create_one(path);
+		}
+	}
+
+	fn topology_create_one(&mut self, path: PathBuf) {
+		self.topology_create_one_with_removal(path, true);
+	}
+
+	fn topology_create_one_with_removal(&mut self, path: PathBuf, queue_removal: bool) {
+		self.clear_authoritative_prefix(&path);
+		let mut roots = self.candidate_roots(&path, false);
+		if queue_removal {
+			self.queue_remove_prefix(&path);
+		}
+		self.requeue_guarded_roots_below(&path);
+		self.requeue_configured_roots_below(&path);
+		for root in roots.drain() {
+			self.seen.remove(&root);
+			self.retry_candidates.insert((root.clone(), path.clone()));
+			self.work.push_front(Work::Candidate {
+				root,
+				path: path.clone(),
+				transient_retries: TRANSIENT_RETRIES,
+			});
+		}
+	}
+
+	pub(super) fn topology_remove(&mut self, path: PathBuf) {
+		if !self.is_managed() {
+			return;
+		}
+		let path = self.absolute(&path);
+		for path in self.projected_topology_paths(&path) {
+			self.topology_remove_one(path);
+		}
+	}
+
+	fn topology_remove_one(&mut self, path: PathBuf) {
+		self.refresh_tombstones = false;
+		self.removed_prefixes.insert(path.clone());
+		let mut affected: HashSet<_> = self
+			.root_guards
+			.iter()
+			.filter(|(root, guard)| root.path.starts_with(&path) || guard.starts_with(&path))
+			.map(|(root, _)| root.clone())
+			.collect();
+		affected.extend(
+			self.roots
+				.iter()
+				.filter(|root| root.path.starts_with(&path))
+				.cloned(),
+		);
+		self.queue_remove_prefix(&path);
+		for root in affected {
+			self.work.push_back(Work::Guard(root));
+		}
+	}
+
+	pub(super) fn topology_rename(&mut self, from: PathBuf, to: PathBuf) {
+		if !self.is_managed() {
+			return;
+		}
+		let from = self.absolute(&from);
+		let to = self.absolute(&to);
+		let from = self.projected_topology_paths(&from);
+		let to = self.projected_topology_paths(&to);
+		for path in from {
+			self.topology_remove_one(path);
+		}
+		for path in &to {
+			self.topology_remove_one(path.clone());
+		}
+		for path in to {
+			self.topology_create_one_with_removal(path, false);
+		}
+	}
+
+	pub(super) fn topology_ambiguous(&mut self, path: PathBuf) {
+		if !self.is_managed() {
+			return;
+		}
+		let path = self.absolute(&path);
+		for path in self.projected_topology_paths(&path) {
+			self.topology_ambiguous_one(path);
+		}
+	}
+
+	fn topology_ambiguous_one(&mut self, path: PathBuf) {
+		self.clear_authoritative_prefix(&path);
+		self.queue_remove_prefix(&path);
+		self.work.push_back(Work::Probe(path.clone()));
+		self.requeue_guarded_roots_below(&path);
+		self.requeue_configured_roots_below(&path);
+	}
+
+	fn projected_topology_paths(&self, path: &Path) -> Vec<PathBuf> {
+		let mut projected = HashSet::from([path.to_owned()]);
+		let Some(parent) = path.parent() else {
+			return projected.into_iter().collect();
+		};
+		let Some(name) = path.file_name() else {
+			return projected.into_iter().collect();
+		};
+		let identities: HashSet<_> = self
+			.logical
+			.get(parent)
+			.map(|watch| &watch.identity)
+			.into_iter()
+			.chain(self.guards.get(parent).map(|watch| &watch.identity))
+			.cloned()
+			.collect();
+		for identity in identities {
+			let Some(physical) = self
+				.physical
+				.get(&identity)
+				.filter(|physical| physical.watch_path == parent)
+			else {
+				continue;
+			};
+			for alias in physical.logicals.iter().chain(&physical.guards) {
+				projected.insert(alias.join(name));
+			}
+		}
+		let mut projected: Vec<_> = projected.into_iter().collect();
+		projected.sort();
+		projected
+	}
+
+	fn clear_authoritative_prefix(&mut self, path: &Path) {
+		self.removed_prefixes
+			.retain(|prefix| !prefix.starts_with(path) && !path.starts_with(prefix));
+		self.skipped_additions
+			.retain(|candidate| !candidate.starts_with(path));
+		self.addition_failures
+			.retain(|candidate, _| !candidate.starts_with(path));
+	}
+
+	fn requeue_guarded_roots_below(&mut self, path: &Path) {
+		let guarded: Vec<_> = self
+			.root_guards
+			.keys()
+			.filter(|root| root.path.starts_with(path))
+			.cloned()
+			.collect();
+		for root in guarded {
+			// Run before a probe can prune queued work below the newly-created
+			// ancestor. This moves the guard down one or more levels immediately.
+			self.work.push_front(Work::Guard(root));
+		}
+	}
+
+	fn requeue_configured_roots_below(&mut self, path: &Path) {
+		let roots: Vec<_> = self
+			.roots
+			.iter()
+			.filter(|root| root.path.starts_with(path))
+			.cloned()
+			.collect();
+		for root in roots {
+			self.seen.remove(&root);
+			let already_queued = self.work.iter().any(
+				|work| matches!(work, Work::Root(queued) | Work::Guard(queued) if queued == &root),
+			);
+			if !already_queued {
+				self.work.push_back(Work::Root(root));
+			}
+		}
+	}
+
+	pub(super) fn step(&mut self) -> StepResult {
+		let mut result = StepResult::default();
+
+		if self.rebuild_requested {
+			self.rebuild_requested = false;
+			result.rebuild_backend = true;
+			return result;
+		}
+
+		if let Some(identity) = self.replay_queue.pop_front() {
+			self.step_replay(identity, &mut result);
+			return result;
+		}
+
+		if let Some(path) = self.pending_removals.pop_front() {
+			self.pending_removal_set.remove(&path);
+			self.remove_logical(&path, &mut result);
+			return result;
+		}
+
+		if let Some((path, root)) = self.pending_owner_removals.pop_front() {
+			let entry = SweepEntry {
+				path,
+				root,
+				epoch: self.epoch,
+			};
+			self.remove_owner_force(entry, &mut result);
+			return result;
+		}
+
+		if self.refresh_tombstones {
+			self.removed_prefixes.clear();
+			self.refresh_tombstones = false;
+		}
+
+		if let Some(work) = self.work.pop_front() {
+			self.step_work(work, &mut result);
+			return result;
+		}
+
+		match self.phase {
+			Phase::Traversing => {
+				self.prepare_sweep();
+				if self.sweep.is_empty() {
+					self.settle();
+				}
+			}
+			Phase::Sweeping => {
+				if let Some(entry) = self.sweep.pop_front() {
+					self.remove_owner(entry, &mut result);
+				} else {
+					self.settle();
+				}
+			}
+			Phase::Settled => {}
+		}
+
+		result
+	}
+
+	fn begin_epoch(&mut self) {
+		self.epoch = self
+			.epoch
+			.checked_add(1)
+			.expect("filesystem recursion epoch overflow");
+		self.resource_latched = false;
+		self.resource_reported = false;
+		self.skipped_additions.clear();
+		self.addition_failures.clear();
+		self.rebuild_exclusions.clear();
+		self.refresh_tombstones = true;
+		self.restart_epoch_work();
+	}
+
+	fn restart_epoch_work(&mut self) {
+		self.work.clear();
+		self.seen.clear();
+		self.sweep.clear();
+		self.phase = Phase::Traversing;
+		self.retry_roots.retain(|root| self.roots.contains(root));
+		self.retry_candidates
+			.retain(|(root, _)| self.roots.contains(root));
+		self.requeue_replay();
+		let mut roots: Vec<_> = self.roots.iter().cloned().collect();
+		roots.sort_by(|left, right| {
+			left.path
+				.cmp(&right.path)
+				.then_with(|| right.recursive.cmp(&left.recursive))
+		});
+		if self.is_managed() {
+			let mut guarded: Vec<_> = self.root_guards.keys().cloned().collect();
+			guarded.sort_by(|left, right| left.path.cmp(&right.path));
+			self.work.extend(guarded.into_iter().map(Work::Guard));
+			self.work.extend(
+				self.retry_candidates
+					.iter()
+					.filter(|(root, _)| self.roots.contains(root))
+					.cloned()
+					.map(|(root, path)| Work::Candidate {
+						root,
+						path,
+						transient_retries: TRANSIENT_RETRIES,
+					}),
+			);
+		}
+		self.work.extend(
+			self.retry_roots
+				.iter()
+				.filter(|root| self.roots.contains(*root))
+				.cloned()
+				.map(Work::Root),
+		);
+		self.work.extend(roots.into_iter().map(Work::Root));
+	}
+
+	fn requeue_replay(&mut self) {
+		let queued: HashSet<_> = self.replay_queue.iter().cloned().collect();
+		let mut replay: Vec<_> = self
+			.replay_desired
+			.iter()
+			.filter(|(identity, _)| !queued.contains(*identity))
+			.map(|(identity, watch)| (watch.watch_path.clone(), identity.clone()))
+			.collect();
+		replay.sort_by(|(left, _), (right, _)| left.cmp(right));
+		self.replay_queue
+			.extend(replay.into_iter().map(|(_, identity)| identity));
+	}
+
+	fn schedule_retries(&mut self) {
+		self.resource_latched = false;
+		self.requeue_replay();
+
+		let mut roots: Vec<_> = self
+			.retry_roots
+			.iter()
+			.filter(|root| self.roots.contains(*root))
+			.cloned()
+			.collect();
+		roots.sort_by(|left, right| left.path.cmp(&right.path));
+		self.work.extend(roots.into_iter().map(Work::Root));
+
+		let mut candidates: Vec<_> = self
+			.retry_candidates
+			.iter()
+			.filter(|(root, _)| self.roots.contains(root))
+			.cloned()
+			.collect();
+		candidates.sort_by(|(_, left), (_, right)| left.cmp(right));
+		self.work
+			.extend(candidates.into_iter().map(|(root, path)| Work::Candidate {
+				root,
+				path,
+				transient_retries: TRANSIENT_RETRIES,
+			}));
+	}
+
+	fn step_replay(&mut self, identity: Identity, result: &mut StepResult) {
+		if self.resource_latched {
+			self.replay_queue.clear();
+			return;
+		}
+		let Some(mut replay) = self.replay_desired.remove(&identity) else {
+			return;
+		};
+
+		loop {
+			if self.skipped_additions.contains(&replay.watch_path) {
+				if let Some((path, _)) = replay
+					.logicals
+					.iter()
+					.find(|(path, _)| !self.skipped_additions.contains(path))
+				{
+					replay.watch_path.clone_from(path);
+				} else {
+					return;
+				}
+			}
+
+			let attempted = replay.watch_path.clone();
+			match self.backend.watch(&attempted, replay.mode) {
+				Ok(()) => {
+					if !self.verify_poll_registration(&attempted, &identity, result) {
+						return;
+					}
+					self.addition_failures.remove(&attempted);
+					let logicals = replay
+						.logicals
+						.iter()
+						.map(|(path, _)| path.clone())
+						.collect();
+					self.physical.insert(
+						identity.clone(),
+						PhysicalWatch {
+							watch_path: attempted,
+							logicals,
+							guards: HashSet::new(),
+							mode: replay.mode,
+						},
+					);
+					for (path, watch) in replay.logicals {
+						self.logical.insert(path, watch);
+					}
+					return;
+				}
+				Err(error) => {
+					if path_not_found(&error) {
+						result.errors.extend(notify_multi_path_errors(
+							self.kind,
+							WatchedPath::non_recursive(attempted.clone()),
+							error,
+							false,
+						));
+						self.addition_failures.remove(&attempted);
+						self.skipped_additions.remove(&attempted);
+						if let Some(path) = self.retain_valid_replay_aliases(
+							&mut replay,
+							&identity,
+							&attempted,
+							result,
+						) {
+							replay.watch_path = path;
+							continue;
+						}
+					} else if let Some(resource) = classify_resource_error(&error) {
+						self.resource_latched = true;
+						self.replay_queue.clear();
+						if !self.resource_reported {
+							self.resource_reported = true;
+							let error = resource.into_fs_error(error);
+							result.errors.push(RuntimeError::FsWatcher {
+								kind: self.kind,
+								err: error,
+							});
+						}
+						self.replay_desired.insert(identity, replay);
+					} else {
+						let failures = self.addition_failures.entry(attempted.clone()).or_default();
+						*failures = failures.saturating_add(1);
+						result.errors.extend(notify_multi_path_errors(
+							self.kind,
+							WatchedPath::non_recursive(attempted.clone()),
+							error,
+							false,
+						));
+						if *failures >= 2 {
+							self.skipped_additions.insert(attempted);
+						} else {
+							self.replay_desired.insert(identity, replay);
+							result.rebuild_backend = true;
+						}
+					}
+					return;
+				}
+			}
+		}
+	}
+
+	fn retain_valid_replay_aliases(
+		&self,
+		replay: &mut ReplayWatch,
+		identity: &Identity,
+		failed: &Path,
+		result: &mut StepResult,
+	) -> Option<PathBuf> {
+		let mut representative = None;
+		replay.logicals.retain(|(path, _)| {
+			if path == failed
+				|| self.skipped_additions.contains(path)
+				|| self
+					.removed_prefixes
+					.iter()
+					.any(|prefix| path.starts_with(prefix))
+			{
+				return false;
+			}
+
+			let valid = match self.scanner.classify(path, self.follow_symlinks) {
+				Ok(EntryKind::Directory(canonical)) => identity == &Identity::Canonical(canonical),
+				Ok(EntryKind::Other) => identity == &Identity::Lexical(path.clone()),
+				Ok(EntryKind::NonFollowedSymlink) => false,
+				Err(error) => {
+					result.errors.push(self.scan_error(path.clone(), error));
+					false
+				}
+			};
+			if valid && representative.is_none() {
+				representative = Some(path.clone());
+			}
+			valid
+		});
+		representative
+	}
+
+	fn step_work(&mut self, work: Work, result: &mut StepResult) {
+		match work {
+			Work::Guard(root) => self.step_guard(root, result),
+			Work::Root(root) => self.step_root(root, result),
+			Work::Candidate {
+				root,
+				path,
+				transient_retries,
+			} => self.step_candidate(root, path, transient_retries, result),
+			Work::Scan {
+				root,
+				path,
+				transient_retries,
+			} => self.step_scan(root, path, transient_retries, result),
+			Work::Probe(path) => self.step_probe(path, result),
+		}
+	}
+
+	fn classify_explicit_root(
+		&self,
+		path: &Path,
+	) -> Result<ExplicitRootState, (PathBuf, io::Error)> {
+		if self.follow_symlinks {
+			return match self.scanner.classify(path, true) {
+				Ok(entry) => Ok(ExplicitRootState::Entry(entry)),
+				Err(error) if error.kind() == io::ErrorKind::NotFound => {
+					Ok(ExplicitRootState::Missing {
+						path: path.to_owned(),
+						error,
+					})
+				}
+				Err(error) => Err((path.to_owned(), error)),
+			};
+		}
+
+		let mut prefixes: Vec<_> = path
+			.ancestors()
+			.filter(|prefix| !prefix.as_os_str().is_empty())
+			.map(Path::to_owned)
+			.collect();
+		prefixes.reverse();
+		for prefix in prefixes {
+			let is_root = prefix == path;
+			match self.scanner.classify(&prefix, false) {
+				Ok(EntryKind::Directory(identity)) if is_root => {
+					return Ok(ExplicitRootState::Entry(EntryKind::Directory(identity)));
+				}
+				Ok(EntryKind::Directory(_)) => {}
+				Ok(EntryKind::Other) if is_root => {
+					return Ok(ExplicitRootState::Entry(EntryKind::Other));
+				}
+				Ok(EntryKind::Other | EntryKind::NonFollowedSymlink) => {
+					return Ok(ExplicitRootState::Unsafe);
+				}
+				Err(error) if error.kind() == io::ErrorKind::NotFound => {
+					return Ok(ExplicitRootState::Missing {
+						path: prefix,
+						error,
+					});
+				}
+				Err(error) => return Err((prefix, error)),
+			}
+		}
+		Ok(ExplicitRootState::Unsafe)
+	}
+
+	fn recheck_guarded_root(&mut self, root: Root, result: &mut StepResult) {
+		match self.classify_explicit_root(&root.path) {
+			Ok(ExplicitRootState::Entry(_)) => {
+				self.removed_prefixes
+					.retain(|prefix| !root.path.starts_with(prefix));
+				self.skipped_additions.remove(&root.path);
+				self.addition_failures.remove(&root.path);
+				self.work.push_front(Work::Root(root));
+			}
+			Ok(ExplicitRootState::Missing { .. } | ExplicitRootState::Unsafe) => {}
+			Err((path, error)) => {
+				result.errors.push(self.scan_error(path, error));
+				self.retry_roots.insert(root);
+			}
+		}
+	}
+
+	fn step_guard(&mut self, root: Root, result: &mut StepResult) {
+		if !self.is_managed() {
+			return;
+		}
+		if !self.roots.contains(&root) {
+			self.remove_root_guard(&root, result);
+			return;
+		}
+
+		let tombstoned = self
+			.removed_prefixes
+			.iter()
+			.any(|prefix| root.path.starts_with(prefix));
+		if !tombstoned {
+			match self.classify_explicit_root(&root.path) {
+				Ok(ExplicitRootState::Entry(_)) => {
+					self.remove_root_guard(&root, result);
+					self.work.push_front(Work::Root(root));
+					return;
+				}
+				Ok(ExplicitRootState::Missing { .. } | ExplicitRootState::Unsafe) => {}
+				Err((path, error)) => {
+					result.errors.push(self.scan_error(path, error));
+					self.retry_roots.insert(root);
+					return;
+				}
+			}
+		}
+		self.ensure_guard(root, result);
+	}
+
+	fn ensure_guard(&mut self, root: Root, result: &mut StepResult) {
+		let mut found = None;
+		if self.follow_symlinks {
+			let mut ancestor = root.path.parent().map(Path::to_owned);
+			while let Some(path) = ancestor {
+				match self.scanner.classify(&path, true) {
+					Ok(EntryKind::Directory(identity)) => {
+						// Metadata at processing time is authoritative after an atomic
+						// exchange, even if a From/Remove callback tombstoned this guard.
+						let replaced = self.removed_prefixes.remove(&path);
+						found = Some((path, Identity::Canonical(identity), replaced));
+						break;
+					}
+					Ok(EntryKind::NonFollowedSymlink | EntryKind::Other) => {}
+					Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+					Err(error) => {
+						result.errors.push(self.scan_error(path, error));
+						self.retry_roots.insert(root);
+						return;
+					}
+				}
+				ancestor = path.parent().map(Path::to_owned);
+			}
+		} else if let Some(parent) = root.path.parent() {
+			let mut prefixes: Vec<_> = parent
+				.ancestors()
+				.filter(|prefix| !prefix.as_os_str().is_empty())
+				.map(Path::to_owned)
+				.collect();
+			prefixes.reverse();
+			for path in prefixes {
+				match self.scanner.classify(&path, false) {
+					Ok(EntryKind::Directory(identity)) => {
+						let replaced = self.removed_prefixes.remove(&path);
+						found = Some((path, Identity::Canonical(identity), replaced));
+					}
+					Ok(EntryKind::NonFollowedSymlink | EntryKind::Other) => break,
+					Err(error) if error.kind() == io::ErrorKind::NotFound => break,
+					Err(error) => {
+						result.errors.push(self.scan_error(path, error));
+						self.retry_roots.insert(root);
+						return;
+					}
+				}
+			}
+		}
+
+		let Some((path, identity, replaced)) = found else {
+			self.remove_root_guard(&root, result);
+			return;
+		};
+
+		let same_guard = self.root_guards.get(&root) == Some(&path)
+			&& self
+				.guards
+				.get(&path)
+				.map_or(false, |guard| guard.identity == identity);
+		let attached = self
+			.physical
+			.get(&identity)
+			.map_or(false, |physical| physical.guards.contains(&path));
+		if same_guard && attached && !replaced {
+			self.retry_roots.remove(&root);
+			self.recheck_guarded_root(root, result);
+			return;
+		}
+
+		if replaced
+			|| self
+				.guards
+				.get(&path)
+				.map_or(false, |guard| guard.identity != identity)
+		{
+			let old_identity = self.guards.get(&path).map(|guard| guard.identity.clone());
+			if let Some(old_identity) = old_identity {
+				if !self.detach_guard_registration(&path, &old_identity, result) {
+					self.retry_roots.insert(root);
+					return;
+				}
+			}
+		}
+		if self.root_guards.get(&root) != Some(&path) {
+			self.remove_root_guard(&root, result);
+			if result.rebuild_backend {
+				self.retry_roots.insert(root);
+				return;
+			}
+		}
+
+		let shared = if let Some(physical) = self.physical.get_mut(&identity) {
+			physical.guards.insert(path.clone());
+			true
+		} else {
+			false
+		};
+		if !shared {
+			if self.resource_latched || self.skipped_additions.contains(&path) {
+				self.retry_roots.insert(root);
+				return;
+			}
+			match self.backend.watch(&path, RecursiveMode::NonRecursive) {
+				Ok(()) => {
+					if !self.verify_poll_registration(&path, &identity, result) {
+						self.work.push_front(Work::Guard(root));
+						return;
+					}
+					self.addition_failures.remove(&path);
+					self.physical.insert(
+						identity.clone(),
+						PhysicalWatch {
+							watch_path: path.clone(),
+							logicals: HashSet::new(),
+							guards: HashSet::from([path.clone()]),
+							mode: RecursiveMode::NonRecursive,
+						},
+					);
+				}
+				Err(error) => {
+					self.retry_roots.insert(root.clone());
+					if path_not_found(&error) {
+						result.errors.extend(notify_multi_path_errors(
+							self.kind,
+							WatchedPath::non_recursive(path.clone()),
+							error,
+							false,
+						));
+						self.removed_prefixes.insert(path);
+						self.work.push_front(Work::Guard(root));
+					} else if let Some(resource) = classify_resource_error(&error) {
+						self.resource_latched = true;
+						if !self.resource_reported {
+							self.resource_reported = true;
+							let error = resource.into_fs_error(error);
+							result.errors.push(RuntimeError::FsWatcher {
+								kind: self.kind,
+								err: error,
+							});
+						}
+					} else {
+						let failures = self.addition_failures.entry(path.clone()).or_default();
+						*failures = failures.saturating_add(1);
+						result.errors.extend(notify_multi_path_errors(
+							self.kind,
+							WatchedPath::non_recursive(path.clone()),
+							error,
+							false,
+						));
+						if *failures >= 2 {
+							self.skipped_additions.insert(path);
+						} else {
+							result.rebuild_backend = true;
+						}
+					}
+					return;
+				}
+			}
+		}
+		self.guards
+			.entry(path.clone())
+			.and_modify(|guard| {
+				guard.identity = identity.clone();
+				guard.owners.insert(root.clone());
+			})
+			.or_insert_with(|| GuardWatch {
+				identity,
+				owners: HashSet::from([root.clone()]),
+			});
+		self.root_guards.insert(root.clone(), path);
+		self.retry_roots.remove(&root);
+
+		// Close the classify/install exchange race: the root may have appeared
+		// between deciding it needed a guard and installing that guard.
+		self.recheck_guarded_root(root, result);
+	}
+
+	fn detach_guard_registration(
+		&mut self,
+		path: &Path,
+		identity: &Identity,
+		result: &mut StepResult,
+	) -> bool {
+		let Some(physical) = self.physical.get_mut(identity) else {
+			return true;
+		};
+		physical.guards.remove(path);
+		let has_owners = !physical.logicals.is_empty() || !physical.guards.is_empty();
+		if has_owners {
+			if physical.watch_path == path && !physical.logicals.contains(path) {
+				// The removed alias is the backend representative. Replay surviving
+				// aliases on a fresh backend rather than unwatching their shared watch.
+				result.rebuild_backend = true;
+				return false;
+			}
+			return true;
+		}
+
+		let Some(physical) = self.physical.remove(identity) else {
+			return true;
+		};
+		if self.try_unwatch(&physical.watch_path, result) {
+			self.schedule_retries();
+			true
+		} else {
+			false
+		}
+	}
+
+	fn remove_root_guard(&mut self, root: &Root, result: &mut StepResult) {
+		let Some(path) = self.root_guards.remove(root) else {
+			return;
+		};
+		let remove = if let Some(guard) = self.guards.get_mut(&path) {
+			guard.owners.remove(root);
+			guard.owners.is_empty()
+		} else {
+			false
+		};
+		if !remove {
+			return;
+		}
+		let Some(guard) = self.guards.remove(&path) else {
+			return;
+		};
+		self.detach_guard_registration(&path, &guard.identity, result);
+	}
+
+	fn step_root(&mut self, root: Root, result: &mut StepResult) {
+		if !self.roots.contains(&root) || self.skipped_additions.contains(&root.path) {
+			return;
+		}
+
+		if !self.is_managed() {
+			if !self.follow_symlinks {
+				match self.classify_explicit_root(&root.path) {
+					Ok(ExplicitRootState::Entry(_) | ExplicitRootState::Missing { .. }) => {}
+					Ok(ExplicitRootState::Unsafe) => {
+						self.retry_roots.remove(&root);
+						self.queue_remove_prefix(&root.path);
+						return;
+					}
+					Err((path, error)) => {
+						result.errors.push(self.scan_error(path, error));
+						self.retry_roots.insert(root);
+						return;
+					}
+				}
+			}
+			let mode = if root.recursive {
+				RecursiveMode::Recursive
+			} else {
+				RecursiveMode::NonRecursive
+			};
+			match self.add_logical(
+				root.path.clone(),
+				Identity::Lexical(root.path.clone()),
+				root.clone(),
+				mode,
+				result,
+			) {
+				AddResult::Added => {
+					self.retry_roots.remove(&root);
+				}
+				AddResult::Skipped | AddResult::Invalidated | AddResult::Rebuild => {
+					self.retry_roots.insert(root);
+				}
+			}
+			return;
+		}
+
+		let tombstoned = self
+			.removed_prefixes
+			.iter()
+			.any(|prefix| root.path.starts_with(prefix));
+		if tombstoned {
+			self.queue_remove_prefix(&root.path);
+			self.work.push_front(Work::Guard(root));
+			return;
+		}
+
+		let (identity, scan) = match self.classify_explicit_root(&root.path) {
+			Ok(ExplicitRootState::Entry(EntryKind::Directory(identity))) => {
+				(Identity::Canonical(identity), root.recursive)
+			}
+			Ok(ExplicitRootState::Entry(EntryKind::Other)) => {
+				(Identity::Lexical(root.path.clone()), false)
+			}
+			Ok(
+				ExplicitRootState::Entry(EntryKind::NonFollowedSymlink) | ExplicitRootState::Unsafe,
+			) => {
+				self.retry_roots.remove(&root);
+				self.queue_remove_prefix(&root.path);
+				self.work.push_front(Work::Guard(root));
+				return;
+			}
+			Ok(ExplicitRootState::Missing { path, error }) => {
+				result.errors.push(self.scan_error(path, error));
+				self.retry_roots.remove(&root);
+				self.removed_prefixes.insert(root.path.clone());
+				self.queue_remove_prefix(&root.path);
+				self.work.push_front(Work::Guard(root));
+				return;
+			}
+			Err((path, error)) => {
+				result.errors.push(self.scan_error(path, error));
+				self.retry_roots.insert(root.clone());
+				if self.has_source_owner(&root.path, &root) {
+					self.carry_forward(&root, &root.path);
+				}
+				// Classification can fail before the explicit root has any backend
+				// coverage. Install (or retain) the nearest safe ancestor guard. Guard
+				// installation rechecks the root once, providing a bounded transient
+				// retry while leaving later recovery event-driven.
+				self.ensure_guard(root, result);
+				return;
+			}
+		};
+
+		match self.add_logical(
+			root.path.clone(),
+			identity.clone(),
+			root.clone(),
+			RecursiveMode::NonRecursive,
+			result,
+		) {
+			AddResult::Added => {
+				self.retry_roots.remove(&root);
+				self.remove_root_guard(&root, result);
+				if scan && self.mark_seen(&root, identity) {
+					let path = root.path.clone();
+					self.work.push_back(Work::Scan {
+						root,
+						path,
+						transient_retries: TRANSIENT_RETRIES,
+					});
+				}
+			}
+			AddResult::Skipped | AddResult::Rebuild => {
+				self.retry_roots.insert(root);
+			}
+			AddResult::Invalidated => {
+				self.retry_roots.remove(&root);
+				self.removed_prefixes.insert(root.path.clone());
+				self.queue_remove_prefix(&root.path);
+				self.work.push_front(Work::Guard(root));
+			}
+		}
+	}
+
+	fn retry_transient_candidate(&mut self, root: &Root, path: &Path, transient_retries: u8) {
+		self.retry_candidates
+			.remove(&(root.clone(), path.to_owned()));
+		self.carry_forward(root, path);
+		if transient_retries > 0 {
+			self.work.push_back(Work::Candidate {
+				root: root.clone(),
+				path: path.to_owned(),
+				transient_retries: transient_retries - 1,
+			});
+		}
+	}
+
+	fn step_candidate(
+		&mut self,
+		root: Root,
+		path: PathBuf,
+		transient_retries: u8,
+		result: &mut StepResult,
+	) {
+		if !self.roots.contains(&root) || !root.recursive {
+			self.retry_candidates.remove(&(root, path));
+			return;
+		}
+		if self.skipped_additions.contains(&path) {
+			return;
+		}
+
+		if self
+			.removed_prefixes
+			.iter()
+			.any(|prefix| path.starts_with(prefix))
+		{
+			self.retry_candidates.remove(&(root, path));
+			return;
+		}
+		let classification = match self.scanner.classify(&path, self.follow_symlinks) {
+			Ok(classification) => classification,
+			Err(error) if error.kind() == io::ErrorKind::NotFound => {
+				result.errors.push(self.scan_error(path.clone(), error));
+				self.retry_candidates.remove(&(root.clone(), path.clone()));
+				self.queue_remove_owner_prefix(&root, &path);
+				for explicit in self.roots.iter().filter(|item| item.path == path).cloned() {
+					self.work.push_back(Work::Guard(explicit));
+				}
+				return;
+			}
+			Err(error) => {
+				result.errors.push(self.scan_error(path.clone(), error));
+				self.retry_transient_candidate(&root, &path, transient_retries);
+				return;
+			}
+		};
+		let EntryKind::Directory(identity) = classification else {
+			self.retry_candidates.remove(&(root.clone(), path.clone()));
+			self.queue_remove_owner_prefix(&root, &path);
+			return;
+		};
+
+		match self.candidate_allowed(&root, &path) {
+			Ok(true) => {}
+			Ok(false) => {
+				self.retry_candidates.remove(&(root.clone(), path.clone()));
+				self.queue_remove_owner_prefix(&root, &path);
+				return;
+			}
+			Err(error) => {
+				result.errors.push(error);
+				self.retry_transient_candidate(&root, &path, transient_retries);
+				return;
+			}
+		}
+
+		let identity = Identity::Canonical(identity);
+		match self.add_logical(
+			path.clone(),
+			identity.clone(),
+			root.clone(),
+			RecursiveMode::NonRecursive,
+			result,
+		) {
+			AddResult::Added => {
+				self.retry_candidates.remove(&(root.clone(), path.clone()));
+				if self.mark_seen(&root, identity) {
+					self.work.push_back(Work::Scan {
+						root,
+						path,
+						transient_retries: TRANSIENT_RETRIES,
+					});
+				}
+			}
+			AddResult::Skipped | AddResult::Rebuild => {
+				self.retry_candidates.insert((root, path));
+			}
+			AddResult::Invalidated => {
+				self.retry_candidates.remove(&(root.clone(), path.clone()));
+				self.queue_remove_owner_prefix(&root, &path);
+			}
+		}
+	}
+
+	fn retry_transient_scan(&mut self, root: &Root, path: &Path, transient_retries: u8) {
+		self.carry_forward(root, path);
+		if transient_retries > 0 {
+			self.work.push_back(Work::Scan {
+				root: root.clone(),
+				path: path.to_owned(),
+				transient_retries: transient_retries - 1,
+			});
+		}
+	}
+
+	fn step_scan(
+		&mut self,
+		root: Root,
+		path: PathBuf,
+		transient_retries: u8,
+		result: &mut StepResult,
+	) {
+		if !self.roots.contains(&root)
+			|| !self
+				.logical
+				.get(&path)
+				.map_or(false, |watch| watch.owners.contains_key(&root))
+		{
+			return;
+		}
+
+		let mut entry_failed = false;
+		let kind = self.kind;
+		let scan_result = {
+			let scanner = &self.scanner;
+			let cwd = &self.cwd;
+			let work = &mut self.work;
+			let errors = &mut result.errors;
+			scanner.scan(&path, &mut |entry| match entry {
+				Ok(entry_path) => {
+					let entry_path = if entry_path.is_absolute() {
+						entry_path.normalize()
+					} else {
+						cwd.join(entry_path).normalize()
+					};
+					work.push_back(Work::Candidate {
+						root: root.clone(),
+						path: entry_path,
+						transient_retries: TRANSIENT_RETRIES,
+					});
+				}
+				Err(error) => {
+					entry_failed = true;
+					errors.push(RuntimeError::FsWatcher {
+						kind,
+						err: FsWatcherError::PathScan {
+							path: path.clone(),
+							err: error,
+						},
+					});
+				}
+			})
+		};
+
+		match scan_result {
+			Ok(()) => {
+				if entry_failed {
+					self.retry_transient_scan(&root, &path, transient_retries);
+				}
+			}
+			Err(error) if error.kind() == io::ErrorKind::NotFound => {
+				result.errors.push(self.scan_error(path.clone(), error));
+				self.retry_candidates.remove(&(root.clone(), path.clone()));
+				self.queue_remove_owner_prefix(&root, &path);
+				for explicit in self.roots.iter().filter(|item| item.path == path).cloned() {
+					self.work.push_back(Work::Guard(explicit));
+				}
+			}
+			Err(error) => {
+				result.errors.push(self.scan_error(path.clone(), error));
+				self.retry_candidates.remove(&(root.clone(), path.clone()));
+				self.retry_transient_scan(&root, &path, transient_retries);
+			}
+		}
+	}
+
+	fn step_probe(&mut self, path: PathBuf, result: &mut StepResult) {
+		match self.scanner.classify(&path, self.follow_symlinks) {
+			Ok(EntryKind::Directory(_)) => {
+				let roots = self.candidate_roots(&path, true);
+				// Canonical text can stay unchanged across an atomic replacement;
+				// discard the old registration before installing and scanning it.
+				self.queue_remove_prefix(&path);
+				for root in roots {
+					self.seen.remove(&root);
+					self.work.push_back(Work::Candidate {
+						root,
+						path: path.clone(),
+						transient_retries: TRANSIENT_RETRIES,
+					});
+				}
+				self.requeue_configured_roots_below(&path);
+			}
+			Ok(EntryKind::NonFollowedSymlink | EntryKind::Other) => {
+				self.queue_remove_prefix(&path);
+				self.requeue_configured_roots_below(&path);
+			}
+			Err(error) if error.kind() == io::ErrorKind::NotFound => {
+				self.queue_remove_prefix(&path);
+				self.requeue_configured_roots_below(&path);
+			}
+			Err(error) => result.errors.push(self.scan_error(path, error)),
+		}
+	}
+
+	fn candidate_allowed(&self, root: &Root, path: &Path) -> Result<bool, RuntimeError> {
+		let Ok(relative) = path.strip_prefix(&root.path) else {
+			return Ok(false);
+		};
+		let mut candidate = root.path.clone();
+		for component in relative.components() {
+			candidate.push(component);
+			if !self.filter.check_dir(&candidate)? {
+				return Ok(false);
+			}
+		}
+		Ok(true)
+	}
+
+	fn candidate_roots(&self, path: &Path, include_self: bool) -> HashSet<Root> {
+		let mut roots = HashSet::new();
+		let self_path = if include_self { Some(path) } else { None };
+		for owner_path in path.parent().into_iter().chain(self_path) {
+			if let Some(watch) = self.logical.get(owner_path) {
+				roots.extend(
+					watch
+						.owners
+						.iter()
+						.filter(|(root, generation)| {
+							**generation == self.epoch
+								&& root.recursive && self.roots.contains(*root)
+						})
+						.map(|(root, _)| root.clone()),
+				);
+			}
+		}
+		roots
+	}
+
+	fn add_logical(
+		&mut self,
+		path: PathBuf,
+		identity: Identity,
+		root: Root,
+		mode: RecursiveMode,
+		result: &mut StepResult,
+	) -> AddResult {
+		if let Some(watch) = self.logical.get_mut(&path) {
+			let mode_matches = self
+				.physical
+				.get(&watch.identity)
+				.map_or(false, |physical| mode_satisfies(physical.mode, mode));
+			if watch.identity != identity || !mode_matches {
+				self.rebuild_exclusions.insert(path.clone());
+				result.rebuild_backend = true;
+				return AddResult::Rebuild;
+			}
+			watch.owners.insert(root, self.epoch);
+			self.addition_failures.remove(&path);
+			return AddResult::Added;
+		}
+
+		if let Some(physical) = self.physical.get_mut(&identity) {
+			if !mode_satisfies(physical.mode, mode) {
+				result.rebuild_backend = true;
+				return AddResult::Rebuild;
+			}
+			physical.logicals.insert(path.clone());
+			self.addition_failures.remove(&path);
+			self.logical.insert(
+				path,
+				LogicalWatch {
+					identity,
+					owners: HashMap::from([(root, self.epoch)]),
+				},
+			);
+			return AddResult::Added;
+		}
+
+		if self.resource_latched || self.skipped_additions.contains(&path) {
+			return AddResult::Skipped;
+		}
+
+		match self.backend.watch(&path, mode) {
+			Ok(()) => {
+				if !self.verify_poll_registration(&path, &identity, result) {
+					return if result.rebuild_backend {
+						AddResult::Rebuild
+					} else {
+						AddResult::Invalidated
+					};
+				}
+				self.addition_failures.remove(&path);
+				self.physical.insert(
+					identity.clone(),
+					PhysicalWatch {
+						watch_path: path.clone(),
+						logicals: HashSet::from([path.clone()]),
+						guards: HashSet::new(),
+						mode,
+					},
+				);
+				self.logical.insert(
+					path,
+					LogicalWatch {
+						identity,
+						owners: HashMap::from([(root, self.epoch)]),
+					},
+				);
+				AddResult::Added
+			}
+			Err(error) => {
+				if path_not_found(&error) {
+					result.errors.extend(notify_multi_path_errors(
+						self.kind,
+						WatchedPath::non_recursive(path),
+						error,
+						false,
+					));
+					AddResult::Invalidated
+				} else if let Some(resource) = classify_resource_error(&error) {
+					self.resource_latched = true;
+					if !self.resource_reported {
+						self.resource_reported = true;
+						let error = resource.into_fs_error(error);
+						result.errors.push(RuntimeError::FsWatcher {
+							kind: self.kind,
+							err: error,
+						});
+					}
+					AddResult::Skipped
+				} else {
+					let failures = self.addition_failures.entry(path.clone()).or_default();
+					*failures = failures.saturating_add(1);
+					result.errors.extend(notify_multi_path_errors(
+						self.kind,
+						WatchedPath::non_recursive(path.clone()),
+						error,
+						false,
+					));
+					if *failures >= 2 {
+						self.skipped_additions.insert(path);
+						AddResult::Skipped
+					} else {
+						result.rebuild_backend = true;
+						AddResult::Rebuild
+					}
+				}
+			}
+		}
+	}
+
+	fn verify_poll_registration(
+		&mut self,
+		path: &Path,
+		expected: &Identity,
+		result: &mut StepResult,
+	) -> bool {
+		if self.backend_kind != notify::WatcherKind::PollWatcher {
+			return true;
+		}
+
+		let verification = match self.scanner.classify(path, self.follow_symlinks) {
+			Ok(verification) => verification,
+			Err(error) => {
+				result.errors.push(self.scan_error(path.to_owned(), error));
+				return self.undo_invalid_poll_registration(path, result);
+			}
+		};
+		let valid = match verification {
+			EntryKind::Directory(identity) => expected == &Identity::Canonical(identity),
+			EntryKind::Other => expected == &Identity::Lexical(path.to_owned()),
+			EntryKind::NonFollowedSymlink => false,
+		};
+		if valid {
+			return true;
+		}
+
+		result.errors.push(self.scan_error(
+			path.to_owned(),
+			io::Error::new(
+				io::ErrorKind::InvalidData,
+				"path changed while installing polling watch",
+			),
+		));
+		self.undo_invalid_poll_registration(path, result)
+	}
+
+	fn undo_invalid_poll_registration(&mut self, path: &Path, result: &mut StepResult) -> bool {
+		self.try_unwatch(path, result);
+		false
+	}
+
+	fn try_unwatch(&mut self, path: &Path, result: &mut StepResult) -> bool {
+		match self.backend.unwatch(path) {
+			Ok(())
+			| Err(notify::Error {
+				kind: notify::ErrorKind::WatchNotFound,
+				..
+			}) => true,
+			Err(error) => {
+				result.errors.extend(notify_multi_path_errors(
+					self.kind,
+					WatchedPath::non_recursive(path),
+					error,
+					true,
+				));
+				result.rebuild_backend = true;
+				false
+			}
+		}
+	}
+
+	fn mark_seen(&mut self, root: &Root, identity: Identity) -> bool {
+		self.seen.entry(root.clone()).or_default().insert(identity)
+	}
+
+	fn has_source_owner(&self, path: &Path, root: &Root) -> bool {
+		self.logical
+			.get(path)
+			.map_or(false, |watch| watch.owners.contains_key(root))
+	}
+
+	fn carry_forward(&mut self, root: &Root, prefix: &Path) {
+		for (path, watch) in &mut self.logical {
+			if path.starts_with(prefix) && watch.owners.contains_key(root) {
+				watch.owners.insert(root.clone(), self.epoch);
+			}
+		}
+	}
+
+	fn prepare_sweep(&mut self) {
+		let mut stale = Vec::new();
+		for (path, watch) in &self.logical {
+			for (root, generation) in &watch.owners {
+				if *generation != self.epoch || !self.roots.contains(root) {
+					stale.push(SweepEntry {
+						path: path.clone(),
+						root: root.clone(),
+						epoch: self.epoch,
+					});
+				}
+			}
+		}
+		stale.sort_by(|left, right| {
+			right
+				.path
+				.components()
+				.count()
+				.cmp(&left.path.components().count())
+				.then_with(|| right.path.cmp(&left.path))
+		});
+		self.sweep = stale.into();
+		self.phase = Phase::Sweeping;
+	}
+
+	fn queue_remove_owner_prefix(&mut self, root: &Root, prefix: &Path) {
+		self.retry_candidates
+			.retain(|(owner, path)| owner != root || !path.starts_with(prefix));
+		self.work.retain(|work| {
+			!matches!(
+				work,
+				Work::Candidate {
+					root: owner, path, ..
+				} | Work::Scan {
+					root: owner, path, ..
+				}
+					if owner == root && path.starts_with(prefix)
+			)
+		});
+		let mut paths: Vec<_> = self
+			.logical
+			.iter()
+			.filter(|(path, watch)| path.starts_with(prefix) && watch.owners.contains_key(root))
+			.map(|(path, _)| path.clone())
+			.collect();
+		paths.sort_by_key(|path| Reverse(path.components().count()));
+		self.pending_owner_removals
+			.extend(paths.into_iter().map(|path| (path, root.clone())));
+	}
+
+	fn queue_remove_prefix(&mut self, prefix: &Path) {
+		let configured = &self.roots;
+		self.work.retain(|work| match work {
+			Work::Root(root) | Work::Guard(root) if configured.contains(root) => true,
+			_ => !work.path().starts_with(prefix),
+		});
+		self.retry_candidates
+			.retain(|(_, path)| !path.starts_with(prefix));
+		for replay in self.replay_desired.values_mut() {
+			replay
+				.logicals
+				.retain(|(path, _)| !path.starts_with(prefix));
+			if !replay
+				.logicals
+				.iter()
+				.any(|(path, _)| path == &replay.watch_path)
+			{
+				if let Some((path, _)) = replay.logicals.first() {
+					replay.watch_path.clone_from(path);
+				}
+			}
+		}
+		self.replay_desired
+			.retain(|_, replay| !replay.logicals.is_empty());
+		self.replay_queue
+			.retain(|identity| self.replay_desired.contains_key(identity));
+
+		let mut paths: Vec<_> = self
+			.logical
+			.keys()
+			.filter(|path| path.starts_with(prefix))
+			.cloned()
+			.collect();
+		paths.sort_by(|left, right| {
+			right
+				.components()
+				.count()
+				.cmp(&left.components().count())
+				.then_with(|| right.cmp(left))
+		});
+		for path in paths {
+			if self.pending_removal_set.insert(path.clone()) {
+				self.pending_removals.push_back(path);
+			}
+		}
+	}
+
+	fn remove_owner_force(&mut self, entry: SweepEntry, result: &mut StepResult) {
+		let remove_logical = if let Some(watch) = self.logical.get_mut(&entry.path) {
+			watch.owners.remove(&entry.root);
+			watch.owners.is_empty()
+		} else {
+			false
+		};
+		if remove_logical {
+			self.remove_logical(&entry.path, result);
+		}
+	}
+
+	fn remove_owner(&mut self, entry: SweepEntry, result: &mut StepResult) {
+		if entry.epoch != self.epoch {
+			return;
+		}
+		let remove_logical = if let Some(watch) = self.logical.get_mut(&entry.path) {
+			if watch.owners.get(&entry.root).copied() != Some(entry.epoch) {
+				watch.owners.remove(&entry.root);
+			}
+			watch.owners.is_empty()
+		} else {
+			false
+		};
+		if remove_logical {
+			self.remove_logical(&entry.path, result);
+		}
+	}
+
+	fn remove_logical(&mut self, path: &Path, result: &mut StepResult) {
+		let Some(logical) = self.logical.remove(path) else {
+			return;
+		};
+		let (remove_physical, removed_representative) =
+			if let Some(physical) = self.physical.get_mut(&logical.identity) {
+				physical.logicals.remove(path);
+				let has_owners = !physical.logicals.is_empty() || !physical.guards.is_empty();
+				(
+					!has_owners,
+					physical.watch_path == path && has_owners && !physical.guards.contains(path),
+				)
+			} else {
+				(false, false)
+			};
+		if removed_representative {
+			// The surviving aliases cannot rely on a registration whose lexical
+			// representative has disappeared. Replay them on a fresh backend.
+			result.rebuild_backend = true;
+			return;
+		}
+		if !remove_physical {
+			return;
+		}
+
+		let Some(physical) = self.physical.remove(&logical.identity) else {
+			return;
+		};
+		if self.try_unwatch(&physical.watch_path, result) {
+			self.schedule_retries();
+		}
+	}
+
+	fn settle(&mut self) {
+		self.phase = Phase::Settled;
+	}
+
+	const fn scan_error(&self, path: PathBuf, error: io::Error) -> RuntimeError {
+		RuntimeError::FsWatcher {
+			kind: self.kind,
+			err: FsWatcherError::PathScan { path, err: error },
+		}
+	}
+
+	fn absolute(&self, path: &Path) -> PathBuf {
+		if path.is_absolute() {
+			path.normalize()
+		} else {
+			self.cwd.join(path).normalize()
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::{Arc, Mutex};
+
+	use notify::ErrorKind;
+	use watchexec_events::{Event, Priority};
+
+	use super::*;
+
+	#[derive(Clone, Debug, PartialEq, Eq)]
+	enum Operation {
+		Watch(PathBuf, RecursiveMode),
+		Unwatch(PathBuf),
+		Classify(PathBuf),
+		Scan(PathBuf),
+	}
+
+	#[derive(Default)]
+	struct FakeBackendState {
+		operations: Vec<Operation>,
+		resource_failure: Option<PathBuf>,
+		path_not_found_failures: HashMap<PathBuf, usize>,
+		generic_failures: HashMap<PathBuf, usize>,
+		generic_unwatch_failures: HashMap<PathBuf, usize>,
+		watch_not_found: HashSet<PathBuf>,
+	}
+
+	struct FakeBackend(Arc<Mutex<FakeBackendState>>);
+
+	impl Backend for FakeBackend {
+		fn watch(&mut self, path: &Path, mode: RecursiveMode) -> notify::Result<()> {
+			let mut state = self.0.lock().unwrap();
+			state
+				.operations
+				.push(Operation::Watch(path.to_owned(), mode));
+			if state.resource_failure.as_deref() == Some(path) {
+				Err(notify::Error::new(ErrorKind::MaxFilesWatch))
+			} else if let Some(remaining) = state.path_not_found_failures.get_mut(path) {
+				if *remaining > 0 {
+					*remaining -= 1;
+					return Err(notify::Error::new(ErrorKind::PathNotFound));
+				}
+				Ok(())
+			} else if let Some(remaining) = state.generic_failures.get_mut(path) {
+				if *remaining > 0 {
+					*remaining -= 1;
+					return Err(notify::Error::generic("fake watch failure"));
+				}
+				Ok(())
+			} else {
+				Ok(())
+			}
+		}
+
+		fn unwatch(&mut self, path: &Path) -> notify::Result<()> {
+			let mut state = self.0.lock().unwrap();
+			state.operations.push(Operation::Unwatch(path.to_owned()));
+			if let Some(remaining) = state.generic_unwatch_failures.get_mut(path) {
+				if *remaining > 0 {
+					*remaining -= 1;
+					return Err(notify::Error::generic("fake unwatch failure"));
+				}
+			}
+			if state.watch_not_found.contains(path) {
+				Err(notify::Error::new(ErrorKind::WatchNotFound))
+			} else {
+				Ok(())
+			}
+		}
+	}
+
+	#[derive(Default)]
+	struct FakeScannerState {
+		directories: HashMap<PathBuf, PathBuf>,
+		entries: HashMap<PathBuf, Vec<PathBuf>>,
+		not_found: HashSet<PathBuf>,
+		not_found_after: HashMap<PathBuf, usize>,
+		non_followed_symlinks: HashSet<PathBuf>,
+		classify_errors: HashSet<PathBuf>,
+		classify_errors_after: HashMap<PathBuf, usize>,
+		scan_errors: HashSet<PathBuf>,
+		operations: Vec<Operation>,
+	}
+
+	struct FakeScanner(Arc<Mutex<FakeScannerState>>);
+
+	impl Scanner for FakeScanner {
+		fn classify(&self, path: &Path, follow_symlinks: bool) -> io::Result<EntryKind> {
+			let mut state = self.0.lock().unwrap();
+			state.operations.push(Operation::Classify(path.to_owned()));
+			let delayed_missing = state
+				.not_found_after
+				.get_mut(path)
+				.map_or(false, |remaining| {
+					if *remaining == 0 {
+						true
+					} else {
+						*remaining -= 1;
+						false
+					}
+				});
+			let delayed_error =
+				state
+					.classify_errors_after
+					.get_mut(path)
+					.map_or(false, |remaining| {
+						if *remaining == 0 {
+							true
+						} else {
+							*remaining -= 1;
+							false
+						}
+					});
+			if state.not_found.contains(path) || delayed_missing {
+				Err(io::Error::new(io::ErrorKind::NotFound, "fake missing path"))
+			} else if state.non_followed_symlinks.contains(path) && !follow_symlinks {
+				Ok(EntryKind::NonFollowedSymlink)
+			} else if state.classify_errors.contains(path) || delayed_error {
+				Err(io::Error::new(
+					io::ErrorKind::PermissionDenied,
+					"fake classify failure",
+				))
+			} else {
+				Ok(state
+					.directories
+					.get(path)
+					.cloned()
+					.map_or(EntryKind::Other, EntryKind::Directory))
+			}
+		}
+
+		fn scan(&self, path: &Path, visit: &mut dyn FnMut(io::Result<PathBuf>)) -> io::Result<()> {
+			let entries = {
+				let mut state = self.0.lock().unwrap();
+				state.operations.push(Operation::Scan(path.to_owned()));
+				if state.scan_errors.contains(path) {
+					return Err(io::Error::new(
+						io::ErrorKind::PermissionDenied,
+						"fake scan failure",
+					));
+				}
+				state.entries.get(path).cloned().unwrap_or_default()
+			};
+			for entry in entries {
+				visit(Ok(entry));
+			}
+			Ok(())
+		}
+	}
+
+	#[derive(Debug)]
+	struct TestFilter {
+		denied: HashSet<PathBuf>,
+	}
+
+	impl Filterer for TestFilter {
+		fn check_dir(&self, path: &Path) -> Result<bool, RuntimeError> {
+			Ok(!self.denied.contains(path))
+		}
+
+		fn check_event(&self, _event: &Event, _priority: Priority) -> Result<bool, RuntimeError> {
+			Ok(true)
+		}
+	}
+
+	fn filter(denied: impl IntoIterator<Item = &'static str>) -> Arc<dyn Filterer> {
+		Arc::new(TestFilter {
+			denied: denied.into_iter().map(PathBuf::from).collect(),
+		})
+	}
+
+	fn directory(state: &Arc<Mutex<FakeScannerState>>, path: &str) {
+		state
+			.lock()
+			.unwrap()
+			.directories
+			.insert(path.into(), path.into());
+	}
+
+	fn entries(state: &Arc<Mutex<FakeScannerState>>, path: &str, entries: &[&str]) {
+		state
+			.lock()
+			.unwrap()
+			.entries
+			.insert(path.into(), entries.iter().map(PathBuf::from).collect());
+	}
+
+	fn fixture() -> (
+		Recursor,
+		Arc<Mutex<FakeBackendState>>,
+		Arc<Mutex<FakeScannerState>>,
+	) {
+		let backend = Arc::new(Mutex::new(FakeBackendState::default()));
+		let scanner = Arc::new(Mutex::new(FakeScannerState::default()));
+		directory(&scanner, "/");
+		let recursor = Recursor::new(
+			Box::new(FakeBackend(backend.clone())),
+			Box::new(FakeScanner(scanner.clone())),
+			Watcher::Native,
+			notify::WatcherKind::Inotify,
+			true,
+			PathBuf::from("/work"),
+			filter([]),
+		);
+		(recursor, backend, scanner)
+	}
+
+	fn drain(recursor: &mut Recursor) -> Vec<RuntimeError> {
+		let mut errors = Vec::new();
+		for _ in 0..256 {
+			if !recursor.has_work() {
+				return errors;
+			}
+			let step = recursor.step();
+			assert!(!step.rebuild_backend, "unexpected backend rebuild");
+			errors.extend(step.errors);
+		}
+		panic!("recursor did not settle");
+	}
+
+	fn run_until_rebuild(recursor: &mut Recursor) -> Vec<RuntimeError> {
+		let mut errors = Vec::new();
+		for _ in 0..256 {
+			assert!(recursor.has_work(), "recursor settled before rebuilding");
+			let step = recursor.step();
+			errors.extend(step.errors);
+			if step.rebuild_backend {
+				return errors;
+			}
+		}
+		panic!("recursor did not request a rebuild");
+	}
+
+	fn watched(backend: &Arc<Mutex<FakeBackendState>>, path: &str) -> usize {
+		backend
+			.lock()
+			.unwrap()
+			.operations
+			.iter()
+			.filter(
+				|operation| matches!(operation, Operation::Watch(watched, _) if watched == Path::new(path)),
+			)
+			.count()
+	}
+
+	fn unwatched(backend: &Arc<Mutex<FakeBackendState>>, path: &str) -> usize {
+		backend
+			.lock()
+			.unwrap()
+			.operations
+			.iter()
+			.filter(
+				|operation| matches!(operation, Operation::Unwatch(watched) if watched == Path::new(path)),
+			)
+			.count()
+	}
+
+	#[test]
+	fn watches_each_directory_before_scanning_it() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		directory(&scanner, "/root/child");
+		entries(&scanner, "/root", &["/root/child"]);
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+
+		// The first bounded step watches the root. Classification is allowed
+		// before registration, but directory contents are not read until the
+		// following step.
+		recursor.step();
+		assert_eq!(watched(&backend, "/root"), 1);
+		assert!(!scanner
+			.lock()
+			.unwrap()
+			.operations
+			.contains(&Operation::Scan("/root".into())));
+
+		recursor.step();
+		assert!(scanner
+			.lock()
+			.unwrap()
+			.operations
+			.contains(&Operation::Scan("/root".into())));
+
+		// The discovered child follows the same watch-then-scan ordering.
+		recursor.step();
+		assert_eq!(watched(&backend, "/root/child"), 1);
+		assert!(!scanner
+			.lock()
+			.unwrap()
+			.operations
+			.contains(&Operation::Scan("/root/child".into())));
+		recursor.step();
+		assert!(scanner
+			.lock()
+			.unwrap()
+			.operations
+			.contains(&Operation::Scan("/root/child".into())));
+		drain(&mut recursor);
+
+		assert!(backend.lock().unwrap().operations.iter().all(|operation| {
+			!matches!(operation, Operation::Watch(_, RecursiveMode::Recursive))
+		}));
+	}
+
+	#[test]
+	fn ignored_descendant_is_pruned_but_explicit_root_is_not() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/ignored", "/root/ignored/nested"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/ignored"]);
+		entries(&scanner, "/root/ignored", &["/root/ignored/nested"]);
+
+		recursor.reconcile(
+			&[WatchedPath::recursive("/root")],
+			filter(["/root/ignored"]),
+		);
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/root/ignored"), 0);
+
+		// Adding the ignored directory as a configured root bypasses check_dir,
+		// while its own accepted descendants are still traversed.
+		recursor.reconcile(
+			&[
+				WatchedPath::recursive("/root"),
+				WatchedPath::recursive("/root/ignored"),
+			],
+			filter(["/root/ignored"]),
+		);
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root/ignored"), 1);
+		assert_eq!(watched(&backend, "/root/ignored/nested"), 1);
+	}
+
+	#[test]
+	fn a_local_scan_failure_does_not_stop_good_siblings() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/good"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/bad", "/root/good"]);
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors
+			.insert("/root/bad".into());
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		let errors = drain(&mut recursor);
+
+		assert!(errors.iter().any(|error| matches!(
+			error,
+			RuntimeError::FsWatcher {
+				err: FsWatcherError::PathScan { path, .. },
+				..
+			} if path == Path::new("/root/bad")
+		)));
+		assert_eq!(watched(&backend, "/root/good"), 1);
+	}
+
+	#[test]
+	fn transient_child_classification_failure_is_retried_once() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/child", "/root/child/grand"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/child"]);
+		entries(&scanner, "/root/child", &["/root/child/grand"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		recursor.step();
+		recursor.step();
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors
+			.insert("/root/child".into());
+
+		let failed = recursor.step();
+		assert_eq!(failed.errors.len(), 1);
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors
+			.remove(Path::new("/root/child"));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root/child"), 1);
+		assert_eq!(watched(&backend, "/root/child/grand"), 1);
+	}
+
+	#[test]
+	fn transient_child_scan_failure_is_retried_once() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/child", "/root/child/grand"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/child"]);
+		entries(&scanner, "/root/child", &["/root/child/grand"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		recursor.step();
+		recursor.step();
+		recursor.step();
+		scanner
+			.lock()
+			.unwrap()
+			.scan_errors
+			.insert("/root/child".into());
+
+		let failed = recursor.step();
+		assert_eq!(failed.errors.len(), 1);
+		scanner
+			.lock()
+			.unwrap()
+			.scan_errors
+			.remove(Path::new("/root/child"));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root/child/grand"), 1);
+	}
+
+	#[test]
+	fn persistent_child_errors_are_bounded_and_keep_parent_coverage() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		directory(&scanner, "/root/child");
+		entries(&scanner, "/root", &["/root/child"]);
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors
+			.insert("/root/child".into());
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		let errors = drain(&mut recursor);
+		let classifications = scanner
+			.lock()
+			.unwrap()
+			.operations
+			.iter()
+			.filter(|operation| operation == &&Operation::Classify("/root/child".into()))
+			.count();
+
+		assert_eq!(errors.len(), 2);
+		assert_eq!(classifications, 2);
+		assert!(recursor.logical.contains_key(Path::new("/root")));
+		assert_eq!(unwatched(&backend, "/root"), 0);
+	}
+
+	#[test]
+	fn second_epoch_classification_failure_preserves_known_subtree() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/child", "/root/child/grand"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/child"]);
+		entries(&scanner, "/root/child", &["/root/child/grand"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors
+			.insert("/root/child".into());
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		let errors = drain(&mut recursor);
+
+		assert_eq!(errors.len(), 2);
+		assert_eq!(unwatched(&backend, "/root/child"), 0);
+		assert_eq!(unwatched(&backend, "/root/child/grand"), 0);
+		assert!(recursor
+			.logical
+			.contains_key(Path::new("/root/child/grand")));
+	}
+
+	#[test]
+	fn second_epoch_scan_failure_preserves_known_descendants() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/child", "/root/child/grand"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/child"]);
+		entries(&scanner, "/root/child", &["/root/child/grand"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		scanner
+			.lock()
+			.unwrap()
+			.scan_errors
+			.insert("/root/child".into());
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		let errors = drain(&mut recursor);
+
+		assert_eq!(errors.len(), 2);
+		assert_eq!(unwatched(&backend, "/root/child/grand"), 0);
+		assert!(recursor
+			.logical
+			.contains_key(Path::new("/root/child/grand")));
+	}
+
+	#[test]
+	fn nonrecursive_root_is_watched_once_without_scanning() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		entries(&scanner, "/root", &["/root/child"]);
+
+		recursor.reconcile(&[WatchedPath::non_recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root"), 1);
+		assert!(!scanner
+			.lock()
+			.unwrap()
+			.operations
+			.iter()
+			.any(|operation| matches!(operation, Operation::Scan(_))));
+	}
+
+	#[test]
+	fn native_poll_fallback_verifies_success_against_metadata() {
+		let (mut recursor, backend, scanner) = fixture();
+		recursor.backend_kind = notify::WatcherKind::PollWatcher;
+		directory(&scanner, "/root");
+		scanner
+			.lock()
+			.unwrap()
+			.not_found_after
+			.insert("/root".into(), 1);
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		let errors = drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root"), 1);
+		assert_eq!(unwatched(&backend, "/root"), 1);
+		assert!(!recursor.logical.contains_key(Path::new("/root")));
+		assert!(errors.iter().any(|error| matches!(
+			error,
+			RuntimeError::FsWatcher {
+				err: FsWatcherError::PathScan { path, .. },
+				..
+			} if path == Path::new("/root")
+		)));
+	}
+
+	#[test]
+	fn poll_permission_error_does_not_commit_unverified_registration() {
+		let (mut recursor, backend, scanner) = fixture();
+		recursor.backend_kind = notify::WatcherKind::PollWatcher;
+		directory(&scanner, "/root");
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors_after
+			.insert("/root".into(), 1);
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		let errors = drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root"), 1);
+		assert_eq!(unwatched(&backend, "/root"), 1);
+		assert!(!recursor.logical.contains_key(Path::new("/root")));
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/"))
+		);
+		assert!(errors.iter().any(|error| matches!(
+			error,
+			RuntimeError::FsWatcher {
+				err: FsWatcherError::PathScan { path, err },
+				..
+			} if path == Path::new("/root") && err.kind() == io::ErrorKind::PermissionDenied
+		)));
+	}
+
+	#[test]
+	fn unmanaged_backend_installs_complete_roots_with_requested_modes() {
+		let backend = Arc::new(Mutex::new(FakeBackendState::default()));
+		let scanner = Arc::new(Mutex::new(FakeScannerState::default()));
+		let mut recursor = Recursor::new(
+			Box::new(FakeBackend(backend.clone())),
+			Box::new(FakeScanner(scanner.clone())),
+			Watcher::Native,
+			notify::WatcherKind::Fsevent,
+			true,
+			PathBuf::from("/work"),
+			filter([]),
+		);
+		recursor.reconcile(
+			&[
+				WatchedPath::recursive("/one"),
+				WatchedPath::non_recursive("/two"),
+			],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		let operations = &backend.lock().unwrap().operations;
+		assert!(operations.contains(&Operation::Watch("/one".into(), RecursiveMode::Recursive)));
+		assert!(operations.contains(&Operation::Watch(
+			"/two".into(),
+			RecursiveMode::NonRecursive
+		)));
+		assert!(scanner.lock().unwrap().operations.is_empty());
+	}
+
+	#[test]
+	fn unmanaged_same_value_epoch_retries_resource_failed_root() {
+		let backend = Arc::new(Mutex::new(FakeBackendState::default()));
+		let scanner = Arc::new(Mutex::new(FakeScannerState::default()));
+		backend.lock().unwrap().resource_failure = Some("/root".into());
+		let mut recursor = Recursor::new(
+			Box::new(FakeBackend(backend.clone())),
+			Box::new(FakeScanner(scanner)),
+			Watcher::Native,
+			notify::WatcherKind::Fsevent,
+			true,
+			PathBuf::from("/work"),
+			filter([]),
+		);
+		let pathset = [WatchedPath::recursive("/root")];
+		recursor.reconcile(&pathset, filter([]));
+		let first = drain(&mut recursor);
+		assert_eq!(first.len(), 1);
+		assert!(recursor.needs_retry());
+
+		backend.lock().unwrap().resource_failure = None;
+		recursor.reconcile(&pathset, filter([]));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root"), 2);
+		assert!(recursor.logical.contains_key(Path::new("/root")));
+		assert!(!recursor.needs_retry());
+	}
+
+	#[test]
+	fn recursive_and_nonrecursive_same_root_share_one_watch() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		recursor.reconcile(
+			&[
+				WatchedPath::non_recursive("/root"),
+				WatchedPath::recursive("/root"),
+			],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root"), 1);
+		assert!(scanner
+			.lock()
+			.unwrap()
+			.operations
+			.contains(&Operation::Scan("/root".into())));
+	}
+
+	#[test]
+	fn queued_sweep_does_not_remove_refreshed_owner() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/child"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/child"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		let root = recursor.roots.iter().next().unwrap().clone();
+		recursor.work.clear();
+		recursor.prepare_sweep();
+		assert!(!recursor.sweep.is_empty());
+		recursor
+			.logical
+			.get_mut(Path::new("/root/child"))
+			.unwrap()
+			.owners
+			.insert(root, recursor.epoch);
+		drain(&mut recursor);
+
+		assert_eq!(unwatched(&backend, "/root/child"), 0);
+		assert!(recursor.logical.contains_key(Path::new("/root/child")));
+	}
+
+	#[test]
+	fn overlapping_roots_share_registrations_and_ownership() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/child", "/root/child/grand"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/child"]);
+		entries(&scanner, "/root/child", &["/root/child/grand"]);
+
+		recursor.reconcile(
+			&[
+				WatchedPath::recursive("/root"),
+				WatchedPath::recursive("/root/child"),
+			],
+			filter([]),
+		);
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/root/child"), 1);
+
+		recursor.reconcile(&[WatchedPath::recursive("/root/child")], filter([]));
+		drain(&mut recursor);
+		assert_eq!(unwatched(&backend, "/root/child"), 0);
+		assert_eq!(unwatched(&backend, "/root/child/grand"), 0);
+		assert_eq!(unwatched(&backend, "/root"), 1);
+	}
+
+	#[test]
+	fn recursive_file_discovery_keeps_explicit_file_owner() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		entries(&scanner, "/root", &["/root/file"]);
+		recursor.reconcile(
+			&[
+				WatchedPath::recursive("/root"),
+				WatchedPath::non_recursive("/root/file"),
+			],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		let explicit = Root {
+			path: "/root/file".into(),
+			recursive: false,
+		};
+		let recursive = Root {
+			path: "/root".into(),
+			recursive: true,
+		};
+		let file = recursor.logical.get(Path::new("/root/file")).unwrap();
+		assert!(file.owners.contains_key(&explicit));
+		assert!(!file.owners.contains_key(&recursive));
+		assert_eq!(watched(&backend, "/root/file"), 1);
+		assert_eq!(unwatched(&backend, "/root/file"), 0);
+	}
+
+	#[test]
+	fn removal_uses_known_prefix_without_metadata() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/gone", "/root/gone/child"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/gone"]);
+		entries(&scanner, "/root/gone", &["/root/gone/child"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+		let classifications = scanner.lock().unwrap().operations.len();
+
+		recursor.topology_remove("/root/gone".into());
+		drain(&mut recursor);
+
+		assert_eq!(scanner.lock().unwrap().operations.len(), classifications);
+		assert_eq!(unwatched(&backend, "/root/gone/child"), 1);
+		assert_eq!(unwatched(&backend, "/root/gone"), 1);
+	}
+
+	#[test]
+	fn prefix_removal_finishes_after_generic_unwatch_rebuild() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/gone", "/root/gone/child"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/gone"]);
+		entries(&scanner, "/root/gone", &["/root/gone/child"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+		backend
+			.lock()
+			.unwrap()
+			.generic_unwatch_failures
+			.insert("/root/gone/child".into(), 1);
+
+		recursor.topology_remove("/root/gone".into());
+		assert_eq!(run_until_rebuild(&mut recursor).len(), 1);
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		recursor.replace_backend(Box::new(FakeBackend(replacement.clone())));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&replacement, "/root/gone"), 0);
+		assert_eq!(watched(&replacement, "/root/gone/child"), 0);
+		assert!(!recursor.logical.contains_key(Path::new("/root/gone")));
+		assert!(!recursor.logical.contains_key(Path::new("/root/gone/child")));
+	}
+
+	#[test]
+	fn already_removed_backend_watch_converges_without_error() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/gone"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/gone"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+		backend
+			.lock()
+			.unwrap()
+			.watch_not_found
+			.insert("/root/gone".into());
+
+		recursor.topology_remove("/root/gone".into());
+		let errors = drain(&mut recursor);
+
+		assert!(errors.is_empty());
+		assert!(!recursor.logical.contains_key(Path::new("/root/gone")));
+		assert_eq!(unwatched(&backend, "/root/gone"), 1);
+	}
+
+	#[test]
+	fn configured_directory_root_is_reacquired_after_delete_recreate() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/"), 0);
+
+		scanner.lock().unwrap().not_found.insert("/root".into());
+		recursor.topology_remove("/root".into());
+		drain(&mut recursor);
+		assert!(!recursor.logical.contains_key(Path::new("/root")));
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/"))
+		);
+		assert_eq!(watched(&backend, "/"), 1);
+
+		scanner.lock().unwrap().not_found.remove(Path::new("/root"));
+		recursor.topology_create("/root".into());
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/root"), 2);
+		assert!(recursor.logical.contains_key(Path::new("/root")));
+		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn from_only_atomic_root_exchange_reacquires_without_create() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.insert("/root".into(), "/identity/a".into());
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.insert("/root".into(), "/identity/b".into());
+		recursor.topology_remove("/root".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root"), 2);
+		assert_eq!(
+			recursor.logical.get(Path::new("/root")).unwrap().identity,
+			Identity::Canonical("/identity/b".into())
+		);
+		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn missing_root_guard_moves_to_nearest_existing_ancestor() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner
+			.lock()
+			.unwrap()
+			.not_found
+			.extend([PathBuf::from("/a"), PathBuf::from("/a/b")]);
+		recursor.reconcile(&[WatchedPath::recursive("/a/b")], filter([]));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/a/b"), 0);
+		assert_eq!(watched(&backend, "/"), 1);
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/"))
+		);
+
+		directory(&scanner, "/a");
+		scanner.lock().unwrap().not_found.remove(Path::new("/a"));
+		recursor.topology_create("/a".into());
+		drain(&mut recursor);
+		assert_eq!(unwatched(&backend, "/"), 1);
+		assert_eq!(watched(&backend, "/a"), 1);
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/a"))
+		);
+
+		scanner.lock().unwrap().not_found.insert("/a".into());
+		recursor.topology_remove("/a".into());
+		drain(&mut recursor);
+		assert_eq!(unwatched(&backend, "/a"), 1);
+		assert_eq!(watched(&backend, "/"), 2);
+
+		scanner.lock().unwrap().not_found.remove(Path::new("/a"));
+		scanner.lock().unwrap().not_found.remove(Path::new("/a/b"));
+		directory(&scanner, "/a/b");
+		recursor.topology_create("/a".into());
+		recursor.topology_create("/a/b".into());
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/a/b"), 1);
+		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn missing_outer_root_does_not_discard_queued_nested_root() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner
+			.lock()
+			.unwrap()
+			.not_found
+			.extend([PathBuf::from("/a"), PathBuf::from("/a/b")]);
+
+		recursor.reconcile(
+			&[
+				WatchedPath::non_recursive("/a"),
+				WatchedPath::recursive("/a/b"),
+			],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		assert_eq!(recursor.root_guards.len(), 2);
+		assert!(recursor
+			.roots
+			.iter()
+			.all(|root| recursor.root_guards.get(root) == Some(&PathBuf::from("/"))));
+		assert_eq!(watched(&backend, "/"), 1);
+		assert_eq!(watched(&backend, "/a"), 0);
+		assert_eq!(watched(&backend, "/a/b"), 0);
+	}
+
+	#[test]
+	fn guarded_nested_root_advances_on_one_sided_move_to_ancestor() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner
+			.lock()
+			.unwrap()
+			.not_found
+			.extend([PathBuf::from("/a"), PathBuf::from("/a/b")]);
+		recursor.reconcile(&[WatchedPath::recursive("/a/b")], filter([]));
+		drain(&mut recursor);
+		assert_eq!(
+			recursor
+				.root_guards
+				.get(recursor.roots.iter().next().unwrap()),
+			Some(&PathBuf::from("/"))
+		);
+
+		directory(&scanner, "/a");
+		scanner.lock().unwrap().not_found.remove(Path::new("/a"));
+		// A one-sided rename To is conservatively delivered as ambiguous.
+		recursor.topology_ambiguous("/a".into());
+		drain(&mut recursor);
+		assert_eq!(
+			recursor
+				.root_guards
+				.get(recursor.roots.iter().next().unwrap()),
+			Some(&PathBuf::from("/a"))
+		);
+		assert_eq!(watched(&backend, "/a"), 1);
+
+		directory(&scanner, "/a/b");
+		scanner.lock().unwrap().not_found.remove(Path::new("/a/b"));
+		recursor.topology_create("/a/b".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/a/b"), 1);
+		assert!(recursor.logical.contains_key(Path::new("/a/b")));
+		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn atomic_exchange_of_guarded_ancestor_reregisters_closer_guard() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.extend([(PathBuf::from("/a"), PathBuf::from("/identity/old"))]);
+		scanner.lock().unwrap().not_found.insert("/a/b".into());
+		recursor.reconcile(&[WatchedPath::recursive("/a/b")], filter([]));
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/a"), 1);
+
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.insert("/a".into(), "/identity/new".into());
+		// A From may be all that is delivered for an atomic exchange. Current
+		// metadata must supersede the callback tombstone for the guard path.
+		recursor.topology_remove("/a".into());
+		drain(&mut recursor);
+
+		assert_eq!(unwatched(&backend, "/a"), 1);
+		assert_eq!(watched(&backend, "/a"), 2);
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/a"))
+		);
+
+		directory(&scanner, "/a/b");
+		scanner.lock().unwrap().not_found.remove(Path::new("/a/b"));
+		recursor.topology_create("/a/b".into());
+		drain(&mut recursor);
+		assert!(recursor.logical.contains_key(Path::new("/a/b")));
+		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn guard_permission_error_preserves_closer_existing_coverage() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/a");
+		scanner.lock().unwrap().not_found.insert("/a/b".into());
+		recursor.reconcile(&[WatchedPath::recursive("/a/b")], filter([]));
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/a"), 1);
+
+		scanner.lock().unwrap().classify_errors.insert("/a".into());
+		let root = recursor.roots.iter().next().unwrap().clone();
+		recursor.work.push_back(Work::Guard(root));
+		let errors = drain(&mut recursor);
+
+		assert_eq!(errors.len(), 1);
+		assert_eq!(unwatched(&backend, "/a"), 0);
+		assert_eq!(watched(&backend, "/"), 0);
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/a"))
+		);
+	}
+
+	#[test]
+	fn initial_root_permission_error_installs_guard_and_retries_once() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors
+			.insert("/denied".into());
+
+		recursor.reconcile(&[WatchedPath::recursive("/denied")], filter([]));
+		let errors = drain(&mut recursor);
+
+		assert_eq!(errors.len(), 2);
+		assert_eq!(watched(&backend, "/denied"), 0);
+		assert_eq!(watched(&backend, "/"), 1);
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/"))
+		);
+		assert_eq!(
+			scanner
+				.lock()
+				.unwrap()
+				.operations
+				.iter()
+				.filter(|operation| {
+					matches!(operation, Operation::Classify(path) if path == Path::new("/denied"))
+				})
+				.count(),
+			2
+		);
+
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors
+			.remove(Path::new("/denied"));
+		directory(&scanner, "/denied");
+		recursor.topology_create("/denied".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/denied"), 1);
+		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn non_followed_explicit_symlink_uses_only_ancestor_guard() {
+		let (mut recursor, backend, scanner) = fixture();
+		recursor.follow_symlinks = false;
+		scanner
+			.lock()
+			.unwrap()
+			.non_followed_symlinks
+			.insert("/link".into());
+
+		recursor.reconcile(&[WatchedPath::recursive("/link")], filter([]));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/link"), 0);
+		assert_eq!(watched(&backend, "/"), 1);
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/"))
+		);
+	}
+
+	#[test]
+	fn non_followed_component_uses_nearest_safe_guard() {
+		let (mut recursor, backend, scanner) = fixture();
+		recursor.follow_symlinks = false;
+		directory(&scanner, "/base");
+		scanner
+			.lock()
+			.unwrap()
+			.non_followed_symlinks
+			.insert("/base/link".into());
+
+		recursor.reconcile(
+			&[WatchedPath::recursive("/base/link/deeper/root")],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/base"), 1);
+		assert_eq!(watched(&backend, "/base/link"), 0);
+		assert_eq!(watched(&backend, "/base/link/deeper/root"), 0);
+
+		scanner
+			.lock()
+			.unwrap()
+			.non_followed_symlinks
+			.remove(Path::new("/base/link"));
+		for path in ["/base/link", "/base/link/deeper", "/base/link/deeper/root"] {
+			directory(&scanner, path);
+		}
+		recursor.topology_create("/base/link".into());
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/base/link/deeper/root"), 1);
+		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn unmanaged_non_followed_component_skips_notify_registration() {
+		let backend = Arc::new(Mutex::new(FakeBackendState::default()));
+		let scanner = Arc::new(Mutex::new(FakeScannerState::default()));
+		directory(&scanner, "/");
+		directory(&scanner, "/base");
+		scanner
+			.lock()
+			.unwrap()
+			.non_followed_symlinks
+			.insert("/base/link".into());
+		let mut recursor = Recursor::new(
+			Box::new(FakeBackend(backend.clone())),
+			Box::new(FakeScanner(scanner)),
+			Watcher::Native,
+			notify::WatcherKind::Fsevent,
+			false,
+			PathBuf::from("/work"),
+			filter([]),
+		);
+
+		recursor.reconcile(
+			&[WatchedPath::recursive("/base/link/deeper/root")],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/base/link/deeper/root"), 0);
+		assert_eq!(watched(&backend, "/base"), 0);
+	}
+
+	#[test]
+	fn followed_missing_root_guards_lexical_symlink_ancestor() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.insert("/alias".into(), "/target".into());
+		scanner
+			.lock()
+			.unwrap()
+			.not_found
+			.insert("/alias/missing".into());
+
+		recursor.reconcile(&[WatchedPath::recursive("/alias/missing")], filter([]));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/alias"), 1);
+		assert_eq!(watched(&backend, "/"), 0);
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/alias"))
+		);
+	}
+
+	#[test]
+	fn canonical_source_alias_covers_guard_and_projects_topology() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner.lock().unwrap().directories.extend([
+			(PathBuf::from("/a-source"), PathBuf::from("/real")),
+			(PathBuf::from("/b-alias"), PathBuf::from("/real")),
+		]);
+		scanner
+			.lock()
+			.unwrap()
+			.not_found
+			.insert("/b-alias/missing".into());
+		recursor.reconcile(
+			&[
+				WatchedPath::recursive("/a-source"),
+				WatchedPath::recursive("/b-alias/missing"),
+			],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/a-source"), 1);
+		assert_eq!(watched(&backend, "/b-alias"), 0);
+		assert_eq!(
+			recursor
+				.root_guards
+				.values()
+				.find(|path| path.as_path() == Path::new("/b-alias")),
+			Some(&PathBuf::from("/b-alias"))
+		);
+
+		scanner
+			.lock()
+			.unwrap()
+			.not_found
+			.remove(Path::new("/b-alias/missing"));
+		scanner.lock().unwrap().directories.extend([
+			(
+				PathBuf::from("/a-source/missing"),
+				PathBuf::from("/real/missing"),
+			),
+			(
+				PathBuf::from("/b-alias/missing"),
+				PathBuf::from("/real/missing"),
+			),
+		]);
+		// The backend is registered at A, so its lexical event must also drive
+		// the guarded B alias.
+		recursor.topology_create("/a-source/missing".into());
+		drain(&mut recursor);
+
+		assert!(recursor.logical.contains_key(Path::new("/a-source")));
+		assert!(recursor.logical.contains_key(Path::new("/b-alias/missing")));
+		assert_eq!(
+			watched(&backend, "/a-source/missing") + watched(&backend, "/b-alias/missing"),
+			1
+		);
+		assert_eq!(unwatched(&backend, "/a-source"), 0);
+		assert_eq!(watched(&backend, "/a-source"), 1);
+		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn configured_file_root_is_reacquired_after_delete_recreate() {
+		let (mut recursor, backend, scanner) = fixture();
+		recursor.reconcile(&[WatchedPath::non_recursive("/file")], filter([]));
+		drain(&mut recursor);
+
+		scanner.lock().unwrap().not_found.insert("/file".into());
+		recursor.topology_remove("/file".into());
+		drain(&mut recursor);
+		scanner.lock().unwrap().not_found.remove(Path::new("/file"));
+		recursor.topology_create("/file".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/file"), 2);
+		assert!(recursor.logical.contains_key(Path::new("/file")));
+	}
+
+	#[test]
+	fn parent_guard_events_outside_roots_are_not_public() {
+		let (mut recursor, _backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		let sibling = notify::Event::new(notify::EventKind::Create(notify::event::CreateKind::Any))
+			.add_path("/sibling".into());
+		let root = notify::Event::new(notify::EventKind::Create(notify::event::CreateKind::Any))
+			.add_path("/root".into());
+		assert!(!recursor.event_is_public(&sibling));
+		assert!(recursor.event_is_public(&root));
+	}
+
+	#[test]
+	fn create_scans_an_already_populated_subtree() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		for path in ["/root/new", "/root/new/child"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root/new", &["/root/new/child"]);
+		recursor.topology_create("/root/new".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root/new"), 1);
+		assert_eq!(watched(&backend, "/root/new/child"), 1);
+	}
+
+	#[test]
+	fn split_replacement_rebuilds_populated_subtree_and_later_nested_state() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/item", "/root/item/old"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/item"]);
+		entries(&scanner, "/root/item", &["/root/item/old"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		scanner
+			.lock()
+			.unwrap()
+			.not_found
+			.insert("/root/item/old".into());
+		for path in ["/root/item/new", "/root/item/new/grand"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root/item", &["/root/item/new"]);
+		entries(&scanner, "/root/item/new", &[]);
+
+		// Split From(P)/To(P) delivery must not leave From's subtree tombstone
+		// suppressing the authoritative replacement at P.
+		recursor.topology_remove("/root/item".into());
+		recursor.topology_ambiguous("/root/item".into());
+		drain(&mut recursor);
+
+		assert!(!recursor.logical.contains_key(Path::new("/root/item/old")));
+		assert!(recursor.logical.contains_key(Path::new("/root/item/new")));
+		assert_eq!(watched(&backend, "/root/item"), 2);
+
+		entries(&scanner, "/root/item/new", &["/root/item/new/grand"]);
+		recursor.topology_create("/root/item/new/grand".into());
+		drain(&mut recursor);
+
+		assert!(recursor
+			.logical
+			.contains_key(Path::new("/root/item/new/grand")));
+		assert!(recursor.event_is_public(
+			&notify::Event::new(notify::EventKind::Modify(notify::event::ModifyKind::Any))
+				.add_path("/root/item/new/grand".into())
+		));
+	}
+
+	#[test]
+	fn topology_does_not_inherit_stale_owner_during_filter_epoch() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/ignored", "/root/ignored/new"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/ignored"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		recursor.reconcile(
+			&[WatchedPath::recursive("/root")],
+			filter(["/root/ignored"]),
+		);
+		// The ignored directory still has old-epoch ownership here, but must not
+		// be used as the parent of a topology addition.
+		recursor.topology_create("/root/ignored/new".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root/ignored/new"), 0);
+		assert!(!recursor
+			.logical
+			.contains_key(Path::new("/root/ignored/new")));
+	}
+
+	#[test]
+	fn filter_replacement_prunes_and_reopens_subtrees() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/build", "/root/build/cache"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/build"]);
+		entries(&scanner, "/root/build", &["/root/build/cache"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter(["/root/build"]));
+		drain(&mut recursor);
+		assert_eq!(unwatched(&backend, "/root/build/cache"), 1);
+		assert_eq!(unwatched(&backend, "/root/build"), 1);
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/root/build"), 2);
+		assert_eq!(watched(&backend, "/root/build/cache"), 2);
+	}
+
+	#[test]
+	fn resource_error_preserves_existing_watches_and_latches_epoch() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/root"), 1);
+
+		directory(&scanner, "/root/new");
+		backend.lock().unwrap().resource_failure = Some("/root/new".into());
+		recursor.topology_create("/root/new".into());
+		let first = recursor.step();
+		assert!(!first.rebuild_backend);
+		assert_eq!(first.errors.len(), 1);
+		assert!(matches!(
+			first.errors[0],
+			RuntimeError::FsWatcher {
+				err: FsWatcherError::TooManyWatches(_),
+				..
+			}
+		));
+		assert!(recursor.logical.contains_key(Path::new("/root")));
+		assert_eq!(unwatched(&backend, "/root"), 0);
+
+		// Further additions are skipped without another backend call or error.
+		directory(&scanner, "/root/other");
+		recursor.topology_create("/root/other".into());
+		let second = recursor.step();
+		assert!(second.errors.is_empty());
+		assert_eq!(watched(&backend, "/root/other"), 0);
+
+		// A relevant reconciliation starts a fresh epoch and retries additions.
+		backend.lock().unwrap().resource_failure = None;
+		entries(&scanner, "/root", &["/root/new", "/root/other"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/root/new"), 2);
+		assert_eq!(watched(&backend, "/root/other"), 1);
+	}
+
+	#[test]
+	fn resource_skipped_candidate_retries_when_removal_frees_capacity() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/old", "/root/new"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/old"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		backend.lock().unwrap().resource_failure = Some("/root/new".into());
+		recursor.topology_create("/root/new".into());
+		let failed = recursor.step();
+		assert_eq!(failed.errors.len(), 1);
+		assert_eq!(watched(&backend, "/root/new"), 1);
+
+		backend.lock().unwrap().resource_failure = None;
+		recursor.topology_remove("/root/old".into());
+		drain(&mut recursor);
+
+		assert_eq!(unwatched(&backend, "/root/old"), 1);
+		assert_eq!(watched(&backend, "/root/new"), 2);
+		assert!(recursor.logical.contains_key(Path::new("/root/new")));
+	}
+
+	#[test]
+	fn generic_watch_failure_is_retried_once_on_fresh_backend() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		backend
+			.lock()
+			.unwrap()
+			.generic_failures
+			.insert("/root".into(), 1);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+
+		let errors = run_until_rebuild(&mut recursor);
+		assert_eq!(errors.len(), 1);
+		recursor.replace_backend(Box::new(FakeBackend(backend.clone())));
+		assert!(drain(&mut recursor).is_empty());
+		assert_eq!(watched(&backend, "/root"), 2);
+		assert!(recursor.logical.contains_key(Path::new("/root")));
+	}
+
+	#[test]
+	fn backend_path_not_found_is_local_invalidation_not_rebuild() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		backend
+			.lock()
+			.unwrap()
+			.path_not_found_failures
+			.insert("/root".into(), 1);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+
+		let errors = drain(&mut recursor);
+
+		assert_eq!(errors.len(), 1);
+		assert_eq!(watched(&backend, "/root"), 2);
+		assert!(recursor.logical.contains_key(Path::new("/root")));
+		assert!(recursor.addition_failures.get(Path::new("/root")).is_none());
+		assert!(!recursor.skipped_additions.contains(Path::new("/root")));
+	}
+
+	#[test]
+	fn recreated_descendant_clears_persistent_watch_suppression() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/child"] {
+			directory(&scanner, path);
+		}
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+		backend
+			.lock()
+			.unwrap()
+			.generic_failures
+			.insert("/root/child".into(), 2);
+
+		recursor.topology_create("/root/child".into());
+		assert_eq!(run_until_rebuild(&mut recursor).len(), 1);
+		recursor.replace_backend(Box::new(FakeBackend(backend.clone())));
+		assert_eq!(drain(&mut recursor).len(), 1);
+		assert!(recursor
+			.skipped_additions
+			.contains(Path::new("/root/child")));
+		assert!(!recursor.logical.contains_key(Path::new("/root/child")));
+
+		// A Create for a new inode/object is authoritative and must clear the
+		// old path's permanent suppression without waiting for reconfiguration.
+		recursor.topology_create("/root/child".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root/child"), 3);
+		assert!(!recursor
+			.skipped_additions
+			.contains(Path::new("/root/child")));
+		assert!(recursor.logical.contains_key(Path::new("/root/child")));
+	}
+
+	#[test]
+	fn generic_rebuild_replays_coverage_before_scanner_failures() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/child", "/root/child/grand", "/root/new"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/child"]);
+		entries(&scanner, "/root/child", &["/root/child/grand"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		backend
+			.lock()
+			.unwrap()
+			.generic_failures
+			.insert("/root/new".into(), 1);
+		recursor.topology_create("/root/new".into());
+		assert_eq!(run_until_rebuild(&mut recursor).len(), 1);
+		scanner
+			.lock()
+			.unwrap()
+			.classify_errors
+			.insert("/root/child".into());
+
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		recursor.replace_backend(Box::new(FakeBackend(replacement.clone())));
+		drain(&mut recursor);
+		assert_eq!(watched(&replacement, "/root/child"), 1);
+		assert_eq!(watched(&replacement, "/root/child/grand"), 1);
+		assert_eq!(watched(&replacement, "/root/new"), 1);
+		assert!(recursor
+			.logical
+			.contains_key(Path::new("/root/child/grand")));
+	}
+
+	#[test]
+	fn persistent_watch_failure_is_excluded_after_one_retry() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/bad", "/healthy"] {
+			directory(&scanner, path);
+		}
+		recursor.reconcile(&[WatchedPath::recursive("/healthy")], filter([]));
+		drain(&mut recursor);
+		backend
+			.lock()
+			.unwrap()
+			.generic_failures
+			.insert("/bad".into(), 2);
+		recursor.reconcile(
+			&[
+				WatchedPath::recursive("/bad"),
+				WatchedPath::recursive("/healthy"),
+			],
+			filter([]),
+		);
+
+		assert_eq!(run_until_rebuild(&mut recursor).len(), 1);
+		recursor.replace_backend(Box::new(FakeBackend(backend.clone())));
+		assert_eq!(drain(&mut recursor).len(), 1);
+
+		assert_eq!(watched(&backend, "/bad"), 2);
+		assert_eq!(watched(&backend, "/healthy"), 2);
+		assert!(!recursor.logical.contains_key(Path::new("/bad")));
+		assert!(recursor.logical.contains_key(Path::new("/healthy")));
+	}
+
+	#[test]
+	fn replacing_backend_replays_all_roots() {
+		let (mut recursor, _backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		recursor.replace_backend(Box::new(FakeBackend(replacement.clone())));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&replacement, "/root"), 1);
+	}
+
+	#[test]
+	fn fresh_backend_replays_known_coverage_before_returning() {
+		let (mut recursor, _backend, scanner) = fixture();
+		for path in ["/root", "/root/child"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/child"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		recursor.prepare_backend_rebuild();
+		recursor.install_backend(Box::new(FakeBackend(replacement.clone())));
+		let replay = recursor.replay_backend_snapshot();
+
+		assert!(!replay.rebuild_backend);
+		assert!(replay.errors.is_empty());
+		assert_eq!(watched(&replacement, "/root"), 1);
+		assert_eq!(watched(&replacement, "/root/child"), 1);
+		assert!(recursor.replay_queue.is_empty());
+		assert!(recursor.logical.contains_key(Path::new("/root/child")));
+	}
+
+	#[test]
+	fn replay_path_not_found_migrates_to_surviving_alias() {
+		let (mut recursor, _backend, scanner) = fixture();
+		scanner.lock().unwrap().directories.extend([
+			(PathBuf::from("/alias-a"), PathBuf::from("/real")),
+			(PathBuf::from("/alias-b"), PathBuf::from("/real")),
+		]);
+		recursor.reconcile(
+			&[
+				WatchedPath::recursive("/alias-a"),
+				WatchedPath::recursive("/alias-b"),
+			],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		replacement
+			.lock()
+			.unwrap()
+			.path_not_found_failures
+			.insert("/alias-a".into(), 1);
+		recursor.prepare_backend_rebuild();
+		recursor.install_backend(Box::new(FakeBackend(replacement.clone())));
+		let replay = recursor.replay_backend_snapshot();
+
+		assert_eq!(replay.errors.len(), 1);
+		assert!(!replay.rebuild_backend);
+		assert_eq!(watched(&replacement, "/alias-a"), 1);
+		assert_eq!(watched(&replacement, "/alias-b"), 1);
+		assert!(recursor.replay_queue.is_empty());
+		assert!(recursor.replay_desired.is_empty());
+		assert!(!recursor.logical.contains_key(Path::new("/alias-a")));
+		assert!(recursor.logical.contains_key(Path::new("/alias-b")));
+		assert_eq!(
+			recursor
+				.physical
+				.get(&Identity::Canonical("/real".into()))
+				.unwrap()
+				.watch_path,
+			PathBuf::from("/alias-b")
+		);
+	}
+
+	#[test]
+	fn replay_resource_latch_stops_later_calls_and_retains_pending() {
+		let (mut recursor, _backend, scanner) = fixture();
+		for path in ["/a", "/b"] {
+			directory(&scanner, path);
+		}
+		recursor.reconcile(
+			&[WatchedPath::recursive("/a"), WatchedPath::recursive("/b")],
+			filter([]),
+		);
+		drain(&mut recursor);
+
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		replacement.lock().unwrap().resource_failure = Some("/a".into());
+		recursor.prepare_backend_rebuild();
+		recursor.install_backend(Box::new(FakeBackend(replacement.clone())));
+		let replay = recursor.replay_backend_snapshot();
+
+		assert_eq!(replay.errors.len(), 1);
+		assert!(!replay.rebuild_backend);
+		assert_eq!(watched(&replacement, "/a"), 1);
+		assert_eq!(watched(&replacement, "/b"), 0);
+		assert_eq!(recursor.replay_desired.len(), 2);
+		assert!(recursor.replay_queue.is_empty());
+		assert!(recursor.needs_retry());
+	}
+
+	#[test]
+	fn managed_rescan_rebuilds_and_replays_backend() {
+		let (mut recursor, _backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		recursor.rescan();
+		assert!(run_until_rebuild(&mut recursor).is_empty());
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		recursor.replace_backend(Box::new(FakeBackend(replacement.clone())));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&replacement, "/root"), 1);
+		assert!(recursor.logical.contains_key(Path::new("/root")));
+	}
+
+	#[test]
+	fn canonical_identity_change_rebuilds_before_scanning_new_tree() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.insert("/root/link".into(), "/identity/one".into());
+		entries(&scanner, "/root", &["/root/link"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.insert("/root/link".into(), "/identity/two".into());
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		assert!(run_until_rebuild(&mut recursor).is_empty());
+
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		recursor.replace_backend(Box::new(FakeBackend(replacement)));
+		drain(&mut recursor);
+		assert_eq!(
+			recursor
+				.logical
+				.get(Path::new("/root/link"))
+				.unwrap()
+				.identity,
+			Identity::Canonical("/identity/two".into())
+		);
+		assert_eq!(watched(&backend, "/root/link"), 1);
+	}
+
+	#[test]
+	fn paired_rename_invalidates_existing_destination_before_add() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in [
+			"/root",
+			"/root/from",
+			"/root/to",
+			"/root/to/old",
+			"/root/to/new",
+		] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/from", "/root/to"]);
+		entries(&scanner, "/root/to", &["/root/to/old"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		entries(&scanner, "/root/to", &["/root/to/new"]);
+		recursor.topology_rename("/root/from".into(), "/root/to".into());
+		drain(&mut recursor);
+
+		assert_eq!(unwatched(&backend, "/root/to/old"), 1);
+		assert_eq!(unwatched(&backend, "/root/to"), 1);
+		assert_eq!(watched(&backend, "/root/to"), 2);
+		assert_eq!(watched(&backend, "/root/to/new"), 1);
+		assert!(!recursor.logical.contains_key(Path::new("/root/from")));
+	}
+
+	#[test]
+	fn ambiguous_directory_to_file_removes_stale_subtree() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/root", "/root/item", "/root/item/child"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/root", &["/root/item"]);
+		entries(&scanner, "/root/item", &["/root/item/child"]);
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.remove(Path::new("/root/item"));
+		recursor.topology_ambiguous("/root/item".into());
+		drain(&mut recursor);
+
+		assert!(!recursor.logical.contains_key(Path::new("/root/item")));
+		assert!(!recursor.logical.contains_key(Path::new("/root/item/child")));
+		assert_eq!(unwatched(&backend, "/root/item/child"), 1);
+		assert_eq!(unwatched(&backend, "/root/item"), 1);
+	}
+
+	#[test]
+	fn ambiguous_same_identity_directory_is_reregistered() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/item", "/item/child"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/item", &["/item/child"]);
+		recursor.reconcile(&[WatchedPath::recursive("/item")], filter([]));
+		drain(&mut recursor);
+
+		recursor.topology_ambiguous("/item".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/item"), 2);
+		assert_eq!(watched(&backend, "/item/child"), 2);
+	}
+
+	#[test]
+	fn same_path_root_replacement_installs_new_identity() {
+		let (mut recursor, backend, scanner) = fixture();
+		for path in ["/item", "/item/child"] {
+			directory(&scanner, path);
+		}
+		entries(&scanner, "/item", &["/item/child"]);
+		recursor.reconcile(&[WatchedPath::recursive("/item")], filter([]));
+		drain(&mut recursor);
+
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.remove(Path::new("/item"));
+		recursor.topology_ambiguous("/item".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/item"), 2);
+		assert!(!recursor.logical.contains_key(Path::new("/item/child")));
+		assert_eq!(
+			recursor.logical.get(Path::new("/item")).unwrap().identity,
+			Identity::Lexical("/item".into())
+		);
+	}
+
+	#[test]
+	fn removing_representative_alias_replays_surviving_alias() {
+		let (mut recursor, backend, scanner) = fixture();
+		scanner.lock().unwrap().directories.extend([
+			(PathBuf::from("/alias1"), PathBuf::from("/real")),
+			(PathBuf::from("/alias2"), PathBuf::from("/real")),
+		]);
+		recursor.reconcile(
+			&[
+				WatchedPath::recursive("/alias1"),
+				WatchedPath::recursive("/alias2"),
+			],
+			filter([]),
+		);
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/alias1"), 1);
+		assert_eq!(watched(&backend, "/alias2"), 0);
+
+		recursor.reconcile(&[WatchedPath::recursive("/alias2")], filter([]));
+		assert!(run_until_rebuild(&mut recursor).is_empty());
+		let replacement = Arc::new(Mutex::new(FakeBackendState::default()));
+		recursor.replace_backend(Box::new(FakeBackend(replacement.clone())));
+		drain(&mut recursor);
+		assert_eq!(watched(&replacement, "/alias2"), 1);
+
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.insert("/alias2/new".into(), "/real/new".into());
+		recursor.topology_create("/alias2/new".into());
+		drain(&mut recursor);
+		assert_eq!(watched(&replacement, "/alias2/new"), 1);
+	}
+
+	#[test]
+	fn canonical_identity_breaks_basic_symlink_cycle() {
+		let (mut recursor, backend, scanner) = fixture();
+		directory(&scanner, "/root");
+		scanner
+			.lock()
+			.unwrap()
+			.directories
+			.insert("/root/link".into(), "/root".into());
+		entries(&scanner, "/root", &["/root/link"]);
+		entries(&scanner, "/root/link", &["/root/link"]);
+
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/root"), 1);
+		assert_eq!(watched(&backend, "/root/link"), 0);
+		assert!(!scanner
+			.lock()
+			.unwrap()
+			.operations
+			.contains(&Operation::Scan("/root/link".into())));
+	}
+}

--- a/crates/lib/src/sources/fs/recursor.rs
+++ b/crates/lib/src/sources/fs/recursor.rs
@@ -272,6 +272,12 @@ impl Recursor {
 		)
 	}
 
+	const fn retains_nondirectory_root_guard(&self) -> bool {
+		// Inotify file watches follow an inode across renames, so keep the parent
+		// watched to observe replacements installed at the configured path.
+		matches!(self.backend_kind, notify::WatcherKind::Inotify)
+	}
+
 	pub(super) fn needs_retry(&self) -> bool {
 		!self.retry_roots.is_empty()
 			|| !self.retry_candidates.is_empty()
@@ -991,9 +997,12 @@ impl Recursor {
 		if !tombstoned {
 			match self.classify_explicit_root(&root.path) {
 				Ok(ExplicitRootState::Entry(entry)) => {
-					if !self.retains_directory_root_guard()
-						|| !matches!(entry, EntryKind::Directory(_))
-					{
+					let retain_guard = match entry {
+						EntryKind::Directory(_) => self.retains_directory_root_guard(),
+						EntryKind::Other => self.retains_nondirectory_root_guard(),
+						EntryKind::NonFollowedSymlink => false,
+					};
+					if !retain_guard {
 						self.remove_root_guard(&root, result);
 					}
 					self.work.push_front(Work::Root(root));
@@ -1295,9 +1304,11 @@ impl Recursor {
 				root.recursive,
 				self.retains_directory_root_guard(),
 			),
-			Ok(ExplicitRootState::Entry(EntryKind::Other)) => {
-				(Identity::Lexical(root.path.clone()), false, false)
-			}
+			Ok(ExplicitRootState::Entry(EntryKind::Other)) => (
+				Identity::Lexical(root.path.clone()),
+				false,
+				self.retains_nondirectory_root_guard(),
+			),
 			Ok(
 				ExplicitRootState::Entry(EntryKind::NonFollowedSymlink) | ExplicitRootState::Unsafe,
 			) => {
@@ -2888,6 +2899,24 @@ mod tests {
 			Identity::Canonical("/identity/b".into())
 		);
 		assert!(recursor.root_guards.is_empty());
+	}
+
+	#[test]
+	fn from_only_atomic_file_root_exchange_reacquires_without_create() {
+		let (mut recursor, backend, _scanner) = fixture();
+		recursor.reconcile(&[WatchedPath::recursive("/file")], filter([]));
+		drain(&mut recursor);
+
+		recursor.topology_remove("/file".into());
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/file"), 2);
+		assert!(recursor.logical.contains_key(Path::new("/file")));
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/"))
+		);
+		assert_eq!(watched(&backend, "/"), 1);
 	}
 
 	#[test]

--- a/crates/lib/src/sources/fs/recursor.rs
+++ b/crates/lib/src/sources/fs/recursor.rs
@@ -263,6 +263,15 @@ impl Recursor {
 		managed_backend(self.backend_kind)
 	}
 
+	const fn retains_directory_root_guard(&self) -> bool {
+		// ReadDirectoryChangesW reports changes beneath a watched directory, but not
+		// removal of the watched directory itself.
+		matches!(
+			self.backend_kind,
+			notify::WatcherKind::ReadDirectoryChangesWatcher
+		)
+	}
+
 	pub(super) fn needs_retry(&self) -> bool {
 		!self.retry_roots.is_empty()
 			|| !self.retry_candidates.is_empty()
@@ -981,8 +990,12 @@ impl Recursor {
 			.any(|prefix| root.path.starts_with(prefix));
 		if !tombstoned {
 			match self.classify_explicit_root(&root.path) {
-				Ok(ExplicitRootState::Entry(_)) => {
-					self.remove_root_guard(&root, result);
+				Ok(ExplicitRootState::Entry(entry)) => {
+					if !self.retains_directory_root_guard()
+						|| !matches!(entry, EntryKind::Directory(_))
+					{
+						self.remove_root_guard(&root, result);
+					}
 					self.work.push_front(Work::Root(root));
 					return;
 				}
@@ -1276,12 +1289,14 @@ impl Recursor {
 			return;
 		}
 
-		let (identity, scan) = match self.classify_explicit_root(&root.path) {
-			Ok(ExplicitRootState::Entry(EntryKind::Directory(identity))) => {
-				(Identity::Canonical(identity), root.recursive)
-			}
+		let (identity, scan, retain_guard) = match self.classify_explicit_root(&root.path) {
+			Ok(ExplicitRootState::Entry(EntryKind::Directory(identity))) => (
+				Identity::Canonical(identity),
+				root.recursive,
+				self.retains_directory_root_guard(),
+			),
 			Ok(ExplicitRootState::Entry(EntryKind::Other)) => {
-				(Identity::Lexical(root.path.clone()), false)
+				(Identity::Lexical(root.path.clone()), false, false)
 			}
 			Ok(
 				ExplicitRootState::Entry(EntryKind::NonFollowedSymlink) | ExplicitRootState::Unsafe,
@@ -1323,7 +1338,13 @@ impl Recursor {
 		) {
 			AddResult::Added => {
 				self.retry_roots.remove(&root);
-				self.remove_root_guard(&root, result);
+				if retain_guard {
+					if !self.root_guards.contains_key(&root) {
+						self.ensure_guard(root.clone(), result);
+					}
+				} else {
+					self.remove_root_guard(&root, result);
+				}
 				if scan && self.mark_seen(&root, identity) {
 					let path = root.path.clone();
 					self.work.push_back(Work::Scan {
@@ -2154,6 +2175,16 @@ mod tests {
 		Arc<Mutex<FakeBackendState>>,
 		Arc<Mutex<FakeScannerState>>,
 	) {
+		fixture_with_backend_kind(notify::WatcherKind::Inotify)
+	}
+
+	fn fixture_with_backend_kind(
+		backend_kind: notify::WatcherKind,
+	) -> (
+		Recursor,
+		Arc<Mutex<FakeBackendState>>,
+		Arc<Mutex<FakeScannerState>>,
+	) {
 		let backend = Arc::new(Mutex::new(FakeBackendState::default()));
 		let scanner = Arc::new(Mutex::new(FakeScannerState::default()));
 		directory(&scanner, "/");
@@ -2161,7 +2192,7 @@ mod tests {
 			Box::new(FakeBackend(backend.clone())),
 			Box::new(FakeScanner(scanner.clone())),
 			Watcher::Native,
-			notify::WatcherKind::Inotify,
+			backend_kind,
 			true,
 			PathBuf::from("/work"),
 			filter([]),
@@ -2771,6 +2802,39 @@ mod tests {
 		assert!(errors.is_empty());
 		assert!(!recursor.logical.contains_key(Path::new("/root/gone")));
 		assert_eq!(unwatched(&backend, "/root/gone"), 1);
+	}
+
+	#[test]
+	fn windows_directory_root_keeps_parent_guard_after_recreation() {
+		let (mut recursor, backend, scanner) =
+			fixture_with_backend_kind(notify::WatcherKind::ReadDirectoryChangesWatcher);
+		directory(&scanner, "/root");
+		recursor.reconcile(&[WatchedPath::recursive("/root")], filter([]));
+		drain(&mut recursor);
+
+		assert_eq!(watched(&backend, "/"), 1);
+		assert_eq!(watched(&backend, "/root"), 1);
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/"))
+		);
+
+		scanner.lock().unwrap().not_found.insert("/root".into());
+		recursor.topology_remove("/root".into());
+		drain(&mut recursor);
+		assert!(!recursor.logical.contains_key(Path::new("/root")));
+		assert_eq!(unwatched(&backend, "/"), 0);
+
+		scanner.lock().unwrap().not_found.remove(Path::new("/root"));
+		recursor.topology_create("/root".into());
+		drain(&mut recursor);
+		assert_eq!(watched(&backend, "/root"), 2);
+		assert!(recursor.logical.contains_key(Path::new("/root")));
+		assert_eq!(
+			recursor.root_guards.values().next(),
+			Some(&PathBuf::from("/"))
+		);
+		assert_eq!(watched(&backend, "/"), 1);
 	}
 
 	#[test]

--- a/crates/lib/src/watched_path.rs
+++ b/crates/lib/src/watched_path.rs
@@ -65,6 +65,8 @@ impl AsRef<Path> for WatchedPath {
 
 impl WatchedPath {
 	/// Create a new watched path, recursively descending into subdirectories.
+	///
+	/// Descendant directories are subject to [`Filterer::check_dir`](crate::filter::Filterer::check_dir).
 	pub fn recursive(path: impl Into<PathBuf>) -> Self {
 		Self {
 			path: path.into(),

--- a/crates/lib/tests/fs_worker_real.rs
+++ b/crates/lib/tests/fs_worker_real.rs
@@ -160,6 +160,10 @@ impl FsHarness {
 		while self.events.try_recv().is_ok() {}
 	}
 
+	async fn drain_until_quiet(&self) {
+		while matches!(timeout(QUIET_TIMEOUT, self.events.recv()).await, Ok(Ok(_))) {}
+	}
+
 	fn task_finished(&self) -> bool {
 		self.task.as_ref().map_or(true, JoinHandle::is_finished)
 	}
@@ -308,6 +312,17 @@ fn event_is_remove(event: &Event) -> bool {
 		.any(|tag| matches!(tag, Tag::FileEventKind(EventKind::Remove(_))))
 }
 
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+fn event_is_non_name_modify(event: &Event) -> bool {
+	event.tags.iter().any(|tag| {
+		matches!(
+			tag,
+			Tag::FileEventKind(EventKind::Modify(kind))
+				if !matches!(kind, notify::event::ModifyKind::Name(_))
+		)
+	})
+}
+
 fn make_tempdir(case: WatcherCase, test: &str) -> TempDir {
 	tempfile::Builder::new()
 		.prefix(&format!("watchexec-fs-{test}-{}-", case.name))
@@ -323,6 +338,21 @@ fn create_dir(path: &Path) {
 fn write_file(path: &Path, contents: &str) {
 	std::fs::write(path, contents)
 		.unwrap_or_else(|error| panic!("failed to write file {}: {error}", path.display()));
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+fn replace_file(path: &Path, replacement: &Path, contents: &str) {
+	write_file(replacement, contents);
+	#[cfg(target_os = "windows")]
+	std::fs::remove_file(path)
+		.unwrap_or_else(|error| panic!("failed to remove file {}: {error}", path.display()));
+	std::fs::rename(replacement, path).unwrap_or_else(|error| {
+		panic!(
+			"failed to replace {} with {}: {error}",
+			path.display(),
+			replacement.display()
+		)
+	});
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -560,6 +590,44 @@ async fn configured_root_is_reacquired_after_delete_and_recreate() {
 			.await;
 		harness.shutdown().await;
 	}
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_file_root_survives_repeated_replacement() {
+	let case = WatcherCase {
+		name: "native",
+		watcher: Watcher::Native,
+	};
+	let temp = make_tempdir(case, "replace-file-root");
+	let file = temp.path().join("watched.txt");
+	write_file(&file, "initial");
+	let mut harness = FsHarness::start(case, vec![WatchedPath::recursive(&file)], true, ()).await;
+	harness.drain_until_quiet().await;
+
+	for generation in 1..=2 {
+		let replacement = temp.path().join(format!("replacement-{generation}.txt"));
+		replace_file(&file, &replacement, &format!("replacement {generation}"));
+		harness
+			.wait_for_any_path(
+				std::slice::from_ref(&file),
+				&format!("observing atomic replacement {generation}"),
+			)
+			.await;
+		harness.drain_until_quiet().await;
+
+		write_file(&file, &format!("modified replacement {generation}"));
+		harness
+			.wait_for_any_path_matching(
+				std::slice::from_ref(&file),
+				event_is_non_name_modify,
+				&format!("checking replacement {generation} remains watched"),
+			)
+			.await;
+		harness.drain_until_quiet().await;
+	}
+
+	harness.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/lib/tests/fs_worker_real.rs
+++ b/crates/lib/tests/fs_worker_real.rs
@@ -746,11 +746,11 @@ fn assert_linux_inotify_registration(root: &Path, directory: &Path, expected: bo
 
 #[cfg(target_os = "linux")]
 const fn linux_fdinfo_device(device: u64) -> u64 {
-	// Linux fdinfo prints sb->s_dev through new_encode_dev(), while MetadataExt
-	// exposes dev_t. Decode with libc, then apply the kernel's fdinfo encoding.
+	// Linux fdinfo prints the kernel's internal dev_t layout, while MetadataExt
+	// exposes the userspace layout. Decode with libc, then rebuild the kernel value.
 	let major = libc::major(device) as u64;
 	let minor = libc::minor(device) as u64;
-	(minor & 0xff) | (major << 8) | ((minor & !0xff) << 12)
+	(major << 20) | minor
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/lib/tests/fs_worker_real.rs
+++ b/crates/lib/tests/fs_worker_real.rs
@@ -596,8 +596,10 @@ async fn follow_symlinks_controls_watching_external_directory_targets() {
 
 	for case in managed_watcher_cases() {
 		let temp = make_tempdir(case, "symlinks");
-		let root = temp.path().join("root");
-		let target = temp.path().join("target");
+		let temp_path = std::fs::canonicalize(temp.path())
+			.unwrap_or_else(|error| panic!("failed to canonicalize temporary directory: {error}"));
+		let root = temp_path.join("root");
+		let target = temp_path.join("target");
 		let link = root.join("link");
 		create_dir(&root);
 		create_dir(&target);

--- a/crates/lib/tests/fs_worker_real.rs
+++ b/crates/lib/tests/fs_worker_real.rs
@@ -1,0 +1,807 @@
+use std::{
+	path::{Path, PathBuf},
+	sync::Arc,
+	time::Duration,
+};
+
+#[cfg(target_os = "linux")]
+use std::fmt;
+
+use async_priority_channel as priority;
+use notify::EventKind;
+use tempfile::TempDir;
+use tokio::{
+	sync::{mpsc, watch},
+	task::JoinHandle,
+	time::{timeout, Instant},
+};
+#[cfg(unix)]
+use watchexec::error::FsWatcherError;
+use watchexec::{
+	error::{CriticalError, RuntimeError},
+	filter::Filterer,
+	sources::fs::{worker, Watcher},
+	Config, WatchedPath,
+};
+use watchexec_events::{Event, Priority, Tag};
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+const QUIET_TIMEOUT: Duration = Duration::from_millis(300);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Clone, Copy, Debug)]
+struct WatcherCase {
+	name: &'static str,
+	watcher: Watcher,
+}
+
+fn managed_watcher_cases() -> Vec<WatcherCase> {
+	let poll = WatcherCase {
+		name: "poll",
+		watcher: Watcher::Poll(POLL_INTERVAL),
+	};
+
+	// These native backends have independent non-recursive registrations and
+	// therefore use watchexec's source-filtering recursor.
+	#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+	{
+		vec![
+			WatcherCase {
+				name: "native",
+				watcher: Watcher::Native,
+			},
+			poll,
+		]
+	}
+
+	#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "windows")))]
+	{
+		vec![poll]
+	}
+}
+
+#[derive(Clone, Debug, Default)]
+struct DirFilter {
+	denied: Vec<PathBuf>,
+}
+
+impl DirFilter {
+	fn denying(paths: impl IntoIterator<Item = PathBuf>) -> Self {
+		Self {
+			denied: paths.into_iter().collect(),
+		}
+	}
+}
+
+impl Filterer for DirFilter {
+	fn check_dir(&self, path: &Path) -> Result<bool, RuntimeError> {
+		Ok(!self
+			.denied
+			.iter()
+			.any(|denied| path == denied || path.starts_with(denied)))
+	}
+
+	fn check_event(&self, _event: &Event, _priority: Priority) -> Result<bool, RuntimeError> {
+		Ok(true)
+	}
+}
+
+struct FsHarness {
+	case: WatcherCase,
+	config: Arc<Config>,
+	ready: watch::Receiver<()>,
+	events: priority::Receiver<Event, Priority>,
+	errors: mpsc::Receiver<RuntimeError>,
+	task: Option<JoinHandle<Result<(), CriticalError>>>,
+}
+
+impl FsHarness {
+	async fn start(
+		case: WatcherCase,
+		paths: Vec<WatchedPath>,
+		follow_symlinks: bool,
+		filterer: impl Filterer + 'static,
+	) -> Self {
+		let config = Arc::new(Config::default());
+		config.file_watcher(case.watcher);
+		config.follow_symlinks(follow_symlinks);
+		config.filterer(filterer);
+		config.pathset(paths);
+
+		// Subscribe after configuring but before spawning: the worker has not yet
+		// emitted the initial readiness notification, so it cannot be missed.
+		let ready = config.fs_ready();
+		let event_capacity =
+			u64::try_from(config.event_channel_size).expect("event channel size does not fit u64");
+		let (event_tx, events) = priority::bounded(event_capacity);
+		let (error_tx, errors) = mpsc::channel(config.error_channel_size);
+		let task = tokio::spawn(worker(config.clone(), error_tx, event_tx));
+
+		let mut harness = Self {
+			case,
+			config,
+			ready,
+			events,
+			errors,
+			task: Some(task),
+		};
+		harness.wait_ready("initial filesystem configuration").await;
+		harness
+	}
+
+	async fn wait_ready(&mut self, operation: &str) {
+		match timeout(TEST_TIMEOUT, self.ready.changed()).await {
+			Ok(Ok(())) => {}
+			Ok(Err(error)) => panic!(
+				"{} watcher readiness channel closed while waiting for {operation}: {error}",
+				self.case.name
+			),
+			Err(elapsed) => panic!(
+				"{} watcher did not become ready within {TEST_TIMEOUT:?} while waiting for {operation}: {elapsed}; worker_finished={}",
+				self.case.name,
+				self.task_finished()
+			),
+		}
+	}
+
+	async fn set_paths(&mut self, paths: Vec<WatchedPath>) {
+		self.config.pathset(paths);
+		self.wait_ready("pathset replacement").await;
+		self.drain_events();
+	}
+
+	async fn set_filterer(&mut self, filterer: impl Filterer + 'static) {
+		self.config.filterer(filterer);
+		self.wait_ready("filterer replacement").await;
+		self.drain_events();
+	}
+
+	fn drain_events(&self) {
+		while self.events.try_recv().is_ok() {}
+	}
+
+	fn task_finished(&self) -> bool {
+		self.task.as_ref().map_or(true, JoinHandle::is_finished)
+	}
+
+	fn take_available_errors(&mut self) -> Vec<String> {
+		let mut errors = Vec::new();
+		while let Ok(error) = self.errors.try_recv() {
+			errors.push(format!("{error:?}"));
+		}
+		errors
+	}
+
+	async fn wait_for_any_path(&mut self, expected: &[PathBuf], operation: &str) -> Event {
+		self.wait_for_any_path_matching(expected, |_| true, operation)
+			.await
+	}
+
+	async fn wait_for_any_path_matching(
+		&mut self,
+		expected: &[PathBuf],
+		matches_event: impl Fn(&Event) -> bool,
+		operation: &str,
+	) -> Event {
+		let deadline = Instant::now() + TEST_TIMEOUT;
+		let mut observed = Vec::new();
+
+		loop {
+			let now = Instant::now();
+			if now >= deadline {
+				let errors = self.take_available_errors();
+				panic!(
+					"{} watcher did not report a matching event for any of {expected:?} while {operation}; observed={observed:?}; runtime_errors={errors:?}; worker_finished={}",
+					self.case.name,
+					self.task_finished()
+				);
+			}
+
+			match timeout(deadline.saturating_duration_since(now), self.events.recv()).await {
+				Ok(Ok((event, _priority))) => {
+					let paths = event_paths(&event);
+					if matches_event(&event) && paths.iter().any(|path| expected.contains(path)) {
+						return event;
+					}
+					observed.push(format!("{event:?}"));
+				}
+				Ok(Err(error)) => panic!(
+					"{} watcher event channel closed while {operation}: {error:?}",
+					self.case.name
+				),
+				Err(_) => {
+					let errors = self.take_available_errors();
+					panic!(
+						"{} watcher timed out while {operation}; expected={expected:?}; observed={observed:?}; runtime_errors={errors:?}; worker_finished={}",
+						self.case.name,
+						self.task_finished()
+					);
+				}
+			}
+		}
+	}
+
+	async fn assert_no_path_under(&self, forbidden: &[PathBuf], operation: &str) {
+		let deadline = Instant::now() + QUIET_TIMEOUT;
+		let mut observed = Vec::new();
+
+		loop {
+			let now = Instant::now();
+			if now >= deadline {
+				return;
+			}
+
+			match timeout(deadline.saturating_duration_since(now), self.events.recv()).await {
+				Ok(Ok((event, _priority))) => {
+					let paths = event_paths(&event);
+					// A watched parent can report the forbidden directory itself even
+					// when no watch is installed inside that directory.
+					assert!(
+						!paths.iter().any(|path| {
+							forbidden
+								.iter()
+								.any(|prefix| path != prefix && path.starts_with(prefix))
+						}),
+						"{} watcher unexpectedly reported a path under {forbidden:?} while {operation}: event_paths={paths:?}; previously_observed={observed:?}",
+						self.case.name
+					);
+					observed.push(paths);
+				}
+				Ok(Err(error)) => panic!(
+					"{} watcher event channel closed while checking {operation}: {error:?}",
+					self.case.name
+				),
+				Err(_) => return,
+			}
+		}
+	}
+
+	async fn shutdown(mut self) {
+		let task = self.task.take().expect("filesystem worker task missing");
+		if task.is_finished() {
+			match task.await {
+				Ok(Ok(())) => panic!("{} filesystem worker exited unexpectedly", self.case.name),
+				Ok(Err(error)) => panic!(
+					"{} filesystem worker failed unexpectedly: {error:?}",
+					self.case.name
+				),
+				Err(error) => panic!(
+					"{} filesystem worker task failed unexpectedly: {error:?}",
+					self.case.name
+				),
+			}
+		} else {
+			task.abort();
+			let result = task.await;
+			assert!(
+				matches!(result, Err(ref error) if error.is_cancelled()),
+				"{} filesystem worker did not cancel cleanly: {result:?}",
+				self.case.name
+			);
+		}
+	}
+}
+
+impl Drop for FsHarness {
+	fn drop(&mut self) {
+		if let Some(task) = self.task.take() {
+			task.abort();
+		}
+	}
+}
+
+fn event_paths(event: &Event) -> Vec<PathBuf> {
+	event.paths().map(|(path, _)| path.to_owned()).collect()
+}
+
+fn event_is_create(event: &Event) -> bool {
+	event
+		.tags
+		.iter()
+		.any(|tag| matches!(tag, Tag::FileEventKind(EventKind::Create(_))))
+}
+
+fn event_is_remove(event: &Event) -> bool {
+	event
+		.tags
+		.iter()
+		.any(|tag| matches!(tag, Tag::FileEventKind(EventKind::Remove(_))))
+}
+
+fn make_tempdir(case: WatcherCase, test: &str) -> TempDir {
+	tempfile::Builder::new()
+		.prefix(&format!("watchexec-fs-{test}-{}-", case.name))
+		.tempdir()
+		.unwrap_or_else(|error| panic!("failed to create temporary directory: {error}"))
+}
+
+fn create_dir(path: &Path) {
+	std::fs::create_dir_all(path)
+		.unwrap_or_else(|error| panic!("failed to create directory {}: {error}", path.display()));
+}
+
+fn write_file(path: &Path, contents: &str) {
+	std::fs::write(path, contents)
+		.unwrap_or_else(|error| panic!("failed to write file {}: {error}", path.display()));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recursive_filter_physically_prunes_ignored_subtree() {
+	for case in managed_watcher_cases() {
+		let temp = make_tempdir(case, "prune");
+		let root = temp.path().join("root");
+		let accepted = root.join("src");
+		let accepted_nested = accepted.join("nested");
+		let ignored = root.join("target");
+		let ignored_nested = ignored.join("nested");
+		create_dir(&accepted_nested);
+		create_dir(&ignored_nested);
+
+		let mut harness = FsHarness::start(
+			case,
+			vec![WatchedPath::recursive(&root)],
+			true,
+			DirFilter::denying([ignored.clone()]),
+		)
+		.await;
+
+		#[cfg(target_os = "linux")]
+		if case.watcher == Watcher::Native {
+			assert_linux_inotify_registration(&root, &accepted, true);
+			assert_linux_inotify_registration(&root, &accepted_nested, true);
+			assert_linux_inotify_registration(&root, &ignored, false);
+			assert_linux_inotify_registration(&root, &ignored_nested, false);
+		}
+
+		let ignored_file = ignored_nested.join("ignored.txt");
+		let accepted_file = accepted_nested.join("accepted.txt");
+		write_file(&ignored_file, "ignored");
+		write_file(&accepted_file, "accepted");
+		harness
+			.wait_for_any_path(&[accepted_file], "waiting for an accepted sibling change")
+			.await;
+		harness
+			.assert_no_path_under(&[ignored], "checking the source-pruned subtree")
+			.await;
+		harness.shutdown().await;
+	}
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn directories_created_or_moved_in_after_readiness_are_covered() {
+	for case in managed_watcher_cases() {
+		let temp = make_tempdir(case, "new-tree");
+		let root = temp.path().join("root");
+		create_dir(&root);
+		let mut harness =
+			FsHarness::start(case, vec![WatchedPath::recursive(&root)], true, ()).await;
+
+		let new_tree = root.join("created-after-ready");
+		let new_deep = new_tree.join("one/two");
+		let seed = new_deep.join("seed.txt");
+		create_dir(&new_deep);
+		write_file(&seed, "already populated");
+		harness
+			.wait_for_any_path(
+				&[new_tree.clone(), new_deep.clone(), seed],
+				"discovering a newly populated directory",
+			)
+			.await;
+
+		let probe = new_deep.join("probe.txt");
+		write_file(&probe, "probe");
+		harness
+			.wait_for_any_path(&[probe], "checking the newly discovered deep directory")
+			.await;
+
+		#[cfg(not(target_os = "windows"))]
+		{
+			let staging = temp.path().join("staging");
+			let staging_deep = staging.join("full/subtree");
+			create_dir(&staging_deep);
+			write_file(&staging_deep.join("seed.txt"), "moved seed");
+			let moved = root.join("moved-in");
+			std::fs::rename(&staging, &moved).unwrap_or_else(|error| {
+				panic!("failed to move populated directory {staging:?} to {moved:?}: {error}")
+			});
+			let moved_deep = moved.join("full/subtree");
+			harness
+				.wait_for_any_path(
+					&[
+						moved.clone(),
+						moved_deep.clone(),
+						moved_deep.join("seed.txt"),
+					],
+					"discovering a moved-in populated directory",
+				)
+				.await;
+
+			let moved_probe = moved_deep.join("probe.txt");
+			write_file(&moved_probe, "probe");
+			harness
+				.wait_for_any_path(&[moved_probe], "checking the moved-in deep directory")
+				.await;
+		}
+
+		harness.shutdown().await;
+	}
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replacing_filterer_live_prunes_and_discovers_existing_subtrees() {
+	for case in managed_watcher_cases() {
+		let temp = make_tempdir(case, "replace-filter");
+		let root = temp.path().join("root");
+		let initially_allowed = root.join("old");
+		let newly_allowed = root.join("new");
+		create_dir(&initially_allowed);
+		create_dir(&newly_allowed);
+
+		let initial_filter = Arc::new(DirFilter::denying([newly_allowed.clone()]));
+		let mut harness = FsHarness::start(
+			case,
+			vec![WatchedPath::recursive(&root)],
+			true,
+			initial_filter,
+		)
+		.await;
+
+		let initially_ignored = newly_allowed.join("before.txt");
+		let initially_seen = initially_allowed.join("before.txt");
+		write_file(&initially_ignored, "ignored before replacement");
+		write_file(&initially_seen, "seen before replacement");
+		harness
+			.wait_for_any_path(&[initially_seen], "checking the initial filterer")
+			.await;
+		harness
+			.assert_no_path_under(
+				std::slice::from_ref(&newly_allowed),
+				"checking the initially denied subtree",
+			)
+			.await;
+
+		let replacement = Arc::new(DirFilter::denying([initially_allowed.clone()]));
+		harness.set_filterer(replacement).await;
+
+		#[cfg(target_os = "linux")]
+		if case.watcher == Watcher::Native {
+			assert_linux_inotify_registration(&root, &initially_allowed, false);
+			assert_linux_inotify_registration(&root, &newly_allowed, true);
+		}
+
+		let newly_ignored = initially_allowed.join("after.txt");
+		let newly_seen = newly_allowed.join("after.txt");
+		write_file(&newly_ignored, "ignored after replacement");
+		write_file(&newly_seen, "seen after replacement");
+		harness
+			.wait_for_any_path(&[newly_seen], "checking the replacement filterer")
+			.await;
+		harness
+			.assert_no_path_under(&[initially_allowed], "checking the live-pruned subtree")
+			.await;
+		harness.shutdown().await;
+	}
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn removing_overlapping_parent_root_keeps_explicit_child_root_active() {
+	for case in managed_watcher_cases() {
+		let temp = make_tempdir(case, "overlap");
+		let outer = temp.path().join("outer");
+		let child = outer.join("shared-child");
+		let sibling = outer.join("parent-only");
+		create_dir(&child);
+		create_dir(&sibling);
+
+		let mut harness = FsHarness::start(
+			case,
+			vec![
+				WatchedPath::recursive(&outer),
+				WatchedPath::recursive(&child),
+			],
+			true,
+			(),
+		)
+		.await;
+		harness
+			.set_paths(vec![WatchedPath::recursive(&child)])
+			.await;
+
+		let outside_remaining_root = sibling.join("ignored.txt");
+		let inside_remaining_root = child.join("seen.txt");
+		write_file(&outside_remaining_root, "outside");
+		write_file(&inside_remaining_root, "inside");
+		harness
+			.wait_for_any_path(&[inside_remaining_root], "checking the retained child root")
+			.await;
+		harness
+			.assert_no_path_under(&[sibling], "checking the removed parent root")
+			.await;
+		harness.shutdown().await;
+	}
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn configured_root_is_reacquired_after_delete_and_recreate() {
+	for case in managed_watcher_cases() {
+		let temp = make_tempdir(case, "recreate-root");
+		let root = temp.path().join("configured-root");
+		create_dir(&root.join("old"));
+		let mut harness =
+			FsHarness::start(case, vec![WatchedPath::recursive(&root)], true, ()).await;
+
+		std::fs::remove_dir_all(&root)
+			.unwrap_or_else(|error| panic!("failed to remove configured root {root:?}: {error}"));
+		harness
+			.wait_for_any_path_matching(
+				std::slice::from_ref(&root),
+				event_is_remove,
+				"observing configured root deletion",
+			)
+			.await;
+		harness.drain_events();
+
+		let recreated_deep = root.join("new/deep");
+		let seed = recreated_deep.join("seed.txt");
+		create_dir(&recreated_deep);
+		write_file(&seed, "already populated");
+		harness
+			.wait_for_any_path_matching(
+				&[root.clone(), recreated_deep.clone(), seed],
+				event_is_create,
+				"observing configured root recreation",
+			)
+			.await;
+
+		let probe = recreated_deep.join("probe.txt");
+		write_file(&probe, "probe");
+		harness
+			.wait_for_any_path(&[probe], "checking the reacquired configured root")
+			.await;
+		harness.shutdown().await;
+	}
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_nonrecursive_root_does_not_report_grandchildren() {
+	for case in managed_watcher_cases() {
+		let temp = make_tempdir(case, "nonrecursive");
+		let root = temp.path().join("root");
+		let child = root.join("child");
+		create_dir(&child);
+		let mut harness =
+			FsHarness::start(case, vec![WatchedPath::non_recursive(&root)], true, ()).await;
+
+		let grandchild = child.join("grandchild.txt");
+		let direct = root.join("direct.txt");
+		write_file(&grandchild, "must not be observed");
+		write_file(&direct, "must be observed");
+		harness
+			.wait_for_any_path(&[direct], "checking a direct child of a nonrecursive root")
+			.await;
+		harness
+			.assert_no_path_under(
+				&[grandchild],
+				"checking a grandchild of a nonrecursive root",
+			)
+			.await;
+		harness.shutdown().await;
+	}
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn follow_symlinks_controls_watching_external_directory_targets() {
+	use std::os::unix::fs::symlink;
+
+	for case in managed_watcher_cases() {
+		let temp = make_tempdir(case, "symlinks");
+		let root = temp.path().join("root");
+		let target = temp.path().join("target");
+		let link = root.join("link");
+		create_dir(&root);
+		create_dir(&target);
+		symlink(&target, &link)
+			.unwrap_or_else(|error| panic!("failed to symlink {link:?} to {target:?}: {error}"));
+
+		let mut no_follow =
+			FsHarness::start(case, vec![WatchedPath::recursive(&root)], false, ()).await;
+		let unseen_target_file = target.join("not-followed.txt");
+		let direct = root.join("direct.txt");
+		write_file(&unseen_target_file, "target change");
+		write_file(&direct, "synchronising accepted change");
+		no_follow
+			.wait_for_any_path(&[direct], "checking follow_symlinks=false")
+			.await;
+		no_follow
+			.assert_no_path_under(
+				&[target.clone(), link.clone()],
+				"checking that a symlink target is not followed",
+			)
+			.await;
+		no_follow.shutdown().await;
+
+		let mut follow =
+			FsHarness::start(case, vec![WatchedPath::recursive(&root)], true, ()).await;
+		let target_file = target.join("followed.txt");
+		let link_file = link.join("followed.txt");
+		write_file(&target_file, "target change");
+		follow
+			.wait_for_any_path(&[target_file, link_file], "checking follow_symlinks=true")
+			.await;
+		follow.shutdown().await;
+	}
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn path_local_scan_error_is_reported_without_stopping_worker() {
+	use std::os::unix::fs::symlink;
+
+	for case in managed_watcher_cases() {
+		let temp = make_tempdir(case, "runtime-error");
+		let root = temp.path().join("root");
+		let accepted = root.join("accepted");
+		let loop_link = root.join("loop");
+		create_dir(&accepted);
+		symlink("loop", &loop_link)
+			.unwrap_or_else(|error| panic!("failed to create symlink loop {loop_link:?}: {error}"));
+
+		let mut harness =
+			FsHarness::start(case, vec![WatchedPath::recursive(&root)], true, ()).await;
+		let mut observed_errors = Vec::new();
+		let error = timeout(TEST_TIMEOUT, async {
+			loop {
+				match harness.errors.recv().await {
+					Some(error) => {
+						let is_expected = matches!(
+							&error,
+							RuntimeError::FsWatcher {
+								kind,
+								err: FsWatcherError::PathScan { path, .. },
+							} if *kind == case.watcher && path == &loop_link
+						);
+						if is_expected {
+							break error;
+						}
+						observed_errors.push(format!("{error:?}"));
+					}
+					None => panic!("{} runtime-error channel closed", case.name),
+				}
+			}
+		})
+		.await
+		.unwrap_or_else(|_| {
+			panic!(
+				"{} watcher did not deliver the path-local scan error for {loop_link:?}; observed={observed_errors:?}; worker_finished={}",
+				case.name,
+				harness.task_finished()
+			)
+		});
+		assert!(
+			matches!(error, RuntimeError::FsWatcher { .. }),
+			"expected a filesystem runtime error, got {error:?}"
+		);
+
+		let accepted_file = accepted.join("still-alive.txt");
+		write_file(&accepted_file, "worker remains active");
+		harness
+			.wait_for_any_path(
+				&[accepted_file],
+				"checking progress after a path-local error",
+			)
+			.await;
+		harness.shutdown().await;
+	}
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct FsIdentity {
+	device: u64,
+	inode: u64,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+struct InotifyRegistration {
+	fd: String,
+	identity: FsIdentity,
+	line: String,
+}
+
+#[cfg(target_os = "linux")]
+fn assert_linux_inotify_registration(root: &Path, directory: &Path, expected: bool) {
+	use std::os::unix::fs::MetadataExt;
+
+	assert!(
+		directory.starts_with(root),
+		"physical source-filter proof requires {} to be inside recursive root {}",
+		directory.display(),
+		root.display()
+	);
+	let metadata = std::fs::metadata(directory)
+		.unwrap_or_else(|error| panic!("failed to stat {}: {error}", directory.display()));
+	assert!(
+		metadata.is_dir(),
+		"expected {} to be a directory",
+		directory.display()
+	);
+	let identity = FsIdentity {
+		device: linux_fdinfo_device(metadata.dev()),
+		inode: metadata.ino(),
+	};
+	let registrations = linux_inotify_registrations();
+	let found = registrations
+		.iter()
+		.any(|registration| registration.identity == identity);
+	assert_eq!(
+		found,
+		expected,
+		"unexpected inotify registration state for {} ({identity:?}); all process registrations:\n{}",
+		directory.display(),
+		RegistrationList(&registrations)
+	);
+}
+
+#[cfg(target_os = "linux")]
+const fn linux_fdinfo_device(device: u64) -> u64 {
+	// Linux fdinfo prints sb->s_dev through new_encode_dev(), while MetadataExt
+	// exposes dev_t. Decode with libc, then apply the kernel's fdinfo encoding.
+	let major = libc::major(device) as u64;
+	let minor = libc::minor(device) as u64;
+	(minor & 0xff) | (major << 8) | ((minor & !0xff) << 12)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_inotify_registrations() -> Vec<InotifyRegistration> {
+	let entries = std::fs::read_dir("/proc/self/fdinfo")
+		.unwrap_or_else(|error| panic!("failed to read /proc/self/fdinfo: {error}"));
+	let mut registrations = Vec::new();
+
+	for entry in entries {
+		let entry = entry.unwrap_or_else(|error| panic!("failed to read fdinfo entry: {error}"));
+		let contents = match std::fs::read_to_string(entry.path()) {
+			Ok(contents) => contents,
+			Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+			Err(error) => panic!("failed to read {}: {error}", entry.path().display()),
+		};
+		for line in contents.lines().filter(|line| line.starts_with("inotify ")) {
+			let mut inode = None;
+			let mut device = None;
+			for field in line.split_ascii_whitespace() {
+				if let Some(value) = field.strip_prefix("ino:") {
+					inode = u64::from_str_radix(value, 16).ok();
+				} else if let Some(value) = field.strip_prefix("sdev:") {
+					device = u64::from_str_radix(value, 16).ok();
+				}
+			}
+			if let (Some(device), Some(inode)) = (device, inode) {
+				registrations.push(InotifyRegistration {
+					fd: entry.file_name().to_string_lossy().into_owned(),
+					identity: FsIdentity { device, inode },
+					line: line.to_owned(),
+				});
+			}
+		}
+	}
+
+	registrations
+}
+
+#[cfg(target_os = "linux")]
+struct RegistrationList<'a>(&'a [InotifyRegistration]);
+
+#[cfg(target_os = "linux")]
+impl fmt::Display for RegistrationList<'_> {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		for registration in self.0 {
+			writeln!(
+				formatter,
+				"fd={} {:?}: {}",
+				registration.fd, registration.identity, registration.line
+			)?;
+		}
+		Ok(())
+	}
+}

--- a/doc/watchexec.1
+++ b/doc/watchexec.1
@@ -583,11 +583,11 @@ For more complex uses (like watching non\-recursively), use the argfile capabili
 The special value \*(Aq\-\*(Aq will read from STDIN; this in incompatible with \*(Aq\-\-stdin\-quit\*(Aq.
 .TP
 \fB\-\-no\-follow\-symlinks\fR
-Don\*(Aqt follow symlinks when watching
+Don\*(Aqt follow directory symlinks when watching
 
-By default, Watchexec will follow symbolic links when setting up filesystem watches, which means events from the symlink target are reported using the symlink path. With this option, symlinks are not followed: the symlink itself may still produce events, but its target will not be watched through the link.
+By default, Watchexec follows directory symlinks while constructing recursive watches. With this option, their targets are not included; changes to the symlinks themselves may still produce events.
 
-This can be useful when ignored paths are reachable via symlinks, or when watching a directory that contains symlinks pointing outside the project (e.g. Bazel output symlinks).
+The native macOS watcher does not follow directory symlinks outside the watched hierarchy, even without this option.
 .SH DEBUGGING
 .TP
 \fB\-\-log\-file\fR [\fI<PATH>\fR]

--- a/doc/watchexec.1
+++ b/doc/watchexec.1
@@ -363,9 +363,7 @@ The signal can be specified with the \*(Aq\-\-signal\*(Aq option.
 \fB\-\-poll\fR [\fI<INTERVAL>\fR]
 Poll for filesystem changes
 
-By default, and where available, Watchexec uses the operating system\*(Aqs native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases. It also forces physical ignore pruning on platforms whose native FSEvents or Kqueue backends retain Notify\-owned recursion.
-
-Polling registers each accepted directory separately, so work scales with directory count. Initial traversal reads one directory synchronously at a time; it yields between directories, but one exceptionally large or slow directory can still delay startup.
+By default, and where available, Watchexec uses the operating system\*(Aqs native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.
 
 Optionally takes a unit\-less value in milliseconds, or a time span value such as "2s 500ms", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit\-less value is deprecated and will warn; it will be an error in the future.
 
@@ -469,10 +467,6 @@ This may apply filtering at the kernel level when possible, which can be more ef
 Filename patterns to filter out
 
 Provide a glob\-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
-
-When the actual watcher backend is Inotify, Windows ReadDirectoryChanges, or Poll, ignore files, built\-in ignores, \*(Aq\-\-ignore\*(Aq, and \*(Aq\-\-ignore\-file\*(Aq also prune matching directories from the watched source tree. Positive filters, extension filters, filesystem event kinds, and filter programs only filter events after they are observed; they do not prune sources.
-
-Native FSEvents and Kqueue retain Notify\*(Aqs recursion, so ignores filter their events without physically pruning ignored directories. Use \*(Aq\-\-poll\*(Aq to force source pruning on those platforms. Ignore files are discovered and read once at startup; edits and newly created ignore files are not loaded while Watchexec is running.
 .TP
 \fB\-\-ignore\-file\fR \fI<PATH>\fR
 Files to load ignores from
@@ -570,16 +564,12 @@ Upon starting, Watchexec resolves a "project origin" from the watched paths. See
 
 This option can be specified multiple times to watch multiple files or directories.
 
-Every specified path is an exact watch root. The root itself is retained even if it matches an ignore rule, while descendants of a recursive directory still obey ignores. Filesystem events for the exact root also bypass CLI ignore rules.
-
 The special value \*(Aq/dev/null\*(Aq, provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
 .TP
 \fB\-W\fR, \fB\-\-watch\-non\-recursive\fR \fI<PATH>\fR
 Watch a specific directory, non\-recursively
 
 Unlike \*(Aq\-w\*(Aq, folders watched with this option are not recursed into.
-
-The exact path is retained even if it matches an ignore rule, and filesystem events for that root bypass CLI ignore rules.
 
 This option can be specified multiple times to watch multiple directories non\-recursively.
 .TP
@@ -598,8 +588,6 @@ Don\*(Aqt follow symlinks when watching
 By default, Watchexec will follow symbolic links when setting up filesystem watches, which means events from the symlink target are reported using the symlink path. With this option, symlinks are not followed: the symlink itself may still produce events, but its target will not be watched through the link.
 
 This can be useful when ignored paths are reachable via symlinks, or when watching a directory that contains symlinks pointing outside the project (e.g. Bazel output symlinks).
-
-Watchexec enforces this across every path component for Inotify, Windows ReadDirectoryChanges, and Poll. On those backends it also guards a missing root from its nearest safe existing ancestor, so the root can be watched if it appears later. Other native backends delegate symlink handling to Notify and may behave differently.
 .SH DEBUGGING
 .TP
 \fB\-\-log\-file\fR [\fI<PATH>\fR]

--- a/doc/watchexec.1
+++ b/doc/watchexec.1
@@ -363,7 +363,9 @@ The signal can be specified with the \*(Aq\-\-signal\*(Aq option.
 \fB\-\-poll\fR [\fI<INTERVAL>\fR]
 Poll for filesystem changes
 
-By default, and where available, Watchexec uses the operating system\*(Aqs native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases.
+By default, and where available, Watchexec uses the operating system\*(Aqs native file system watching capabilities. This option disables that and instead uses a polling mechanism, which is less efficient but can work around issues with some file systems (like network shares) or edge cases. It also forces physical ignore pruning on platforms whose native FSEvents or Kqueue backends retain Notify\-owned recursion.
+
+Polling registers each accepted directory separately, so work scales with directory count. Initial traversal reads one directory synchronously at a time; it yields between directories, but one exceptionally large or slow directory can still delay startup.
 
 Optionally takes a unit\-less value in milliseconds, or a time span value such as "2s 500ms", to use as the polling interval. If not specified, the default is 30 seconds. Providing a unit\-less value is deprecated and will warn; it will be an error in the future.
 
@@ -467,6 +469,10 @@ This may apply filtering at the kernel level when possible, which can be more ef
 Filename patterns to filter out
 
 Provide a glob\-like filter pattern, and events for files matching the pattern will be excluded. Multiple patterns can be given by repeating the option. Events that are not from files (e.g. signals, keyboard events) will pass through untouched.
+
+When the actual watcher backend is Inotify, Windows ReadDirectoryChanges, or Poll, ignore files, built\-in ignores, \*(Aq\-\-ignore\*(Aq, and \*(Aq\-\-ignore\-file\*(Aq also prune matching directories from the watched source tree. Positive filters, extension filters, filesystem event kinds, and filter programs only filter events after they are observed; they do not prune sources.
+
+Native FSEvents and Kqueue retain Notify\*(Aqs recursion, so ignores filter their events without physically pruning ignored directories. Use \*(Aq\-\-poll\*(Aq to force source pruning on those platforms. Ignore files are discovered and read once at startup; edits and newly created ignore files are not loaded while Watchexec is running.
 .TP
 \fB\-\-ignore\-file\fR \fI<PATH>\fR
 Files to load ignores from
@@ -564,12 +570,16 @@ Upon starting, Watchexec resolves a "project origin" from the watched paths. See
 
 This option can be specified multiple times to watch multiple files or directories.
 
+Every specified path is an exact watch root. The root itself is retained even if it matches an ignore rule, while descendants of a recursive directory still obey ignores. Filesystem events for the exact root also bypass CLI ignore rules.
+
 The special value \*(Aq/dev/null\*(Aq, provided as the only path watched, will cause Watchexec to not watch any paths. Other event sources (like signals or key events) may still be used.
 .TP
 \fB\-W\fR, \fB\-\-watch\-non\-recursive\fR \fI<PATH>\fR
 Watch a specific directory, non\-recursively
 
 Unlike \*(Aq\-w\*(Aq, folders watched with this option are not recursed into.
+
+The exact path is retained even if it matches an ignore rule, and filesystem events for that root bypass CLI ignore rules.
 
 This option can be specified multiple times to watch multiple directories non\-recursively.
 .TP
@@ -588,6 +598,8 @@ Don\*(Aqt follow symlinks when watching
 By default, Watchexec will follow symbolic links when setting up filesystem watches, which means events from the symlink target are reported using the symlink path. With this option, symlinks are not followed: the symlink itself may still produce events, but its target will not be watched through the link.
 
 This can be useful when ignored paths are reachable via symlinks, or when watching a directory that contains symlinks pointing outside the project (e.g. Bazel output symlinks).
+
+Watchexec enforces this across every path component for Inotify, Windows ReadDirectoryChanges, and Poll. On those backends it also guards a missing root from its nearest safe existing ancestor, so the root can be watched if it appears later. Other native backends delegate symlink handling to Notify and may behave differently.
 .SH DEBUGGING
 .TP
 \fB\-\-log\-file\fR [\fI<PATH>\fR]

--- a/doc/watchexec.1.md
+++ b/doc/watchexec.1.md
@@ -545,8 +545,14 @@ The signal can be specified with the \--signal option.
 By default, and where available, Watchexec uses the operating systems
 native file system watching capabilities. This option disables that and
 instead uses a polling mechanism, which is less efficient but can work
-around issues with some file systems (like network shares) or edge
-cases.
+around issues with some file systems (like network shares) or edge cases.
+It also forces physical ignore pruning on platforms whose native FSEvents
+or Kqueue backends retain Notify-owned recursion.
+
+Polling registers each accepted directory separately, so work scales with
+directory count. Initial traversal reads one directory synchronously at a
+time; it yields between directories, but one exceptionally large or slow
+directory can still delay startup.
 
 Optionally takes a unit-less value in milliseconds, or a time span value
 such as \"2s 500ms\", to use as the polling interval. If not specified,
@@ -718,6 +724,19 @@ pattern will be excluded. Multiple patterns can be given by repeating
 the option. Events that are not from files (e.g. signals, keyboard
 events) will pass through untouched.
 
+When the actual watcher backend is Inotify, Windows
+ReadDirectoryChanges, or Poll, ignore files, built-in ignores, \--ignore,
+and \--ignore-file also prune matching directories from the watched
+source tree. Positive filters, extension filters, filesystem event kinds,
+and filter programs only filter events after they are observed; they do
+not prune sources.
+
+Native FSEvents and Kqueue retain Notify's recursion, so ignores filter
+their events without physically pruning ignored directories. Use \--poll
+to force source pruning on those platforms. Ignore files are discovered
+and read once at startup; edits and newly created ignore files are not
+loaded while Watchexec is running.
+
 **\--ignore-file** *\<PATH\>*
 
 :   Files to load ignores from
@@ -857,6 +876,11 @@ paths. See the help for \--project-origin for more information.
 This option can be specified multiple times to watch multiple files or
 directories.
 
+Every specified path is an exact watch root. The root itself is retained
+even if it matches an ignore rule, while descendants of a recursive
+directory still obey ignores. Filesystem events for the exact root also
+bypass CLI ignore rules.
+
 The special value /dev/null, provided as the only path watched, will
 cause Watchexec to not watch any paths. Other event sources (like
 signals or key events) may still be used.
@@ -866,6 +890,9 @@ signals or key events) may still be used.
 :   Watch a specific directory, non-recursively
 
 Unlike -w, folders watched with this option are not recursed into.
+
+The exact path is retained even if it matches an ignore rule, and
+filesystem events for that root bypass CLI ignore rules.
 
 This option can be specified multiple times to watch multiple
 directories non-recursively.
@@ -896,6 +923,12 @@ will not be watched through the link.
 This can be useful when ignored paths are reachable via symlinks, or
 when watching a directory that contains symlinks pointing outside the
 project (e.g. Bazel output symlinks).
+
+Watchexec enforces this across every path component for Inotify, Windows
+ReadDirectoryChanges, and Poll. On those backends it also guards a
+missing root from its nearest safe existing ancestor, so the root can be
+watched if it appears later. Other native backends delegate symlink
+handling to Notify and may behave differently.
 
 # DEBUGGING
 

--- a/doc/watchexec.1.md
+++ b/doc/watchexec.1.md
@@ -12,7 +12,7 @@ watchexec - Execute commands when watched files change
 \[**\--fs-events**\] \[**-i**\|**\--ignore**\]
 \[**-I**\|**\--interactive**\] \[**\--exit-on-error**\]
 \[**\--ignore-file**\] \[**\--ignore-nothing**\] \[**\--log-file**\]
-\[**\--manual**\] \[**\--map-signal**\] \[**-n **\]
+\[**\--manual**\] \[**\--map-signal**\] \[**-n** \]
 \[**-N**\|**\--notify**\] \[**\--no-default-ignore**\]
 \[**\--no-discover-ignore**\] \[**\--no-process-group**\]
 \[**\--no-global-ignore**\] \[**\--no-meta**\]
@@ -75,919 +75,926 @@ Watch lib and src directories for changes, rebuilding each time:
 
 **\--completions** *\<SHELL\>*
 
-:   Generate a shell completions script
+: Generate a shell completions script
 
-Provides a completions script or configuration for the given shell. If
-Watchexec is not distributed with pre-generated completions, you can use
-this to generate them yourself.
+  Provides a completions script or configuration for the given shell. If
+  Watchexec is not distributed with pre-generated completions, you can
+  use this to generate them yourself.
 
-Supported shells: bash, elvish, fish, nu, powershell, zsh.
+  Supported shells: bash, elvish, fish, nu, powershell, zsh.
 
 **\--manual**
 
-:   Show the manual page
+: Show the manual page
 
-This shows the manual page for Watchexec, if the output is a terminal
-and the man program is available. If not, the manual page is printed to
-stdout in ROFF format (suitable for writing to a watchexec.1 file).
+  This shows the manual page for Watchexec, if the output is a terminal
+  and the man program is available. If not, the manual page is printed
+  to stdout in ROFF format (suitable for writing to a watchexec.1 file).
 
 **\--only-emit-events**
 
-:   Only emit events to stdout, run no commands.
+: Only emit events to stdout, run no commands.
 
-This is a convenience option for using Watchexec as a file watcher,
-without running any commands. It is almost equivalent to using \`cat\`
-as the command, except that it will not spawn a new process for each
-event.
+  This is a convenience option for using Watchexec as a file watcher,
+  without running any commands. It is almost equivalent to using \`cat\`
+  as the command, except that it will not spawn a new process for each
+  event.
 
-This option implies \`\--emit-events-to=json-stdio\`; you may also use
-the text mode by specifying \`\--emit-events-to=stdio\`.
+  This option implies \`\--emit-events-to=json-stdio\`; you may also use
+  the text mode by specifying \`\--emit-events-to=stdio\`.
 
 **-h**, **\--help**
 
-:   Print help (see a summary with -h)
+: Print help (see a summary with -h)
 
 **-V**, **\--version**
 
-:   Print version
+: Print version
 
 \[*COMMAND*\]
 
-:   Command (program and arguments) to run on changes
+: Command (program and arguments) to run on changes
 
-Its run when events pass filters and the debounce period (and once at
-startup unless \--postpone is given). If you pass flags to the command,
-you should separate it with \-- though that is not strictly required.
+  Its run when events pass filters and the debounce period (and once at
+  startup unless \--postpone is given). If you pass flags to the
+  command, you should separate it with \-- though that is not strictly
+  required.
 
-Examples:
+  Examples:
 
-\$ watchexec -w src npm run build
+  \$ watchexec -w src npm run build
 
-\$ watchexec -w src \-- rsync -a src dest
+  \$ watchexec -w src \-- rsync -a src dest
 
-Take care when using globs or other shell expansions in the command.
-Your shell may expand them before ever passing them to Watchexec, and
-the results may not be what you expect. Compare:
+  Take care when using globs or other shell expansions in the command.
+  Your shell may expand them before ever passing them to Watchexec, and
+  the results may not be what you expect. Compare:
 
-\$ watchexec echo src/\*.rs
+  \$ watchexec echo src/\*.rs
 
-\$ watchexec echo src/\*.rs
+  \$ watchexec echo src/\*.rs
 
-\$ watchexec \--shell=none echo src/\*.rs
+  \$ watchexec \--shell=none echo src/\*.rs
 
-Behaviour depends on the value of \--shell: for all except none, every
-part of the command is joined together into one string with a single
-ascii space character, and given to the shell as described in the help
-for \--shell. For none, each distinct element the command is passed as
-per the execvp(3) convention: first argument is the program, as a path
-or searched for in the PATH environment variable, rest are arguments.
+  Behaviour depends on the value of \--shell: for all except none, every
+  part of the command is joined together into one string with a single
+  ascii space character, and given to the shell as described in the help
+  for \--shell. For none, each distinct element the command is passed as
+  per the execvp(3) convention: first argument is the program, as a path
+  or searched for in the PATH environment variable, rest are arguments.
 
 # COMMAND
 
 **\--delay-run** *\<DURATION\>*
 
-:   Sleep before running the command
+: Sleep before running the command
 
-This option will cause Watchexec to sleep for the specified amount of
-time before running the command, after an event is detected. This is
-like using \"sleep 5 && command\" in a shell, but portable and slightly
-more efficient.
+  This option will cause Watchexec to sleep for the specified amount of
+  time before running the command, after an event is detected. This is
+  like using \"sleep 5 && command\" in a shell, but portable and
+  slightly more efficient.
 
-Takes a unit-less value in seconds, or a time span value such as \"2min
-5s\". Providing a unit-less value is deprecated and will warn; it will
-be an error in the future.
+  Takes a unit-less value in seconds, or a time span value such as
+  \"2min 5s\". Providing a unit-less value is deprecated and will warn;
+  it will be an error in the future.
 
 **-E**, **\--env** *\<KEY=VALUE\>*
 
-:   Add env vars to the command
+: Add env vars to the command
 
-This is a convenience option for setting environment variables for the
-command, without setting them for the Watchexec process itself.
+  This is a convenience option for setting environment variables for the
+  command, without setting them for the Watchexec process itself.
 
-Use key=value syntax. Multiple variables can be set by repeating the
-option.
+  Use key=value syntax. Multiple variables can be set by repeating the
+  option.
 
 **\--socket** *\<PORT\>*
 
-:   Provide a socket to the command
+: Provide a socket to the command
 
-This implements the systemd socket-passing protocol, like with
-\`systemfd\`: sockets are opened from the watchexec process, and then
-passed to the commands it runs. This lets you keep sockets open and
-avoid address reuse issues or dropping packets.
+  This implements the systemd socket-passing protocol, like with
+  \`systemfd\`: sockets are opened from the watchexec process, and then
+  passed to the commands it runs. This lets you keep sockets open and
+  avoid address reuse issues or dropping packets.
 
-This option can be supplied multiple times, to open multiple sockets.
+  This option can be supplied multiple times, to open multiple sockets.
 
-The value can be either of \`PORT\` (opens a TCP listening socket at
-that port), \`HOST:PORT\` (specify a host IP address; IPv6 addresses can
-be specified \`\[bracketed\]\`), \`TYPE::PORT\` or \`TYPE::HOST:PORT\`
-(specify a socket type, \`tcp\` / \`udp\`).
+  The value can be either of \`PORT\` (opens a TCP listening socket at
+  that port), \`HOST:PORT\` (specify a host IP address; IPv6 addresses
+  can be specified \`\[bracketed\]\`), \`TYPE::PORT\` or
+  \`TYPE::HOST:PORT\` (specify a socket type, \`tcp\` / \`udp\`).
 
-This integration only provides basic support, if you want more control
-you should use the \`systemfd\` tool from
-\<https://github.com/mitsuhiko/systemfd\>, upon which this is based. The
-syntax here and the spawning behaviour is identical to \`systemfd\`, and
-both watchexec and systemfd are compatible implementations of the
-systemd socket-activation protocol.
+  This integration only provides basic support, if you want more control
+  you should use the \`systemfd\` tool from
+  \<https://github.com/mitsuhiko/systemfd\>, upon which this is based.
+  The syntax here and the spawning behaviour is identical to
+  \`systemfd\`, and both watchexec and systemfd are compatible
+  implementations of the systemd socket-activation protocol.
 
-Watchexec does \_not\_ set the \`LISTEN_PID\` variable on unix, which
-means any child process of your command could accidentally bind to the
-sockets, unless the \`LISTEN\_\*\` variables are removed from the
-environment.
+  Watchexec does \_not\_ set the \`LISTEN_PID\` variable on unix, which
+  means any child process of your command could accidentally bind to the
+  sockets, unless the \`LISTEN\_\*\` variables are removed from the
+  environment.
 
 **-n**
 
-:   Shorthand for \--shell=none
+: Shorthand for \--shell=none
 
 **\--no-process-group**
 
-:   Dont use a process group
+: Dont use a process group
 
-By default, Watchexec will run the command in a process group, so that
-signals and terminations are sent to all processes in the group.
-Sometimes thats not what you want, and you can disable the behaviour
-with this option.
+  By default, Watchexec will run the command in a process group, so that
+  signals and terminations are sent to all processes in the group.
+  Sometimes thats not what you want, and you can disable the behaviour
+  with this option.
 
-Deprecated, use \--wrap-process=none instead.
+  Deprecated, use \--wrap-process=none instead.
 
 **-Q**, **\--quote**
 
-:   Set whether or not to quote the command symbols when passing them to
-    the shell.
+: Set whether or not to quote the command symbols when passing them to
+  the shell.
 
-On Windows by default this is treated as false, as CMD and PowerShell do
-not work correctly when the symbols are quoted. For git-bash and nushell
-on Windows, as well as other shells that wont work correctly without
-quoting, opt in to quoting using this option.
+  On Windows by default this is treated as false, as CMD and PowerShell
+  do not work correctly when the symbols are quoted. For git-bash and
+  nushell on Windows, as well as other shells that wont work correctly
+  without quoting, opt in to quoting using this option.
 
-On Linux and MacOS this is ignored and always treated as true, because
-they do not allow raw values to be passed.
+  On Linux and MacOS this is ignored and always treated as true, because
+  they do not allow raw values to be passed.
 
-The difference between the two operating systems is to allow both to
-work as expected by default for their built in shells, and to allow
-changing the default behavior for non-default shells if necessary.
+  The difference between the two operating systems is to allow both to
+  work as expected by default for their built in shells, and to allow
+  changing the default behavior for non-default shells if necessary.
 
-If you wish to write shell scripts that work on Linux/MacOS as well as
-Windows via git-bash, you should set this option to true so that the
-behavior is the same on all platforms. The same goes for Nushell, and
-possibly other newer shells.
+  If you wish to write shell scripts that work on Linux/MacOS as well as
+  Windows via git-bash, you should set this option to true so that the
+  behavior is the same on all platforms. The same goes for Nushell, and
+  possibly other newer shells.
 
 **\--shell** *\<SHELL\>*
 
-:   Use a different shell
+: Use a different shell
 
-By default, Watchexec will use \$SHELL if its defined or a default of sh
-on Unix-likes, and either pwsh, powershell, or cmd (CMD.EXE) on Windows,
-depending on what Watchexec detects is the running shell.
+  By default, Watchexec will use \$SHELL if its defined or a default of
+  sh on Unix-likes, and either pwsh, powershell, or cmd (CMD.EXE) on
+  Windows, depending on what Watchexec detects is the running shell.
 
-With this option, you can override that and use a different shell, for
-example one with more features or one which has your custom aliases and
-functions.
+  With this option, you can override that and use a different shell, for
+  example one with more features or one which has your custom aliases
+  and functions.
 
-If the value has spaces, it is parsed as a command line, and the first
-word used as the shell program, with the rest as arguments to the shell.
+  If the value has spaces, it is parsed as a command line, and the first
+  word used as the shell program, with the rest as arguments to the
+  shell.
 
-The command is run with the -c flag (except for cmd on Windows, where
-its /C).
+  The command is run with the -c flag (except for cmd on Windows, where
+  its /C).
 
-The special value none can be used to disable shell use entirely. In
-that case, the command provided to Watchexec will be parsed, with the
-first word being the executable and the rest being the arguments, and
-executed directly. Note that this parsing is rudimentary, and may not
-work as expected in all cases.
+  The special value none can be used to disable shell use entirely. In
+  that case, the command provided to Watchexec will be parsed, with the
+  first word being the executable and the rest being the arguments, and
+  executed directly. Note that this parsing is rudimentary, and may not
+  work as expected in all cases.
 
-Using none is a little more efficient and can enable a stricter
-interpretation of the input, but it also means that you cant use shell
-features like globbing, redirection, control flow, logic, or pipes.
+  Using none is a little more efficient and can enable a stricter
+  interpretation of the input, but it also means that you cant use shell
+  features like globbing, redirection, control flow, logic, or pipes.
 
-Examples:
+  Examples:
 
-Use without shell:
+  Use without shell:
 
-\$ watchexec -n \-- zsh -x -o shwordsplit scr
+  \$ watchexec -n \-- zsh -x -o shwordsplit scr
 
-Use with powershell core:
+  Use with powershell core:
 
-\$ watchexec \--shell=pwsh \-- Test-Connection localhost
+  \$ watchexec \--shell=pwsh \-- Test-Connection localhost
 
-Use with CMD.exe:
+  Use with CMD.exe:
 
-\$ watchexec \--shell=cmd \-- dir
+  \$ watchexec \--shell=cmd \-- dir
 
-Use with a different unix shell:
+  Use with a different unix shell:
 
-\$ watchexec \--shell=bash \-- echo \$BASH_VERSION
+  \$ watchexec \--shell=bash \-- echo \$BASH_VERSION
 
-Use with a unix shell and options:
+  Use with a unix shell and options:
 
-\$ watchexec \--shell=zsh -x -o shwordsplit \-- scr
+  \$ watchexec \--shell=zsh -x -o shwordsplit \-- scr
 
 **\--stop-signal** *\<SIGNAL\>*
 
-:   Signal to send to stop the command
+: Signal to send to stop the command
 
-This is used by restart and signal modes of \--on-busy-update (unless
-\--signal is provided). The restart behaviour is to send the signal,
-wait for the command to exit, and if it hasnt exited after some time
-(see \--timeout-stop), forcefully terminate it.
+  This is used by restart and signal modes of \--on-busy-update (unless
+  \--signal is provided). The restart behaviour is to send the signal,
+  wait for the command to exit, and if it hasnt exited after some time
+  (see \--timeout-stop), forcefully terminate it.
 
-The default on unix is \"SIGTERM\".
+  The default on unix is \"SIGTERM\".
 
-Input is parsed as a full signal name (like \"SIGTERM\"), a short signal
-name (like \"TERM\"), or a signal number (like \"15\"). All input is
-case-insensitive.
+  Input is parsed as a full signal name (like \"SIGTERM\"), a short
+  signal name (like \"TERM\"), or a signal number (like \"15\"). All
+  input is case-insensitive.
 
-On Windows this option is technically supported but only supports the
-\"KILL\" event, as Watchexec cannot yet deliver other events. Windows
-doesnt have signals as such; instead it has termination (here called
-\"KILL\" or \"STOP\") and \"CTRL+C\", \"CTRL+BREAK\", and \"CTRL+CLOSE\"
-events. For portability the unix signals \"SIGKILL\", \"SIGINT\",
-\"SIGTERM\", and \"SIGHUP\" are respectively mapped to these.
+  On Windows this option is technically supported but only supports the
+  \"KILL\" event, as Watchexec cannot yet deliver other events. Windows
+  doesnt have signals as such; instead it has termination (here called
+  \"KILL\" or \"STOP\") and \"CTRL+C\", \"CTRL+BREAK\", and
+  \"CTRL+CLOSE\" events. For portability the unix signals \"SIGKILL\",
+  \"SIGINT\", \"SIGTERM\", and \"SIGHUP\" are respectively mapped to
+  these.
 
 **\--stop-timeout** *\<TIMEOUT\>*
 
-:   Time to wait for the command to exit gracefully
+: Time to wait for the command to exit gracefully
 
-This is used by the restart mode of \--on-busy-update. After the
-graceful stop signal is sent, Watchexec will wait for the command to
-exit. If it hasnt exited after this time, it is forcefully terminated.
+  This is used by the restart mode of \--on-busy-update. After the
+  graceful stop signal is sent, Watchexec will wait for the command to
+  exit. If it hasnt exited after this time, it is forcefully terminated.
 
-Takes a unit-less value in seconds, or a time span value such as \"5min
-20s\". Providing a unit-less value is deprecated and will warn; it will
-be an error in the future.
+  Takes a unit-less value in seconds, or a time span value such as
+  \"5min 20s\". Providing a unit-less value is deprecated and will warn;
+  it will be an error in the future.
 
-The default is 10 seconds. Set to 0 to immediately force-kill the
-command.
+  The default is 10 seconds. Set to 0 to immediately force-kill the
+  command.
 
-This has no practical effect on Windows as the command is always
-forcefully terminated; see \--stop-signal for why.
+  This has no practical effect on Windows as the command is always
+  forcefully terminated; see \--stop-signal for why.
 
 **\--timeout** *\<TIMEOUT\>*
 
-:   Kill the command if it runs longer than this duration
+: Kill the command if it runs longer than this duration
 
-Takes a time span value such as \"30s\", \"5min\", or \"1h 30m\".
+  Takes a time span value such as \"30s\", \"5min\", or \"1h 30m\".
 
-When the timeout is reached, the command is gracefully stopped using
-\--stop-signal, then forcefully terminated after \--stop-timeout if
-still running.
+  When the timeout is reached, the command is gracefully stopped using
+  \--stop-signal, then forcefully terminated after \--stop-timeout if
+  still running.
 
-Each run of the command has its own independent timeout.
+  Each run of the command has its own independent timeout.
 
 **\--workdir** *\<DIRECTORY\>*
 
-:   Set the working directory
+: Set the working directory
 
-By default, the working directory of the command is the working
-directory of Watchexec. You can change that with this option. Note that
-paths may be less intuitive to use with this.
+  By default, the working directory of the command is the working
+  directory of Watchexec. You can change that with this option. Note
+  that paths may be less intuitive to use with this.
 
 **\--wrap-process** *\<MODE\>* \[default: group\]
 
-:   Configure how the process is wrapped
+: Configure how the process is wrapped
 
-By default, Watchexec will run the command in a session on Mac, in a
-process group in Unix, and in a Job Object in Windows.
+  By default, Watchexec will run the command in a session on Mac, in a
+  process group in Unix, and in a Job Object in Windows.
 
-Some Unix programs prefer running in a session, while others do not work
-in a process group.
+  Some Unix programs prefer running in a session, while others do not
+  work in a process group.
 
-Use group to use a process group, session to use a process session, and
-none to run the command directly. On Windows, either of group or session
-will use a Job Object.
+  Use group to use a process group, session to use a process session,
+  and none to run the command directly. On Windows, either of group or
+  session will use a Job Object.
 
-If you find you need to specify this frequently for different kinds of
-programs, file an issue at
-\<https://github.com/watchexec/watchexec/issues\>. As errors of this
-nature are hard to debug and can be highly environment-dependent,
-reports from \*multiple affected people\* are more likely to be actioned
-promptly. Ask your friends/colleagues!
+  If you find you need to specify this frequently for different kinds of
+  programs, file an issue at
+  \<https://github.com/watchexec/watchexec/issues\>. As errors of this
+  nature are hard to debug and can be highly environment-dependent,
+  reports from \*multiple affected people\* are more likely to be
+  actioned promptly. Ask your friends/colleagues!
 
 # EVENTS
 
 **-d**, **\--debounce** *\<TIMEOUT\>*
 
-:   Time to wait for new events before taking action
+: Time to wait for new events before taking action
 
-When an event is received, Watchexec will wait for up to this amount of
-time before handling it (such as running the command). This is essential
-as what you might perceive as a single change may actually emit many
-events, and without this behaviour, Watchexec would run much too often.
-Additionally, its not infrequent that file writes are not atomic, and
-each write may emit an event, so this is a good way to avoid running a
-command while a file is partially written.
+  When an event is received, Watchexec will wait for up to this amount
+  of time before handling it (such as running the command). This is
+  essential as what you might perceive as a single change may actually
+  emit many events, and without this behaviour, Watchexec would run much
+  too often. Additionally, its not infrequent that file writes are not
+  atomic, and each write may emit an event, so this is a good way to
+  avoid running a command while a file is partially written.
 
-An alternative use is to set a high value (like \"30min\" or longer), to
-save power or bandwidth on intensive tasks, like an ad-hoc backup
-script. In those use cases, note that every accumulated event will build
-up in memory.
+  An alternative use is to set a high value (like \"30min\" or longer),
+  to save power or bandwidth on intensive tasks, like an ad-hoc backup
+  script. In those use cases, note that every accumulated event will
+  build up in memory.
 
-Takes a unit-less value in milliseconds, or a time span value such as
-\"5sec 20ms\". Providing a unit-less value is deprecated and will warn;
-it will be an error in the future.
+  Takes a unit-less value in milliseconds, or a time span value such as
+  \"5sec 20ms\". Providing a unit-less value is deprecated and will
+  warn; it will be an error in the future.
 
-The default is 50 milliseconds. Setting to 0 is highly discouraged.
+  The default is 50 milliseconds. Setting to 0 is highly discouraged.
 
 **\--emit-events-to** *\<MODE\>*
 
-:   Configure event emission
+: Configure event emission
 
-Watchexec can emit event information when running a command, which can
-be used by the child process to target specific changed files.
+  Watchexec can emit event information when running a command, which can
+  be used by the child process to target specific changed files.
 
-One thing to take care with is assuming inherent behaviour where there
-is only chance. Notably, it could appear as if the \`RENAMED\` variable
-contains both the original and the new path being renamed. In previous
-versions, it would even appear on some platforms as if the original
-always came before the new. However, none of this was true. Its
-impossible to reliably and portably know which changed path is the old
-or new, \"half\" renames may appear (only the original, only the new),
-\"unknown\" renames may appear (change was a rename, but whether it was
-the old or new isnt known), rename events might split across two
-debouncing boundaries, and so on.
+  One thing to take care with is assuming inherent behaviour where there
+  is only chance. Notably, it could appear as if the \`RENAMED\`
+  variable contains both the original and the new path being renamed. In
+  previous versions, it would even appear on some platforms as if the
+  original always came before the new. However, none of this was true.
+  Its impossible to reliably and portably know which changed path is the
+  old or new, \"half\" renames may appear (only the original, only the
+  new), \"unknown\" renames may appear (change was a rename, but whether
+  it was the old or new isnt known), rename events might split across
+  two debouncing boundaries, and so on.
 
-This option controls where that information is emitted. It defaults to
-none, which doesnt emit event information at all. The other options are
-environment (deprecated), stdio, file, json-stdio, and json-file.
+  This option controls where that information is emitted. It defaults to
+  none, which doesnt emit event information at all. The other options
+  are environment (deprecated), stdio, file, json-stdio, and json-file.
 
-The stdio and file modes are text-based: stdio writes absolute paths to
-the stdin of the command, one per line, each prefixed with \`create:\`,
-\`remove:\`, \`rename:\`, \`modify:\`, or \`other:\`, then closes the
-handle; file writes the same thing to a temporary file, and its path is
-given with the \$WATCHEXEC_EVENTS_FILE environment variable.
+  The stdio and file modes are text-based: stdio writes absolute paths
+  to the stdin of the command, one per line, each prefixed with
+  \`create:\`, \`remove:\`, \`rename:\`, \`modify:\`, or \`other:\`,
+  then closes the handle; file writes the same thing to a temporary
+  file, and its path is given with the \$WATCHEXEC_EVENTS_FILE
+  environment variable.
 
-There are also two JSON modes, which are based on JSON objects and can
-represent the full set of events Watchexec handles. Heres an example of
-a folder being created on Linux:
+  There are also two JSON modes, which are based on JSON objects and can
+  represent the full set of events Watchexec handles. Heres an example
+  of a folder being created on Linux:
 
-\`\`\`json { \"tags\": \[ { \"kind\": \"path\", \"absolute\":
-\"/home/user/your/new-folder\", \"filetype\": \"dir\" }, { \"kind\":
-\"fs\", \"simple\": \"create\", \"full\": \"Create(Folder)\" }, {
-\"kind\": \"source\", \"source\": \"filesystem\", } \], \"metadata\": {
-\"notify-backend\": \"inotify\" } } \`\`\`
+  \`\`\`json { \"tags\": \[ { \"kind\": \"path\", \"absolute\":
+  \"/home/user/your/new-folder\", \"filetype\": \"dir\" }, { \"kind\":
+  \"fs\", \"simple\": \"create\", \"full\": \"Create(Folder)\" }, {
+  \"kind\": \"source\", \"source\": \"filesystem\", } \], \"metadata\":
+  { \"notify-backend\": \"inotify\" } } \`\`\`
 
-The fields are as follows:
+  The fields are as follows:
 
-\- \`tags\`, structured event data. - \`tags\[\].kind\`, which can be:
-\* path, along with: + \`absolute\`, an absolute path. + \`filetype\`, a
-file type if known (dir, file, symlink, other). \* fs: + \`simple\`, the
-\"simple\" event type (access, create, modify, remove, or other). +
-\`full\`, the \"full\" event type, which is too complex to fully
-describe here, but looks like General(Precise(Specific)). \* source,
-along with: + \`source\`, the source of the event (filesystem, keyboard,
-mouse, os, time, internal). \* keyboard, along with: + \`keycode\`.
-Currently only the value eof is supported. \* process, for events caused
-by processes: + \`pid\`, the process ID. \* signal, for signals sent to
-Watchexec: + \`signal\`, the normalised signal name (hangup, interrupt,
-quit, terminate, user1, user2). \* completion, for when a command
-ends: + \`disposition\`, the exit disposition (success, error, signal,
-stop, exception, continued). + \`code\`, the exit, signal, stop, or
-exception code. - \`metadata\`, additional information about the event.
+  \- \`tags\`, structured event data. - \`tags\[\].kind\`, which can be:
+  \* path, along with: + \`absolute\`, an absolute path. + \`filetype\`,
+  a file type if known (dir, file, symlink, other). \* fs: + \`simple\`,
+  the \"simple\" event type (access, create, modify, remove, or
+  other). + \`full\`, the \"full\" event type, which is too complex to
+  fully describe here, but looks like General(Precise(Specific)). \*
+  source, along with: + \`source\`, the source of the event (filesystem,
+  keyboard, mouse, os, time, internal). \* keyboard, along with: +
+  \`keycode\`. Currently only the value eof is supported. \* process,
+  for events caused by processes: + \`pid\`, the process ID. \* signal,
+  for signals sent to Watchexec: + \`signal\`, the normalised signal
+  name (hangup, interrupt, quit, terminate, user1, user2). \*
+  completion, for when a command ends: + \`disposition\`, the exit
+  disposition (success, error, signal, stop, exception, continued). +
+  \`code\`, the exit, signal, stop, or exception code. - \`metadata\`,
+  additional information about the event.
 
-The json-stdio mode will emit JSON events to the standard input of the
-command, one per line, then close stdin. The json-file mode will create
-a temporary file, write the events to it, and provide the path to the
-file with the \$WATCHEXEC_EVENTS_FILE environment variable.
+  The json-stdio mode will emit JSON events to the standard input of the
+  command, one per line, then close stdin. The json-file mode will
+  create a temporary file, write the events to it, and provide the path
+  to the file with the \$WATCHEXEC_EVENTS_FILE environment variable.
 
-Finally, the environment mode was the default until 2.0. It sets
-environment variables with the paths of the affected files, for
-filesystem events:
+  Finally, the environment mode was the default until 2.0. It sets
+  environment variables with the paths of the affected files, for
+  filesystem events:
 
-\$WATCHEXEC_COMMON_PATH is set to the longest common path of all of the
-below variables, and so should be prepended to each path to obtain the
-full/real path. Then:
+  \$WATCHEXEC_COMMON_PATH is set to the longest common path of all of
+  the below variables, and so should be prepended to each path to obtain
+  the full/real path. Then:
 
-\- \$WATCHEXEC_CREATED_PATH is set when files/folders were created -
-\$WATCHEXEC_REMOVED_PATH is set when files/folders were removed -
-\$WATCHEXEC_RENAMED_PATH is set when files/folders were renamed -
-\$WATCHEXEC_WRITTEN_PATH is set when files/folders were modified -
-\$WATCHEXEC_META_CHANGED_PATH is set when files/folders metadata were
-modified - \$WATCHEXEC_OTHERWISE_CHANGED_PATH is set for every other
-kind of pathed event
+  \- \$WATCHEXEC_CREATED_PATH is set when files/folders were created -
+  \$WATCHEXEC_REMOVED_PATH is set when files/folders were removed -
+  \$WATCHEXEC_RENAMED_PATH is set when files/folders were renamed -
+  \$WATCHEXEC_WRITTEN_PATH is set when files/folders were modified -
+  \$WATCHEXEC_META_CHANGED_PATH is set when files/folders metadata were
+  modified - \$WATCHEXEC_OTHERWISE_CHANGED_PATH is set for every other
+  kind of pathed event
 
-Multiple paths are separated by the system path separator, ; on Windows
-and : on unix. Within each variable, paths are deduplicated and sorted
-in binary order (i.e. neither Unicode nor locale aware).
+  Multiple paths are separated by the system path separator, ; on
+  Windows and : on unix. Within each variable, paths are deduplicated
+  and sorted in binary order (i.e. neither Unicode nor locale aware).
 
-This is the legacy mode, is deprecated, and will be removed in the
-future. The environment is a very restricted space, while also limited
-in what it can usefully represent. Large numbers of files will either
-cause the environment to be truncated, or may error or crash the process
-entirely. The \$WATCHEXEC_COMMON_PATH is also unintuitive, as
-demonstrated by the multiple confused queries that have landed in my
-inbox over the years.
+  This is the legacy mode, is deprecated, and will be removed in the
+  future. The environment is a very restricted space, while also limited
+  in what it can usefully represent. Large numbers of files will either
+  cause the environment to be truncated, or may error or crash the
+  process entirely. The \$WATCHEXEC_COMMON_PATH is also unintuitive, as
+  demonstrated by the multiple confused queries that have landed in my
+  inbox over the years.
 
 **-I**, **\--interactive**
 
-:   Respond to keypresses to quit, restart, stop, or pause
+: Respond to keypresses to quit, restart, stop, or pause
 
-In interactive mode, Watchexec listens for keypresses and responds to
-them. Currently supported keys are: r to restart the command, s to stop
-the running command, p to toggle pausing the watch, and q to quit. This
-requires a terminal (TTY) and puts stdin into raw mode, so the child
-process will not receive stdin input.
+  In interactive mode, Watchexec listens for keypresses and responds to
+  them. Currently supported keys are: r to restart the command, s to
+  stop the running command, p to toggle pausing the watch, and q to
+  quit. This requires a terminal (TTY) and puts stdin into raw mode, so
+  the child process will not receive stdin input.
 
 **\--exit-on-error**
 
-:   Exit when the command has an error
+: Exit when the command has an error
 
-By default, Watchexec will continue to watch and re-run the command
-after the command exits, regardless of its exit status. With this
-option, it will instead exit when the command completes with any
-non-success exit status.
+  By default, Watchexec will continue to watch and re-run the command
+  after the command exits, regardless of its exit status. With this
+  option, it will instead exit when the command completes with any
+  non-success exit status.
 
-This is useful when running Watchexec in a process manager or container,
-where you want the container to restart when the command fails rather
-than hang waiting for file changes.
+  This is useful when running Watchexec in a process manager or
+  container, where you want the container to restart when the command
+  fails rather than hang waiting for file changes.
 
 **\--map-signal** *\<SIGNAL:SIGNAL\>*
 
-:   Translate signals from the OS to signals to send to the command
+: Translate signals from the OS to signals to send to the command
 
-Takes a pair of signal names, separated by a colon, such as \"TERM:INT\"
-to map SIGTERM to SIGINT. The first signal is the one received by
-watchexec, and the second is the one sent to the command. The second can
-be omitted to discard the first signal, such as \"TERM:\" to not do
-anything on SIGTERM.
+  Takes a pair of signal names, separated by a colon, such as
+  \"TERM:INT\" to map SIGTERM to SIGINT. The first signal is the one
+  received by watchexec, and the second is the one sent to the command.
+  The second can be omitted to discard the first signal, such as
+  \"TERM:\" to not do anything on SIGTERM.
 
-If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec.
-Besides making it hard to quit Watchexec itself, this is useful to send
-pass a Ctrl-C to the command without also terminating Watchexec and the
-underlying program with it, e.g. with \"INT:INT\".
+  If SIGINT or SIGTERM are mapped, then they no longer quit Watchexec.
+  Besides making it hard to quit Watchexec itself, this is useful to
+  send pass a Ctrl-C to the command without also terminating Watchexec
+  and the underlying program with it, e.g. with \"INT:INT\".
 
-This option can be specified multiple times to map multiple signals.
+  This option can be specified multiple times to map multiple signals.
 
-Signal syntax is case-insensitive for short names (like \"TERM\",
-\"USR2\") and long names (like \"SIGKILL\", \"SIGHUP\"). Signal numbers
-are also supported (like \"15\", \"31\"). On Windows, the forms
-\"STOP\", \"CTRL+C\", and \"CTRL+BREAK\" are also supported to receive,
-but Watchexec cannot yet deliver other \"signals\" than a STOP.
+  Signal syntax is case-insensitive for short names (like \"TERM\",
+  \"USR2\") and long names (like \"SIGKILL\", \"SIGHUP\"). Signal
+  numbers are also supported (like \"15\", \"31\"). On Windows, the
+  forms \"STOP\", \"CTRL+C\", and \"CTRL+BREAK\" are also supported to
+  receive, but Watchexec cannot yet deliver other \"signals\" than a
+  STOP.
 
 **-o**, **\--on-busy-update** *\<MODE\>*
 
-:   What to do when receiving events while the command is running
+: What to do when receiving events while the command is running
 
-Default is to do-nothing, which ignores events while the command is
-running, so that changes that occur due to the command are ignored, like
-compilation outputs. You can also use queue which will run the command
-once again when the current run has finished if any events occur while
-its running, or restart, which terminates the running command and starts
-a new one. Finally, theres signal, which only sends a signal; this can
-be useful with programs that can reload their configuration without a
-full restart.
+  Default is to do-nothing, which ignores events while the command is
+  running, so that changes that occur due to the command are ignored,
+  like compilation outputs. You can also use queue which will run the
+  command once again when the current run has finished if any events
+  occur while its running, or restart, which terminates the running
+  command and starts a new one. Finally, theres signal, which only sends
+  a signal; this can be useful with programs that can reload their
+  configuration without a full restart.
 
-The signal can be specified with the \--signal option.
+  The signal can be specified with the \--signal option.
 
 **\--poll** \[*\<INTERVAL\>*\]
 
-:   Poll for filesystem changes
+: Poll for filesystem changes
 
-By default, and where available, Watchexec uses the operating systems
-native file system watching capabilities. This option disables that and
-instead uses a polling mechanism, which is less efficient but can work
-around issues with some file systems (like network shares) or edge
-cases.
+  By default, and where available, Watchexec uses the operating systems
+  native file system watching capabilities. This option disables that
+  and instead uses a polling mechanism, which is less efficient but can
+  work around issues with some file systems (like network shares) or
+  edge cases.
 
-Optionally takes a unit-less value in milliseconds, or a time span value
-such as \"2s 500ms\", to use as the polling interval. If not specified,
-the default is 30 seconds. Providing a unit-less value is deprecated and
-will warn; it will be an error in the future.
+  Optionally takes a unit-less value in milliseconds, or a time span
+  value such as \"2s 500ms\", to use as the polling interval. If not
+  specified, the default is 30 seconds. Providing a unit-less value is
+  deprecated and will warn; it will be an error in the future.
 
-Aliased as \--force-poll.
+  Aliased as \--force-poll.
 
 **-p**, **\--postpone**
 
-:   Wait until first change before running command
+: Wait until first change before running command
 
-By default, Watchexec will run the command once immediately. With this
-option, it will instead wait until an event is detected before running
-the command as normal.
+  By default, Watchexec will run the command once immediately. With this
+  option, it will instead wait until an event is detected before running
+  the command as normal.
 
 **-r**, **\--restart**
 
-:   Restart the process if its still running
+: Restart the process if its still running
 
-This is a shorthand for \--on-busy-update=restart.
+  This is a shorthand for \--on-busy-update=restart.
 
 **-s**, **\--signal** *\<SIGNAL\>*
 
-:   Send a signal to the process when its still running
+: Send a signal to the process when its still running
 
-Specify a signal to send to the process when its still running. This
-implies \--on-busy-update=signal; otherwise the signal used when that
-mode is restart is controlled by \--stop-signal.
+  Specify a signal to send to the process when its still running. This
+  implies \--on-busy-update=signal; otherwise the signal used when that
+  mode is restart is controlled by \--stop-signal.
 
-See the long documentation for \--stop-signal for syntax.
+  See the long documentation for \--stop-signal for syntax.
 
-Signals are not supported on Windows at the moment, and will always be
-overridden to kill. See \--stop-signal for more on Windows \"signals\".
+  Signals are not supported on Windows at the moment, and will always be
+  overridden to kill. See \--stop-signal for more on Windows
+  \"signals\".
 
 **\--stdin-quit**
 
-:   Exit when stdin closes
+: Exit when stdin closes
 
-This watches the stdin file descriptor for EOF, and exits Watchexec
-gracefully when it is closed. This is used by some process managers to
-avoid leaving zombie processes around.
+  This watches the stdin file descriptor for EOF, and exits Watchexec
+  gracefully when it is closed. This is used by some process managers to
+  avoid leaving zombie processes around.
 
 # FILTERING
 
 **-e**, **\--exts** *\<EXTENSIONS\>*
 
-:   Filename extensions to filter to
+: Filename extensions to filter to
 
-This is a quick filter to only emit events for files with the given
-extensions. Extensions can be given with or without the leading dot
-(e.g. js or .js). Multiple extensions can be given by repeating the
-option or by separating them with commas.
+  This is a quick filter to only emit events for files with the given
+  extensions. Extensions can be given with or without the leading dot
+  (e.g. js or .js). Multiple extensions can be given by repeating the
+  option or by separating them with commas.
 
 **-f**, **\--filter** *\<PATTERN\>*
 
-:   Filename patterns to filter to
+: Filename patterns to filter to
 
-Provide a glob-like filter pattern, and only events for files matching
-the pattern will be emitted. Multiple patterns can be given by repeating
-the option. Events that are not from files (e.g. signals, keyboard
-events) will pass through untouched.
+  Provide a glob-like filter pattern, and only events for files matching
+  the pattern will be emitted. Multiple patterns can be given by
+  repeating the option. Events that are not from files (e.g. signals,
+  keyboard events) will pass through untouched.
 
 **\--filter-file** *\<PATH\>*
 
-:   Files to load filters from
+: Files to load filters from
 
-Provide a path to a file containing filters, one per line. Empty lines
-and lines starting with \# are ignored. Uses the same pattern format as
-the \--filter option.
+  Provide a path to a file containing filters, one per line. Empty lines
+  and lines starting with \# are ignored. Uses the same pattern format
+  as the \--filter option.
 
-This can also be used via the \$WATCHEXEC_FILTER_FILES environment
-variable.
+  This can also be used via the \$WATCHEXEC_FILTER_FILES environment
+  variable.
 
 **-j**, **\--filter-prog** *\<EXPRESSION\>*
 
-:   Filter programs.
+: Filter programs.
 
-Provide your own custom filter programs in jaq (similar to jq) syntax.
-Programs are given an event in the same format as described in
-\--emit-events-to and must return a boolean. Invalid programs will make
-watchexec fail to start; use -v to see program runtime errors.
+  Provide your own custom filter programs in jaq (similar to jq) syntax.
+  Programs are given an event in the same format as described in
+  \--emit-events-to and must return a boolean. Invalid programs will
+  make watchexec fail to start; use -v to see program runtime errors.
 
-In addition to the jaq stdlib, watchexec adds some custom filter
-definitions:
+  In addition to the jaq stdlib, watchexec adds some custom filter
+  definitions:
 
-\- path \| file_meta returns file metadata or null if the file does not
-exist.
+  \- path \| file_meta returns file metadata or null if the file does
+  not exist.
 
-\- path \| file_size returns the size of the file at path, or null if it
-does not exist.
+  \- path \| file_size returns the size of the file at path, or null if
+  it does not exist.
 
-\- path \| file_read(bytes) returns a string with the first n bytes of
-the file at path. If the file is smaller than n bytes, the whole file is
-returned. There is no filter to read the whole file at once to encourage
-limiting the amount of data read and processed.
+  \- path \| file_read(bytes) returns a string with the first n bytes of
+  the file at path. If the file is smaller than n bytes, the whole file
+  is returned. There is no filter to read the whole file at once to
+  encourage limiting the amount of data read and processed.
 
-\- string \| hash, and path \| file_hash return the hash of the string
-or file at path. No guarantee is made about the algorithm used: treat it
-as an opaque value.
+  \- string \| hash, and path \| file_hash return the hash of the string
+  or file at path. No guarantee is made about the algorithm used: treat
+  it as an opaque value.
 
-\- any \| kv_store(key), kv_fetch(key), and kv_clear provide a simple
-key-value store. Data is kept in memory only, there is no persistence.
-Consistency is not guaranteed.
+  \- any \| kv_store(key), kv_fetch(key), and kv_clear provide a simple
+  key-value store. Data is kept in memory only, there is no persistence.
+  Consistency is not guaranteed.
 
-\- any \| printout, any \| printerr, and any \| log(level) will print or
-log any given value to stdout, stderr, or the log (levels = error, warn,
-info, debug, trace), and pass the value through (so \[1\] \|
-log(\"debug\") \| .\[\] will produce a 1 and log \[1\]).
+  \- any \| printout, any \| printerr, and any \| log(level) will print
+  or log any given value to stdout, stderr, or the log (levels = error,
+  warn, info, debug, trace), and pass the value through (so \[1\] \|
+  log(\"debug\") \| .\[\] will produce a 1 and log \[1\]).
 
-All filtering done with such programs, and especially those using kv or
-filesystem access, is much slower than the other filtering methods. If
-filtering is too slow, events will back up and stall watchexec. Take
-care when designing your filters.
+  All filtering done with such programs, and especially those using kv
+  or filesystem access, is much slower than the other filtering methods.
+  If filtering is too slow, events will back up and stall watchexec.
+  Take care when designing your filters.
 
-If the argument to this option starts with an @, the rest of the
-argument is taken to be the path to a file containing a jaq program.
+  If the argument to this option starts with an @, the rest of the
+  argument is taken to be the path to a file containing a jaq program.
 
-Jaq programs are run in order, after all other filters, and
-short-circuit: if a filter (jaq or not) rejects an event, execution
-stops there, and no other filters are run. Additionally, they stop after
-outputting the first value, so youll want to use any or all when
-iterating, otherwise only the first item will be processed, which can be
-quite confusing!
+  Jaq programs are run in order, after all other filters, and
+  short-circuit: if a filter (jaq or not) rejects an event, execution
+  stops there, and no other filters are run. Additionally, they stop
+  after outputting the first value, so youll want to use any or all when
+  iterating, otherwise only the first item will be processed, which can
+  be quite confusing!
 
-Find user-contributed programs or submit your own useful ones at
-\<https://github.com/watchexec/watchexec/discussions/592\>.
+  Find user-contributed programs or submit your own useful ones at
+  \<https://github.com/watchexec/watchexec/discussions/592\>.
 
-\## Examples:
+  \## Examples:
 
-Regexp ignore filter on paths:
+  Regexp ignore filter on paths:
 
-all(.tags\[\] \| select(.kind == \"path\"); .absolute \|
-test(\"\[.\]test\[.\]js\$\")) \| not
+  all(.tags\[\] \| select(.kind == \"path\"); .absolute \|
+  test(\"\[.\]test\[.\]js\$\")) \| not
 
-Pass any event that creates a file:
+  Pass any event that creates a file:
 
-any(.tags\[\] \| select(.kind == \"fs\"); .simple == \"create\")
+  any(.tags\[\] \| select(.kind == \"fs\"); .simple == \"create\")
 
-Pass events that touch executable files:
+  Pass events that touch executable files:
 
-any(.tags\[\] \| select(.kind == \"path\" && .filetype == \"file\");
-.absolute \| metadata \| .executable)
+  any(.tags\[\] \| select(.kind == \"path\" && .filetype == \"file\");
+  .absolute \| metadata \| .executable)
 
-Ignore files that start with shebangs:
+  Ignore files that start with shebangs:
 
-any(.tags\[\] \| select(.kind == \"path\" && .filetype == \"file\");
-.absolute \| read(2) == \"#!\") \| not
+  any(.tags\[\] \| select(.kind == \"path\" && .filetype == \"file\");
+  .absolute \| read(2) == \"#!\") \| not
 
 **\--fs-events** *\<EVENTS\>*
 
-:   Filesystem events to filter to
+: Filesystem events to filter to
 
-This is a quick filter to only emit events for the given types of
-filesystem changes. Choose from access, create, remove, rename, modify,
-metadata. Multiple types can be given by repeating the option or by
-separating them with commas. By default, this is all types except for
-access.
+  This is a quick filter to only emit events for the given types of
+  filesystem changes. Choose from access, create, remove, rename,
+  modify, metadata. Multiple types can be given by repeating the option
+  or by separating them with commas. By default, this is all types
+  except for access.
 
-This may apply filtering at the kernel level when possible, which can be
-more efficient, but may be more confusing when reading the logs.
+  This may apply filtering at the kernel level when possible, which can
+  be more efficient, but may be more confusing when reading the logs.
 
 **-i**, **\--ignore** *\<PATTERN\>*
 
-:   Filename patterns to filter out
+: Filename patterns to filter out
 
-Provide a glob-like filter pattern, and events for files matching the
-pattern will be excluded. Multiple patterns can be given by repeating
-the option. Events that are not from files (e.g. signals, keyboard
-events) will pass through untouched.
+  Provide a glob-like filter pattern, and events for files matching the
+  pattern will be excluded. Multiple patterns can be given by repeating
+  the option. Events that are not from files (e.g. signals, keyboard
+  events) will pass through untouched.
 
 **\--ignore-file** *\<PATH\>*
 
-:   Files to load ignores from
+: Files to load ignores from
 
-Provide a path to a file containing ignores, one per line. Empty lines
-and lines starting with \# are ignored. Uses the same pattern format as
-the \--ignore option.
+  Provide a path to a file containing ignores, one per line. Empty lines
+  and lines starting with \# are ignored. Uses the same pattern format
+  as the \--ignore option.
 
-This can also be used via the \$WATCHEXEC_IGNORE_FILES environment
-variable.
+  This can also be used via the \$WATCHEXEC_IGNORE_FILES environment
+  variable.
 
 **\--ignore-nothing**
 
-:   Dont ignore anything at all
+: Dont ignore anything at all
 
-This is a shorthand for \--no-discover-ignore, \--no-default-ignore.
+  This is a shorthand for \--no-discover-ignore, \--no-default-ignore.
 
-Note that ignores explicitly loaded via other command line options, such
-as \--ignore or \--ignore-file, will still be used.
+  Note that ignores explicitly loaded via other command line options,
+  such as \--ignore or \--ignore-file, will still be used.
 
 **\--no-default-ignore**
 
-:   Dont use internal default ignores
+: Dont use internal default ignores
 
-Watchexec has a set of default ignore patterns, such as editor swap
-files, \`\*.pyc\`, \`\*.pyo\`, \`.DS_Store\`, \`.bzr\`, \`\_darcs\`,
-\`.fossil-settings\`, \`.git\`, \`.hg\`, \`.pijul\`, \`.svn\`, and
-Watchexec log files.
+  Watchexec has a set of default ignore patterns, such as editor swap
+  files, \`\*.pyc\`, \`\*.pyo\`, \`.DS_Store\`, \`.bzr\`, \`\_darcs\`,
+  \`.fossil-settings\`, \`.git\`, \`.hg\`, \`.pijul\`, \`.svn\`, and
+  Watchexec log files.
 
 **\--no-discover-ignore**
 
-:   Dont discover ignore files at all
+: Dont discover ignore files at all
 
-This is a shorthand for \--no-global-ignore, \--no-vcs-ignore,
-\--no-project-ignore, but even more efficient as it will skip all the
-ignore discovery mechanisms from the get go.
+  This is a shorthand for \--no-global-ignore, \--no-vcs-ignore,
+  \--no-project-ignore, but even more efficient as it will skip all the
+  ignore discovery mechanisms from the get go.
 
-Note that default ignores are still loaded, see \--no-default-ignore.
+  Note that default ignores are still loaded, see \--no-default-ignore.
 
 **\--no-global-ignore**
 
-:   Dont load global ignores
+: Dont load global ignores
 
-This disables loading of global or user ignore files, like
-\~/.gitignore, \~/.config/watchexec/ignore, or
-%APPDATA%\\Bazzar\\2.0\\ignore. Contrast with \--no-vcs-ignore and
-\--no-project-ignore.
+  This disables loading of global or user ignore files, like
+  \~/.gitignore, \~/.config/watchexec/ignore, or
+  %APPDATA%\\Bazzar\\2.0\\ignore. Contrast with \--no-vcs-ignore and
+  \--no-project-ignore.
 
-Supported global ignore files
+  Supported global ignore files
 
-\- Git (if core.excludesFile is set): the file at that path - Git
-(otherwise): the first found of \$XDG_CONFIG_HOME/git/ignore,
-%APPDATA%/.gitignore, %USERPROFILE%/.gitignore,
-\$HOME/.config/git/ignore, \$HOME/.gitignore. - Bazaar: the first found
-of %APPDATA%/Bazzar/2.0/ignore, \$HOME/.bazaar/ignore. - Watchexec: the
-first found of \$XDG_CONFIG_HOME/watchexec/ignore,
-%APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore,
-\$HOME/.watchexec/ignore.
+  \- Git (if core.excludesFile is set): the file at that path - Git
+  (otherwise): the first found of \$XDG_CONFIG_HOME/git/ignore,
+  %APPDATA%/.gitignore, %USERPROFILE%/.gitignore,
+  \$HOME/.config/git/ignore, \$HOME/.gitignore. - Bazaar: the first
+  found of %APPDATA%/Bazzar/2.0/ignore, \$HOME/.bazaar/ignore. -
+  Watchexec: the first found of \$XDG_CONFIG_HOME/watchexec/ignore,
+  %APPDATA%/watchexec/ignore, %USERPROFILE%/.watchexec/ignore,
+  \$HOME/.watchexec/ignore.
 
-Like for project files, Git and Bazaar global files will only be used
-for the corresponding VCS as used in the project.
+  Like for project files, Git and Bazaar global files will only be used
+  for the corresponding VCS as used in the project.
 
 **\--no-meta**
 
-:   Dont emit fs events for metadata changes
+: Dont emit fs events for metadata changes
 
-This is a shorthand for \--fs-events create,remove,rename,modify. Using
-it alongside the \--fs-events option is non-sensical and not allowed.
+  This is a shorthand for \--fs-events create,remove,rename,modify.
+  Using it alongside the \--fs-events option is non-sensical and not
+  allowed.
 
 **\--no-project-ignore**
 
-:   Dont load project-local ignores
+: Dont load project-local ignores
 
-This disables loading of project-local ignore files, like .gitignore or
-.ignore in the watched project. This is contrasted with
-\--no-vcs-ignore, which disables loading of Git and other VCS ignore
-files, and with \--no-global-ignore, which disables loading of global or
-user ignore files, like \~/.gitignore or \~/.config/watchexec/ignore.
+  This disables loading of project-local ignore files, like .gitignore
+  or .ignore in the watched project. This is contrasted with
+  \--no-vcs-ignore, which disables loading of Git and other VCS ignore
+  files, and with \--no-global-ignore, which disables loading of global
+  or user ignore files, like \~/.gitignore or
+  \~/.config/watchexec/ignore.
 
-Supported project ignore files:
+  Supported project ignore files:
 
-\- Git: .gitignore at project root and child directories,
-.git/info/exclude, and the file pointed to by \`core.excludesFile\` in
-.git/config. - Mercurial: .hgignore at project root and child
-directories. - Bazaar: .bzrignore at project root. - Darcs:
-\_darcs/prefs/boring - Fossil: .fossil-settings/ignore-glob -
-Ripgrep/Watchexec/generic: .ignore at project root and child
-directories.
+  \- Git: .gitignore at project root and child directories,
+  .git/info/exclude, and the file pointed to by \`core.excludesFile\` in
+  .git/config. - Mercurial: .hgignore at project root and child
+  directories. - Bazaar: .bzrignore at project root. - Darcs:
+  \_darcs/prefs/boring - Fossil: .fossil-settings/ignore-glob -
+  Ripgrep/Watchexec/generic: .ignore at project root and child
+  directories.
 
-VCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used
-if the corresponding VCS is discovered to be in use for the
-project/origin. For example, a .bzrignore in a Git repository will be
-discarded.
+  VCS ignore files (Git, Mercurial, Bazaar, Darcs, Fossil) are only used
+  if the corresponding VCS is discovered to be in use for the
+  project/origin. For example, a .bzrignore in a Git repository will be
+  discarded.
 
 **\--no-vcs-ignore**
 
-:   Dont load gitignores
+: Dont load gitignores
 
-Among other VCS exclude files, like for Mercurial, Subversion, Bazaar,
-DARCS, Fossil. Note that Watchexec will detect which of these is in use,
-if any, and only load the relevant files. Both global (like
-\~/.gitignore) and local (like .gitignore) files are considered.
+  Among other VCS exclude files, like for Mercurial, Subversion, Bazaar,
+  DARCS, Fossil. Note that Watchexec will detect which of these is in
+  use, if any, and only load the relevant files. Both global (like
+  \~/.gitignore) and local (like .gitignore) files are considered.
 
-This option is useful if you want to watch files that are ignored by
-Git.
+  This option is useful if you want to watch files that are ignored by
+  Git.
 
 **\--project-origin** *\<DIRECTORY\>*
 
-:   Set the project origin
+: Set the project origin
 
-Watchexec will attempt to discover the projects \"origin\" (or \"root\")
-by searching for a variety of markers, like files or directory patterns.
-It does its best but sometimes gets it it wrong, and you can override
-that with this option.
+  Watchexec will attempt to discover the projects \"origin\" (or
+  \"root\") by searching for a variety of markers, like files or
+  directory patterns. It does its best but sometimes gets it it wrong,
+  and you can override that with this option.
 
-The project origin is used to determine the path of certain ignore
-files, which VCS is being used, the meaning of a leading / in filtering
-patterns, and maybe more in the future.
+  The project origin is used to determine the path of certain ignore
+  files, which VCS is being used, the meaning of a leading / in
+  filtering patterns, and maybe more in the future.
 
-When set, Watchexec will also not bother searching, which can be
-significantly faster.
+  When set, Watchexec will also not bother searching, which can be
+  significantly faster.
 
 **-w**, **\--watch** *\<PATH\>*
 
-:   Watch a specific file or directory
+: Watch a specific file or directory
 
-By default, Watchexec watches the current directory.
+  By default, Watchexec watches the current directory.
 
-When watching a single file, its often better to watch the containing
-directory instead, and filter on the filename. Some editors may replace
-the file with a new one when saving, and some platforms may not detect
-that or further changes.
+  When watching a single file, its often better to watch the containing
+  directory instead, and filter on the filename. Some editors may
+  replace the file with a new one when saving, and some platforms may
+  not detect that or further changes.
 
-Upon starting, Watchexec resolves a \"project origin\" from the watched
-paths. See the help for \--project-origin for more information.
+  Upon starting, Watchexec resolves a \"project origin\" from the
+  watched paths. See the help for \--project-origin for more
+  information.
 
-This option can be specified multiple times to watch multiple files or
-directories.
+  This option can be specified multiple times to watch multiple files or
+  directories.
 
-The special value /dev/null, provided as the only path watched, will
-cause Watchexec to not watch any paths. Other event sources (like
-signals or key events) may still be used.
+  The special value /dev/null, provided as the only path watched, will
+  cause Watchexec to not watch any paths. Other event sources (like
+  signals or key events) may still be used.
 
 **-W**, **\--watch-non-recursive** *\<PATH\>*
 
-:   Watch a specific directory, non-recursively
+: Watch a specific directory, non-recursively
 
-Unlike -w, folders watched with this option are not recursed into.
+  Unlike -w, folders watched with this option are not recursed into.
 
-This option can be specified multiple times to watch multiple
-directories non-recursively.
+  This option can be specified multiple times to watch multiple
+  directories non-recursively.
 
 **-F**, **\--watch-file** *\<PATH\>*
 
-:   Watch files and directories from a file
+: Watch files and directories from a file
 
-Each line in the file will be interpreted as if given to -w.
+  Each line in the file will be interpreted as if given to -w.
 
-For more complex uses (like watching non-recursively), use the argfile
-capability: build a file containing command-line options and pass it to
-watchexec with \`@path/to/argfile\`.
+  For more complex uses (like watching non-recursively), use the argfile
+  capability: build a file containing command-line options and pass it
+  to watchexec with \`@path/to/argfile\`.
 
-The special value - will read from STDIN; this in incompatible with
-\--stdin-quit.
+  The special value - will read from STDIN; this in incompatible with
+  \--stdin-quit.
 
 **\--no-follow-symlinks**
 
-:   Dont follow symlinks when watching
+: Dont follow directory symlinks when watching
 
-By default, Watchexec will follow symbolic links when setting up
-filesystem watches, which means events from the symlink target are
-reported using the symlink path. With this option, symlinks are not
-followed: the symlink itself may still produce events, but its target
-will not be watched through the link.
+  By default, Watchexec follows directory symlinks while constructing
+  recursive watches. With this option, their targets are not included;
+  changes to the symlinks themselves may still produce events.
 
-This can be useful when ignored paths are reachable via symlinks, or
-when watching a directory that contains symlinks pointing outside the
-project (e.g. Bazel output symlinks).
+  The native macOS watcher does not follow directory symlinks outside
+  the watched hierarchy, even without this option.
 
 # DEBUGGING
 
 **\--log-file** \[*\<PATH\>*\]
 
-:   Write diagnostic logs to a file
+: Write diagnostic logs to a file
 
-This writes diagnostic logs to a file, instead of the terminal, in JSON
-format. If a log level was not already specified, this will set it to
--vvv.
+  This writes diagnostic logs to a file, instead of the terminal, in
+  JSON format. If a log level was not already specified, this will set
+  it to -vvv.
 
-If a path is not provided, the default is the working directory. Note
-that with \--ignore-nothing, the write events to the log will likely get
-picked up by Watchexec, causing a loop; prefer setting a path outside of
-the watched directory.
+  If a path is not provided, the default is the working directory. Note
+  that with \--ignore-nothing, the write events to the log will likely
+  get picked up by Watchexec, causing a loop; prefer setting a path
+  outside of the watched directory.
 
-If the path provided is a directory, a file will be created in that
-directory. The file name will be the current date and time, in the
-format watchexec.YYYY-MM-DDTHH-MM-SSZ.log.
+  If the path provided is a directory, a file will be created in that
+  directory. The file name will be the current date and time, in the
+  format watchexec.YYYY-MM-DDTHH-MM-SSZ.log.
 
 **\--print-events**
 
-:   Print events that trigger actions
+: Print events that trigger actions
 
-This prints the events that triggered the action when handling it (after
-debouncing), in a human readable form. This is useful for debugging
-filters.
+  This prints the events that triggered the action when handling it
+  (after debouncing), in a human readable form. This is useful for
+  debugging filters.
 
-Use -vvv instead when you need more diagnostic information.
+  Use -vvv instead when you need more diagnostic information.
 
 **-v**, **\--verbose**
 
-:   Set diagnostic log level
+: Set diagnostic log level
 
-This enables diagnostic logging, which is useful for investigating bugs
-or gaining more insight into faulty filters or \"missing\" events. Use
-multiple times to increase verbosity.
+  This enables diagnostic logging, which is useful for investigating
+  bugs or gaining more insight into faulty filters or \"missing\"
+  events. Use multiple times to increase verbosity.
 
-Goes up to -vvvv. When submitting bug reports, default to a -vvv log
-level.
+  Goes up to -vvvv. When submitting bug reports, default to a -vvv log
+  level.
 
-You may want to use with \--log-file to avoid polluting your terminal.
+  You may want to use with \--log-file to avoid polluting your terminal.
 
-Setting \$WATCHEXEC_LOG also works, and takes precedence, but is not
-recommended. However, using \$WATCHEXEC_LOG is the only way to get logs
-from before these options are parsed.
+  Setting \$WATCHEXEC_LOG also works, and takes precedence, but is not
+  recommended. However, using \$WATCHEXEC_LOG is the only way to get
+  logs from before these options are parsed.
 
 # OUTPUT
 
 **\--bell**
 
-:   Ring the terminal bell on command completion
+: Ring the terminal bell on command completion
 
 **-c**, **\--clear** \[*\<MODE\>*\]
 
-:   Clear screen before running command
+: Clear screen before running command
 
-If this doesnt completely clear the screen, try \--clear=reset.
+  If this doesnt completely clear the screen, try \--clear=reset.
 
 **\--color** *\<MODE\>* \[default: auto\]
 
-:   When to use terminal colours
+: When to use terminal colours
 
-Setting the environment variable \`NO_COLOR\` to any value is equivalent
-to \`\--color=never\`.
+  Setting the environment variable \`NO_COLOR\` to any value is
+  equivalent to \`\--color=never\`.
 
 **-N**, **\--notify** \[*\<WHEN\>*\]
 
-:   Alert when commands start and end
+: Alert when commands start and end
 
-With this, Watchexec will emit a desktop notification when a command
-starts and ends, on supported platforms. On unsupported platforms, it
-may silently do nothing, or log a warning.
+  With this, Watchexec will emit a desktop notification when a command
+  starts and ends, on supported platforms. On unsupported platforms, it
+  may silently do nothing, or log a warning.
 
-The mode can be specified to only notify when the command \`start\`s,
-\`end\`s, or for \`both\` (which is the default).
+  The mode can be specified to only notify when the command \`start\`s,
+  \`end\`s, or for \`both\` (which is the default).
 
 **-q**, **\--quiet**
 
-:   Dont print starting and stopping messages
+: Dont print starting and stopping messages
 
-By default Watchexec will print a message when the command starts and
-stops. This option disables this behaviour, so only the commands output,
-warnings, and errors will be printed.
+  By default Watchexec will print a message when the command starts and
+  stops. This option disables this behaviour, so only the commands
+  output, warnings, and errors will be printed.
 
 **\--timings**
 
-:   Print how long the command took to run
+: Print how long the command took to run
 
-This may not be exactly accurate, as it includes some overhead from
-Watchexec itself. Use the \`time\` utility, high-precision timers, or
-benchmarking tools for more accurate results.
+  This may not be exactly accurate, as it includes some overhead from
+  Watchexec itself. Use the \`time\` utility, high-precision timers, or
+  benchmarking tools for more accurate results.
 
 # EXTRA
 

--- a/doc/watchexec.1.md
+++ b/doc/watchexec.1.md
@@ -545,14 +545,8 @@ The signal can be specified with the \--signal option.
 By default, and where available, Watchexec uses the operating systems
 native file system watching capabilities. This option disables that and
 instead uses a polling mechanism, which is less efficient but can work
-around issues with some file systems (like network shares) or edge cases.
-It also forces physical ignore pruning on platforms whose native FSEvents
-or Kqueue backends retain Notify-owned recursion.
-
-Polling registers each accepted directory separately, so work scales with
-directory count. Initial traversal reads one directory synchronously at a
-time; it yields between directories, but one exceptionally large or slow
-directory can still delay startup.
+around issues with some file systems (like network shares) or edge
+cases.
 
 Optionally takes a unit-less value in milliseconds, or a time span value
 such as \"2s 500ms\", to use as the polling interval. If not specified,
@@ -724,19 +718,6 @@ pattern will be excluded. Multiple patterns can be given by repeating
 the option. Events that are not from files (e.g. signals, keyboard
 events) will pass through untouched.
 
-When the actual watcher backend is Inotify, Windows
-ReadDirectoryChanges, or Poll, ignore files, built-in ignores, \--ignore,
-and \--ignore-file also prune matching directories from the watched
-source tree. Positive filters, extension filters, filesystem event kinds,
-and filter programs only filter events after they are observed; they do
-not prune sources.
-
-Native FSEvents and Kqueue retain Notify's recursion, so ignores filter
-their events without physically pruning ignored directories. Use \--poll
-to force source pruning on those platforms. Ignore files are discovered
-and read once at startup; edits and newly created ignore files are not
-loaded while Watchexec is running.
-
 **\--ignore-file** *\<PATH\>*
 
 :   Files to load ignores from
@@ -876,11 +857,6 @@ paths. See the help for \--project-origin for more information.
 This option can be specified multiple times to watch multiple files or
 directories.
 
-Every specified path is an exact watch root. The root itself is retained
-even if it matches an ignore rule, while descendants of a recursive
-directory still obey ignores. Filesystem events for the exact root also
-bypass CLI ignore rules.
-
 The special value /dev/null, provided as the only path watched, will
 cause Watchexec to not watch any paths. Other event sources (like
 signals or key events) may still be used.
@@ -890,9 +866,6 @@ signals or key events) may still be used.
 :   Watch a specific directory, non-recursively
 
 Unlike -w, folders watched with this option are not recursed into.
-
-The exact path is retained even if it matches an ignore rule, and
-filesystem events for that root bypass CLI ignore rules.
 
 This option can be specified multiple times to watch multiple
 directories non-recursively.
@@ -923,12 +896,6 @@ will not be watched through the link.
 This can be useful when ignored paths are reachable via symlinks, or
 when watching a directory that contains symlinks pointing outside the
 project (e.g. Bazel output symlinks).
-
-Watchexec enforces this across every path component for Inotify, Windows
-ReadDirectoryChanges, and Poll. On those backends it also guards a
-missing root from its nearest safe existing ancestor, so the root can be
-watched if it appears later. Other native backends delegate symlink
-handling to Notify and may behave differently.
 
 # DEBUGGING
 


### PR DESCRIPTION
- only supports inotify, Windows ReadDirectoryChanges, and PollWatcher; FSEvents (Mac) and kqueue (BSDs) still use the `notify` crate directly for upstream and correctness reasons - these keep working as before with no regression - eventually notify will grow a filtered watcher implementation and we'll probably switch to it
- this lets us finally do ignore filtering on the watch tree recursion, which should massively improve startup performance on large trees
- this also lets us recover from watch path errors more gracefully, avoiding parts of the tree we lack permissions on but continuing to watch the rest - again notify will eventually land this https://github.com/notify-rs/notify/pull/970 and we'll switch to that when it does
- we also implement #190's "watch file by watching the parent folder" via this same mechanism, which means it's not yet supported on mac/bsd (but follow ups will add support before release)

Closes #218.

Partially implements #190 (only on supported platforms).

🤖 Assisted by [Claude Code](https://claude.com/claude-code) and [Codex](https://chatgpt.com/codex/)
