### PR TITLE
fix(release): preserve curated changelog entries

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,8 +20,8 @@ name = "test-socketfd"
 publish = false
 release = false
 
-# release-plz retains custom `Next` headings when generating a release, so the release
-# workflow normalizes each generated PR.
+# The body only creates the version heading. The release workflow removes release-plz's
+# retained `Next` heading so its curated entries become that version's release notes.
 [changelog]
 header = """# Changelog
 
@@ -29,9 +29,5 @@ header = """# Changelog
 """
 body = """
 ## v{{ version }} ({{ timestamp | date(format="%Y-%m-%d") }})
-
-{% for commit in commits -%}
-- {% if commit.breaking %}**Breaking:** {% endif %}{{ commit.message }}
-{% endfor %}
 """
 trim = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,8 +20,6 @@ name = "test-socketfd"
 publish = false
 release = false
 
-# The body only creates the version heading. The release workflow removes release-plz's
-# retained `Next` heading so its curated entries become that version's release notes.
 [changelog]
 header = """# Changelog
 


### PR DESCRIPTION
🤖

## Summary

- stop rendering release commits into crate changelogs
- have release-plz create only the dated version heading
- let the normalizer added in #1096 place the existing curated `Next` entries beneath that heading

The current release PR puts an automatically generated commit list ahead of the manually curated entries. This keeps commit analysis for version selection while restoring the changelogs' curated content model.

This PR does not publish crates, create tags, or change versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
