### PR TITLE
docs: fix typos in comments and trace messages

### DIFF
--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -14,7 +14,7 @@ fn get_placeholder_data() -> &'static str {
 pub enum GeneratedFileNesting {
 	/// Only one level of files
 	Flat,
-	/// Random, up to a certiain maximum
+	/// Random, up to a certain maximum
 	RandomToMax(usize),
 }
 

--- a/crates/lib/src/action/handler.rs
+++ b/crates/lib/src/action/handler.rs
@@ -46,7 +46,7 @@ use super::QuitManner;
 ///    [`EventChannelTrySend` errors](crate::error::RuntimeError::EventChannelTrySend).
 ///
 ///    If you want to do something long-running, you should either ignore that error, and accept
-///    events may be dropped, or preferrably spawn a task to do it, and return from the action
+///    events may be dropped, or preferably spawn a task to do it, and return from the action
 ///    handler as soon as possible.
 #[derive(Debug)]
 pub struct Handler {

--- a/crates/lib/src/action/worker.rs
+++ b/crates/lib/src/action/worker.rs
@@ -156,9 +156,9 @@ pub async fn throttle_collect(
 					trace!(?event, ?priority, "got event");
 
 					if priority == Priority::Urgent {
-						trace!("urgent event, by-passing filters");
+						trace!("urgent event, bypassing filters");
 					} else if event.is_empty() {
-						trace!("empty event, by-passing filters");
+						trace!("empty event, bypassing filters");
 					} else {
 						let filtered = config.filterer.check_event(&event, priority);
 						match filtered {
@@ -185,7 +185,7 @@ pub async fn throttle_collect(
 					set.push(event);
 
 					if priority == Priority::Urgent {
-						trace!("urgent event, by-passing throttle");
+						trace!("urgent event, bypassing throttle");
 					} else {
 						let elapsed = last.elapsed();
 						if elapsed < config.throttle.get() {


### PR DESCRIPTION
Three small spelling fixes, no behaviour change:

- `certiain` -> `certain` (doc comment in `crates/cli/tests/common/mod.rs`)
- `preferrably` -> `preferably` (doc comment in `crates/lib/src/action/handler.rs`)
- `by-passing` -> `bypassing` (three `trace!` messages in `crates/lib/src/action/worker.rs`)

Only comments and log strings are touched.