### PR TITLE
fix(release): normalise changelog Next sections

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -65,6 +65,25 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Normalize changelog headers
+        if: steps.release-plz.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          RELEASE_PR: ${{ steps.release-plz.outputs.pr }}
+        run: |
+          pr_number=$(jq -r '.number' <<< "$RELEASE_PR")
+          gh pr checkout "$pr_number"
+
+          bin/changelog-next --fix
+          bin/changelog-next --check
+
+          git add -- ':(glob)crates/**/CHANGELOG.md'
+          if ! git diff --cached --quiet; then
+            git config user.name github-actions[bot]
+            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+            git commit -m "release: normalize changelog headers"
+            git push
+          fi
       - name: Update CLI release metadata
         if: steps.release-plz.outputs.pr != '' && contains(steps.release-plz.outputs.pr, 'watchexec-cli')
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changelogs:
+    name: Check changelogs
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Check Next sections
+      run: bin/changelog-next --check
+
   libs:
     strategy:
       fail-fast: false
@@ -224,6 +233,7 @@ jobs:
     name: Tests pass
     needs:
     - bosion
+    - changelogs
     - cli-e2e
     - cli-unit
     - cross-checks

--- a/bin/changelog-next
+++ b/bin/changelog-next
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+from pathlib import Path
+
+NEXT_HEADING = "## Next (YYYY-MM-DD)"
+OPENING = ("# Changelog", "", NEXT_HEADING)
+
+
+def line_content(line):
+    if line.endswith("\r\n"):
+        return line[:-2]
+    if line.endswith(("\r", "\n")):
+        return line[:-1]
+    return line
+
+
+def read_changelog(path):
+    try:
+        text = path.read_bytes().decode("utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        return None, f"{path}: cannot read changelog: {error}"
+
+    lines = text.splitlines(keepends=True)
+    opening = tuple(line_content(line) for line in lines[:3])
+    if opening != OPENING:
+        return None, (
+            f"{path}: expected the first three lines to be "
+            f"'# Changelog', a blank line, and '{NEXT_HEADING}'"
+        )
+
+    return lines, None
+
+
+def marker_count(lines):
+    return sum(line_content(line) == NEXT_HEADING for line in lines)
+
+
+def normalize(lines):
+    normalized = []
+    seen_marker = False
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if line_content(line) != NEXT_HEADING:
+            normalized.append(line)
+            index += 1
+            continue
+
+        if not seen_marker:
+            seen_marker = True
+            normalized.append(line)
+            index += 1
+            continue
+
+        index += 1
+        if index < len(lines) and line_content(lines[index]) == "":
+            index += 1
+
+    if lines and line_content(lines[-1]) == lines[-1]:
+        while normalized and line_content(normalized[-1]) == "":
+            normalized.pop()
+        if normalized:
+            normalized[-1] = line_content(normalized[-1])
+
+    return normalized
+
+
+def find_changelogs(root):
+    return sorted((root / "crates").glob("**/CHANGELOG.md"))
+
+
+def load_changelogs(paths):
+    changelogs = []
+    errors = []
+    for path in paths:
+        lines, error = read_changelog(path)
+        if error:
+            errors.append(error)
+        else:
+            changelogs.append((path, lines))
+    return changelogs, errors
+
+
+def validate(changelogs):
+    errors = []
+    for path, lines in changelogs:
+        count = marker_count(lines)
+        if count != 1:
+            errors.append(
+                f"{path}: expected exactly one '{NEXT_HEADING}' heading, found {count}"
+            )
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check or normalize Watchexec changelog Next headings."
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="validate without editing")
+    mode.add_argument("--fix", action="store_true", help="remove duplicate headings")
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parent.parent
+    paths = find_changelogs(root)
+    if not paths:
+        print(f"{root}: no crate changelogs found", file=sys.stderr)
+        return 1
+
+    changelogs, errors = load_changelogs(paths)
+    if errors:
+        print(*errors, sep="\n", file=sys.stderr)
+        return 1
+
+    if args.fix:
+        for path, lines in changelogs:
+            normalized = normalize(lines)
+            if normalized != lines:
+                try:
+                    path.write_bytes("".join(normalized).encode("utf-8"))
+                except OSError as error:
+                    print(f"{path}: cannot write changelog: {error}", file=sys.stderr)
+                    return 1
+                print(f"normalized {path.relative_to(root)}")
+
+        changelogs, errors = load_changelogs(paths)
+        if errors:
+            print(*errors, sep="\n", file=sys.stderr)
+            return 1
+
+    errors = validate(changelogs)
+    if errors:
+        print(*errors, sep="\n", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/bosion/CHANGELOG.md
+++ b/crates/bosion/CHANGELOG.md
@@ -7,8 +7,6 @@
 - adopt release-plz
 - use fmt::Write over push_str ([#1054](https://github.com/watchexec/watchexec/pull/1054))
 
-## Next (YYYY-MM-DD)
-
 ## v2.0.0 (2026-01-20)
 
 - Remove `GIT_COMMIT_DESCRIPTION`. In practice this had zero usage, and dropping it means we can stop depending on gix.

--- a/crates/events/CHANGELOG.md
+++ b/crates/events/CHANGELOG.md
@@ -7,8 +7,6 @@
 - update snapbox requirement in /crates/events
 - update changelogs
 
-## Next (YYYY-MM-DD)
-
 ## v6.1.0 (2026-02-22)
 
 - Add `Keyboard::Key` to describe arbitrary single-key keyboard events

--- a/crates/filterer/globset/CHANGELOG.md
+++ b/crates/filterer/globset/CHANGELOG.md
@@ -16,8 +16,6 @@
 - Release
 - Release
 
-## Next (YYYY-MM-DD)
-
 ## v8.0.0 (2025-05-15)
 
 ## v7.0.0 (2025-02-09)

--- a/crates/filterer/ignore/CHANGELOG.md
+++ b/crates/filterer/ignore/CHANGELOG.md
@@ -16,8 +16,6 @@
 - Release
 - Release
 
-## Next (YYYY-MM-DD)
-
 ## v7.0.0 (2025-05-15)
 
 - Deps: remove unused dependency `watchexec-signals` ([#930](https://github.com/watchexec/watchexec/pull/930))

--- a/crates/ignore-files/CHANGELOG.md
+++ b/crates/ignore-files/CHANGELOG.md
@@ -11,8 +11,6 @@
 - update gix-config requirement in /crates/ignore-files
 - adopt release-plz
 
-## Next (YYYY-MM-DD)
-
 ## v3.0.5 (2026-01-20)
 
 - Deps: gix-config 0.50

--- a/crates/lib/CHANGELOG.md
+++ b/crates/lib/CHANGELOG.md
@@ -19,8 +19,6 @@
 - upgrade to nix 0.31 ([#1016](https://github.com/watchexec/watchexec/pull/1016))
 - Release
 
-## Next (YYYY-MM-DD)
-
 ## v8.2.0 (2026-03-02)
 
 - Feat: add `fs_ready` signal for watcher readiness ([#1024](https://github.com/watchexec/watchexec/pull/1024))

--- a/crates/project-origins/CHANGELOG.md
+++ b/crates/project-origins/CHANGELOG.md
@@ -5,8 +5,6 @@
 
 - adopt release-plz
 
-## Next (YYYY-MM-DD)
-
 ## v1.4.2 (2025-05-15)
 
 ## v1.4.1 (2025-02-09)

--- a/crates/signals/CHANGELOG.md
+++ b/crates/signals/CHANGELOG.md
@@ -9,8 +9,6 @@
 - upgrade to nix 0.31 ([#1016](https://github.com/watchexec/watchexec/pull/1016))
 - opt some crates into 3 targets for docsrs
 
-## Next (YYYY-MM-DD)
-
 ## v5.0.1 (2026-01-20)
 
 ## v5.0.0 (2025-05-15)

--- a/crates/supervisor/CHANGELOG.md
+++ b/crates/supervisor/CHANGELOG.md
@@ -10,8 +10,6 @@
 - upgrade to nix 0.31 ([#1016](https://github.com/watchexec/watchexec/pull/1016))
 - opt some crates into 3 targets for docsrs
 
-## Next (YYYY-MM-DD)
-
 ## v5.2.0 (2026-03-09)
 
 - Add the ability to use `spawn_with` from process-wrap (#1013)

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,6 +20,8 @@ name = "test-socketfd"
 publish = false
 release = false
 
+# release-plz retains custom `Next` headings when generating a release, so the release
+# workflow normalizes each generated PR.
 [changelog]
 header = """# Changelog
 


### PR DESCRIPTION
🤖

## Summary

- remove the lower duplicate `## Next (YYYY-MM-DD)` section from every crate changelog while preserving the top section
- add a reusable check/fix script and run it on generated release PRs in an appended commit
- require the one-top-section invariant in the test workflow

release-plz currently recognizes only `Unreleased` headings as persistent, so it retains Watchexec's custom `Next` heading when prepending each release. The postprocessor keeps the existing convention without rewriting generated release commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
