### PR TITLE
release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: |
   If you use this software, please cite it using these metadata.
 title: "Watchexec: a tool to react to filesystem changes, and a crate ecosystem to power it"
 
-version: "2.7.0"
-date-released: 2026-08-24
+version: "2.7.1"
+date-released: 2026-09-03
 
 repository-code: https://github.com/watchexec/watchexec
 license: Apache-2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "object",
  "rustc-demangle",
  "windows-link 0.2.1",
@@ -363,7 +363,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rayon-core",
 ]
 
@@ -504,12 +504,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1004,12 +1004,13 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1358,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046"
+checksum = "38fc6f029ea67de83cbcbd33fd98c05a48360d2932b39d9fdacbc6eae802d475"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1454,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1523,9 +1524,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -1592,9 +1593,9 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1705,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -1914,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -2070,14 +2071,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
  "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -2317,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
 
 [[package]]
 name = "parking"
@@ -2382,7 +2392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -2619,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -3005,9 +3015,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "snapbox"
@@ -3309,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3636,9 +3646,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3760,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "watchexec"
-version = "8.4.0"
+version = "8.4.1"
 dependencies = [
  "async-priority-channel",
  "atomic-take",
@@ -3783,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "watchexec-cli"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "argfile",
  "blake3",
@@ -3847,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "watchexec-filterer-globset"
-version = "8.0.2"
+version = "8.0.3"
 dependencies = [
  "dunce",
  "ignore",
@@ -3864,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "watchexec-filterer-ignore"
-version = "7.0.2"
+version = "7.0.3"
 dependencies = [
  "ignore",
  "ignore-files",
@@ -3888,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "watchexec-supervisor"
-version = "5.3.1"
+version = "5.4.0"
 dependencies = [
  "boxcar",
  "futures",
@@ -3902,9 +3912,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]
@@ -4418,6 +4428,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "watchexec-cli"
-version = "2.7.0"
+version = "2.7.1"
 
 authors = ["Félix Saparelli <felix@passcod.name>", "Matt Green <mattgreenrocks@gmail.com>"]
 license = "Apache-2.0"
@@ -81,7 +81,7 @@ version = "1.4.4"
 path = "../project-origins"
 
 [dependencies.watchexec]
-version = "8.4.0"
+version = "8.4.1"
 path = "../lib"
 
 [dependencies.watchexec-events]
@@ -94,7 +94,7 @@ version = "5.1.1"
 path = "../signals"
 
 [dependencies.watchexec-filterer-globset]
-version = "8.0.2"
+version = "8.0.3"
 path = "../filterer/globset"
 
 [dependencies.tokio]

--- a/crates/cli/watchexec.exe.manifest
+++ b/crates/cli/watchexec.exe.manifest
@@ -3,7 +3,7 @@
 	<assemblyIdentity
 		type="win32"
 		name="Watchexec.Cli.watchexec"
-		version="2.7.0.0"
+		version="2.7.1.0"
 	/>
 
 	<trustInfo>

--- a/crates/filterer/globset/CHANGELOG.md
+++ b/crates/filterer/globset/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Next (YYYY-MM-DD)
 ## v8.0.3 (2026-09-03)
-## Next (YYYY-MM-DD)
 ## v8.0.2 (2026-08-24)
 - Add source-directory filtering from ignore files and ignore globs, with top-down ancestor semantics suitable for pruning recursive walks.
 - Keep positive filters, extension filters, and exact-path whitelists event-only so they do not prune possible matching descendants.

--- a/crates/filterer/globset/CHANGELOG.md
+++ b/crates/filterer/globset/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+## v8.0.3 (2026-09-03)
+## Next (YYYY-MM-DD)
 ## v8.0.2 (2026-08-24)
 - Add source-directory filtering from ignore files and ignore globs, with top-down ancestor semantics suitable for pruning recursive walks.
 - Keep positive filters, extension filters, and exact-path whitelists event-only so they do not prune possible matching descendants.

--- a/crates/filterer/globset/Cargo.toml
+++ b/crates/filterer/globset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "watchexec-filterer-globset"
-version = "8.0.2"
+version = "8.0.3"
 
 authors = ["Matt Green <mattgreenrocks@gmail.com>", "Félix Saparelli <felix@passcod.name>"]
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ version = "3.0.7"
 path = "../../ignore-files"
 
 [dependencies.watchexec]
-version = "8.4.0"
+version = "8.4.1"
 path = "../../lib"
 
 [dependencies.watchexec-events]
@@ -34,7 +34,7 @@ version = "6.1.2"
 path = "../../events"
 
 [dependencies.watchexec-filterer-ignore]
-version = "7.0.2"
+version = "7.0.3"
 path = "../ignore"
 
 [dev-dependencies]

--- a/crates/filterer/ignore/CHANGELOG.md
+++ b/crates/filterer/ignore/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+## v7.0.3 (2026-09-03)
+## Next (YYYY-MM-DD)
 ## v7.0.2 (2026-08-24)
 - Implement `Filterer::check_dir` with top-down ignore-file semantics for recursive source pruning.
 

--- a/crates/filterer/ignore/CHANGELOG.md
+++ b/crates/filterer/ignore/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Next (YYYY-MM-DD)
 ## v7.0.3 (2026-09-03)
-## Next (YYYY-MM-DD)
 ## v7.0.2 (2026-08-24)
 - Implement `Filterer::check_dir` with top-down ignore-file semantics for recursive source pruning.
 

--- a/crates/filterer/ignore/Cargo.toml
+++ b/crates/filterer/ignore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "watchexec-filterer-ignore"
-version = "7.0.2"
+version = "7.0.3"
 
 authors = ["Félix Saparelli <felix@passcod.name>"]
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ version = "3.0.7"
 path = "../../ignore-files"
 
 [dependencies.watchexec]
-version = "8.4.0"
+version = "8.4.1"
 path = "../../lib"
 
 [dependencies.watchexec-events]

--- a/crates/lib/CHANGELOG.md
+++ b/crates/lib/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+## v8.4.1 (2026-09-03)
+## Next (YYYY-MM-DD)
 ## v8.4.0 (2026-08-24)
 - Add `Filterer::check_dir` and Watchexec-owned, source-filtered recursion for Inotify, Windows ReadDirectoryChanges, and Poll backends.
 - Reconcile managed filesystem sources when roots, watcher selection, symlink policy, or the live filterer changes. `fs_ready` now reports settled reconciliation and may signal after partial nonfatal failures.

--- a/crates/lib/CHANGELOG.md
+++ b/crates/lib/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Next (YYYY-MM-DD)
 ## v8.4.1 (2026-09-03)
-## Next (YYYY-MM-DD)
 ## v8.4.0 (2026-08-24)
 - Add `Filterer::check_dir` and Watchexec-owned, source-filtered recursion for Inotify, Windows ReadDirectoryChanges, and Poll backends.
 - Reconcile managed filesystem sources when roots, watcher selection, symlink policy, or the live filterer changes. `fs_ready` now reports settled reconciliation and may signal after partial nonfatal failures.

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "watchexec"
-version = "8.4.0"
+version = "8.4.1"
 
 authors = ["Félix Saparelli <felix@passcod.name>", "Matt Green <mattgreenrocks@gmail.com>"]
 license = "Apache-2.0"
@@ -33,7 +33,7 @@ version = "5.1.1"
 path = "../signals"
 
 [dependencies.watchexec-supervisor]
-version = "5.3.1"
+version = "5.4.0"
 path = "../supervisor"
 
 [dependencies.tokio]

--- a/crates/supervisor/CHANGELOG.md
+++ b/crates/supervisor/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Next (YYYY-MM-DD)
 ## v5.4.0 (2026-09-03)
-## Next (YYYY-MM-DD)
-
 - Add a child spawn function for supervising processes created by external launchers.
 
 ## v5.3.1 (2026-08-24)

--- a/crates/supervisor/CHANGELOG.md
+++ b/crates/supervisor/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+## v5.4.0 (2026-09-03)
+## Next (YYYY-MM-DD)
 
 - Add a child spawn function for supervising processes created by external launchers.
 

--- a/crates/supervisor/Cargo.toml
+++ b/crates/supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "watchexec-supervisor"
-version = "5.3.1"
+version = "5.4.0"
 
 authors = ["Félix Saparelli <felix@passcod.name>"]
 license = "Apache-2.0 OR MIT"

--- a/doc/watchexec.1
+++ b/doc/watchexec.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH watchexec 1  "watchexec 2.7.0" 
+.TH watchexec 1  "watchexec 2.7.1" 
 .SH NAME
 watchexec \- Execute commands when watched files change
 .SH SYNOPSIS
@@ -652,6 +652,6 @@ Use @argfile as first argument to load arguments from the file \*(Aqargfile\*(Aq
 
 Didn\*(Aqt expect this much output? Use the short \*(Aq\-h\*(Aq flag to get short help.
 .SH VERSION
-v2.7.0
+v2.7.1
 .SH AUTHORS
 Félix Saparelli <felix@passcod.name>, Matt Green <mattgreenrocks@gmail.com>

--- a/doc/watchexec.1.md
+++ b/doc/watchexec.1.md
@@ -997,7 +997,7 @@ Didnt expect this much output? Use the short -h flag to get short help.
 
 # VERSION
 
-v2.7.0
+v2.7.1
 
 # AUTHORS
 


### PR DESCRIPTION



## 🤖 New release

* `watchexec-supervisor`: 5.3.1 -> 5.4.0 (✓ API compatible changes)
* `watchexec`: 8.4.0 -> 8.4.1 (✓ API compatible changes)
* `watchexec-cli`: 2.7.0 -> 2.7.1
* `watchexec-filterer-ignore`: 7.0.2 -> 7.0.3
* `watchexec-filterer-globset`: 8.0.2 -> 8.0.3

<details><summary><i><b>Changelog</b></i></summary><p>







</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).