### PR TITLE
fix: replace kqueue with polling

### DIFF
--- a/crates/lib/CHANGELOG.md
+++ b/crates/lib/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Continue traversing independent sibling paths after a scan or watch failure, reporting the failure through the runtime error hook.
 - Classify and latch watch or handle exhaustion so it is reported once per reconciliation rather than once per path.
 - For managed recursion, watch the nearest safe existing ancestor of a missing root so the root can be watched when it is created.
-- We keep native FSEvents and Kqueue on Notify-owned recursion for this release: per-directory updates would repeatedly rebuild FSEvents' shared stream at its since-now history boundary, while Kqueue needs internal per-entry recursion. Use Poll when physical source pruning is required on these platforms.
+- We keep native FSEvents on Notify-owned recursion for this release: per-directory updates would repeatedly rebuild its shared stream at its since-now history boundary.
+- If Notify recommends Kqueue, Watchexec uses Poll instead because Kqueue filesystem watching is resource-intensive and its non-recursive semantics are not reliable enough.
 
 ## v8.3.0 (2026-08-22)
 

--- a/crates/lib/src/sources/fs.rs
+++ b/crates/lib/src/sources/fs.rs
@@ -12,10 +12,11 @@
 //! state.
 //!
 //! Filtered recursive traversal is not supported on FSEvents, because changing individual watches
-//! recreates Notify's shared stream from `SinceNow` and can lose intervening events, or Kqueue,
-//! because Notify recursively registers descendants even for non-recursive watches. On these
-//! backends, recursive watches traverse the entire directory tree; Watchexec delegates recursive
-//! traversal to [`notify`].
+//! recreates Notify's shared stream from `SinceNow` and can lose intervening events. On this backend,
+//! recursive watches traverse the entire directory tree; Watchexec delegates recursive traversal to
+//! [`notify`].
+//!
+//! If Notify recommends Kqueue, Watchexec uses Poll instead.
 
 mod backend;
 mod recursor;
@@ -67,6 +68,8 @@ pub enum Watcher {
 	///
 	/// For platforms Notify supports, that's a [native implementation][notify::RecommendedWatcher],
 	/// for others it's polling with a default interval.
+	///
+	/// If Notify recommends Kqueue, Watchexec uses Poll instead.
 	#[default]
 	Native,
 

--- a/crates/lib/src/sources/fs.rs
+++ b/crates/lib/src/sources/fs.rs
@@ -90,9 +90,16 @@ impl Watcher {
 	}
 
 	fn backend_kind(self) -> notify::WatcherKind {
+		self.backend_kind_for(<notify::RecommendedWatcher as notify::Watcher>::kind())
+	}
+
+	const fn backend_kind_for(self, recommended: notify::WatcherKind) -> notify::WatcherKind {
 		match self {
-			Self::Native => <notify::RecommendedWatcher as notify::Watcher>::kind(),
-			Self::Poll(_) => <notify::PollWatcher as notify::Watcher>::kind(),
+			Self::Native => match recommended {
+				notify::WatcherKind::Kqueue => notify::WatcherKind::PollWatcher,
+				_ => recommended,
+			},
+			Self::Poll(_) => notify::WatcherKind::PollWatcher,
 		}
 	}
 
@@ -884,9 +891,48 @@ mod tests {
 		assert!(!managed_backend(notify::WatcherKind::Fsevent));
 		assert!(!managed_backend(notify::WatcherKind::Kqueue));
 		assert!(!managed_backend(notify::WatcherKind::NullWatcher));
-		let native_kind = <notify::RecommendedWatcher as notify::Watcher>::kind();
+		let recommended = <notify::RecommendedWatcher as notify::Watcher>::kind();
+		let native_kind = Watcher::Native.backend_kind_for(recommended);
 		assert_eq!(Watcher::Native.backend_kind(), native_kind);
 		assert_eq!(Watcher::Native.managed(), managed_backend(native_kind));
+	}
+
+	#[test]
+	fn native_backend_falls_back_from_kqueue_to_poll() {
+		assert_eq!(
+			Watcher::Native.backend_kind_for(notify::WatcherKind::Kqueue),
+			notify::WatcherKind::PollWatcher
+		);
+	}
+
+	#[test]
+	fn native_backend_preserves_other_recommendations() {
+		for kind in [
+			notify::WatcherKind::Inotify,
+			notify::WatcherKind::Fsevent,
+			notify::WatcherKind::PollWatcher,
+			notify::WatcherKind::ReadDirectoryChangesWatcher,
+			notify::WatcherKind::NullWatcher,
+		] {
+			assert_eq!(Watcher::Native.backend_kind_for(kind), kind);
+		}
+	}
+
+	#[test]
+	fn explicit_poll_ignores_native_recommendation() {
+		let poll = Watcher::Poll(std::time::Duration::from_secs(1));
+		for recommended in [
+			notify::WatcherKind::Inotify,
+			notify::WatcherKind::Fsevent,
+			notify::WatcherKind::Kqueue,
+			notify::WatcherKind::ReadDirectoryChangesWatcher,
+			notify::WatcherKind::NullWatcher,
+		] {
+			assert_eq!(
+				poll.backend_kind_for(recommended),
+				notify::WatcherKind::PollWatcher
+			);
+		}
 	}
 
 	#[test]

--- a/crates/lib/src/sources/fs/backend.rs
+++ b/crates/lib/src/sources/fs/backend.rs
@@ -45,13 +45,36 @@ pub(super) fn create_notify(
 	follow_symlinks: bool,
 	handler: impl notify::EventHandler,
 ) -> notify::Result<Box<dyn Backend>> {
+	create_notify_for_recommended(
+		kind,
+		<notify::RecommendedWatcher as notify::Watcher>::kind(),
+		follow_symlinks,
+		handler,
+	)
+	.map(|(backend, _)| backend)
+}
+
+fn create_notify_for_recommended(
+	kind: Watcher,
+	recommended: notify::WatcherKind,
+	follow_symlinks: bool,
+	handler: impl notify::EventHandler,
+) -> notify::Result<(Box<dyn Backend>, notify::WatcherKind)> {
 	let config = notify_config(kind, follow_symlinks);
-	if kind.backend_kind() == notify::WatcherKind::PollWatcher {
-		notify::PollWatcher::new(handler, config)
-			.map(|watcher| Box::new(watcher) as Box<dyn Backend>)
+	if kind.backend_kind_for(recommended) == notify::WatcherKind::PollWatcher {
+		notify::PollWatcher::new(handler, config).map(|watcher| {
+			(
+				Box::new(watcher) as Box<dyn Backend>,
+				<notify::PollWatcher as notify::Watcher>::kind(),
+			)
+		})
 	} else {
-		notify::RecommendedWatcher::new(handler, config)
-			.map(|watcher| Box::new(watcher) as Box<dyn Backend>)
+		notify::RecommendedWatcher::new(handler, config).map(|watcher| {
+			(
+				Box::new(watcher) as Box<dyn Backend>,
+				<notify::RecommendedWatcher as notify::Watcher>::kind(),
+			)
+		})
 	}
 }
 
@@ -101,6 +124,44 @@ mod tests {
 	use std::io;
 
 	use super::*;
+
+	fn ignore_events(_: notify::Result<notify::Event>) {}
+
+	#[test]
+	fn factory_constructs_poll_for_kqueue_recommendation() {
+		let (_, actual) = create_notify_for_recommended(
+			Watcher::Native,
+			notify::WatcherKind::Kqueue,
+			true,
+			ignore_events,
+		)
+		.unwrap();
+		assert_eq!(actual, notify::WatcherKind::PollWatcher);
+	}
+
+	#[test]
+	fn factory_constructs_selected_native_backend() {
+		let (_, actual) = create_notify_for_recommended(
+			Watcher::Native,
+			<notify::RecommendedWatcher as notify::Watcher>::kind(),
+			true,
+			ignore_events,
+		)
+		.unwrap();
+		assert_eq!(actual, Watcher::Native.backend_kind());
+	}
+
+	#[test]
+	fn factory_constructs_poll_for_explicit_poll() {
+		let (_, actual) = create_notify_for_recommended(
+			Watcher::Poll(std::time::Duration::from_millis(1234)),
+			<notify::RecommendedWatcher as notify::Watcher>::kind(),
+			true,
+			ignore_events,
+		)
+		.unwrap();
+		assert_eq!(actual, notify::WatcherKind::PollWatcher);
+	}
 
 	#[test]
 	fn native_poll_uses_notify_default_interval() {

--- a/crates/lib/src/sources/fs/backend.rs
+++ b/crates/lib/src/sources/fs/backend.rs
@@ -45,14 +45,21 @@ pub(super) fn create_notify(
 	follow_symlinks: bool,
 	handler: impl notify::EventHandler,
 ) -> notify::Result<Box<dyn Backend>> {
-	use notify::Config;
+	let config = notify_config(kind, follow_symlinks);
+	if kind.backend_kind() == notify::WatcherKind::PollWatcher {
+		notify::PollWatcher::new(handler, config)
+			.map(|watcher| Box::new(watcher) as Box<dyn Backend>)
+	} else {
+		notify::RecommendedWatcher::new(handler, config)
+			.map(|watcher| Box::new(watcher) as Box<dyn Backend>)
+	}
+}
 
-	let config = Config::default().with_follow_symlinks(follow_symlinks);
+fn notify_config(kind: Watcher, follow_symlinks: bool) -> notify::Config {
+	let config = notify::Config::default().with_follow_symlinks(follow_symlinks);
 	match kind {
-		Watcher::Native => notify::RecommendedWatcher::new(handler, config)
-			.map(|watcher| Box::new(watcher) as Box<dyn Backend>),
-		Watcher::Poll(delay) => notify::PollWatcher::new(handler, config.with_poll_interval(delay))
-			.map(|watcher| Box::new(watcher) as Box<dyn Backend>),
+		Watcher::Native => config,
+		Watcher::Poll(delay) => config.with_poll_interval(delay),
 	}
 }
 
@@ -94,6 +101,29 @@ mod tests {
 	use std::io;
 
 	use super::*;
+
+	#[test]
+	fn native_poll_uses_notify_default_interval() {
+		assert_eq!(
+			notify_config(Watcher::Native, true).poll_interval(),
+			notify::Config::default().poll_interval()
+		);
+	}
+
+	#[test]
+	fn explicit_poll_uses_configured_interval() {
+		let interval = std::time::Duration::from_millis(1234);
+		assert_eq!(
+			notify_config(Watcher::Poll(interval), true).poll_interval(),
+			Some(interval)
+		);
+	}
+
+	#[test]
+	fn notify_config_preserves_symlink_policy() {
+		assert!(notify_config(Watcher::Native, true).follow_symlinks());
+		assert!(!notify_config(Watcher::Native, false).follow_symlinks());
+	}
 
 	#[test]
 	fn max_files_watch_is_always_a_resource_error() {


### PR DESCRIPTION
kqueue is unreliable for our new fine-grained recursion handling (#1091), and also has various performance implications (some users of the notify crate (via higher level consumers like Zed, codex) report hundreds of MBs of kernel memory and crashes taking _hours_ to handle). We'll eventually support FreeBSD's native inotify support (see #1093), but for now, we disable kqueue entirely and use polling on BSDs.