### PR TITLE
supervisor: support externally spawned children

### DIFF
--- a/crates/supervisor/CHANGELOG.md
+++ b/crates/supervisor/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Next (YYYY-MM-DD)
+
+- Add a child spawn function for supervising processes created by external launchers.
+
 ## v5.3.1 (2026-08-24)
 ## v5.3.0 (2026-08-22)
 

--- a/crates/supervisor/src/job.rs
+++ b/crates/supervisor/src/job.rs
@@ -5,7 +5,7 @@ pub use self::{
 	job::Job,
 	messages::{Control, Ticket},
 	state::CommandState,
-	task::{JobTaskContext, SpawnFn},
+	task::{JobTaskContext, SpawnChildFn, SpawnFn},
 };
 
 #[cfg(test)]

--- a/crates/supervisor/src/job/job.rs
+++ b/crates/supervisor/src/job/job.rs
@@ -51,6 +51,9 @@ pub struct Job {
 
 	/// Mirrors the command state: true when a child process is running.
 	pub(crate) running: Arc<AtomicBool>,
+
+	/// Selects the spawn implementation without extending the public `Control` enum.
+	pub(super) spawner: Arc<super::task::SpawnerSlot>,
 }
 
 impl Job {
@@ -360,6 +363,9 @@ impl Job {
 	/// low-level spawn step. This is useful for delegating process spawning to a privileged
 	/// helper (e.g. for Linux capability granting) while keeping the supervisor's lifecycle
 	/// management.
+	///
+	/// Setting this clears any function previously installed with
+	/// [`set_spawn_child_fn`](Self::set_spawn_child_fn).
 	pub fn set_spawn_fn(
 		&self,
 		fun: impl Fn(&mut tokio::process::Command) -> std::io::Result<tokio::process::Child>
@@ -373,6 +379,39 @@ impl Job {
 	/// Unset any spawn function, reverting to the default `CommandWrap::spawn()`.
 	pub fn unset_spawn_fn(&self) -> Ticket {
 		self.control(Control::ClearSpawnFn)
+	}
+
+	/// Set a function that replaces the normal process spawn with an arbitrary supervised child.
+	///
+	/// The function receives ownership of the prepared [`CommandWrap`] after spawn hooks have run
+	/// and returns a boxed [`ChildWrapper`](process_wrap::tokio::ChildWrapper). This supports
+	/// processes created by an external mechanism, such as a privileged launcher, which cannot
+	/// return a [`tokio::process::Child`].
+	///
+	/// Setting this clears any function previously installed with
+	/// [`set_spawn_fn`](Self::set_spawn_fn).
+	/// Since the function owns the `CommandWrap`, it is responsible for spawning it or otherwise
+	/// handling its configured process-wrap layers.
+	pub fn set_spawn_child_fn(
+		&self,
+		fun: impl Fn(CommandWrap) -> std::io::Result<Box<dyn process_wrap::tokio::ChildWrapper>>
+			+ Send
+			+ Sync
+			+ 'static,
+	) -> Ticket {
+		let spawner = Arc::clone(&self.spawner);
+		let fun = Arc::new(fun);
+		self.control(Control::SyncFunc(Box::new(move |_| {
+			spawner.set(super::task::Spawner::Child(fun));
+		})))
+	}
+
+	/// Unset any child spawn function, reverting to the default `CommandWrap::spawn()`.
+	pub fn unset_spawn_child_fn(&self) -> Ticket {
+		let spawner = Arc::clone(&self.spawner);
+		self.control(Control::SyncFunc(Box::new(move |_| {
+			spawner.set(super::task::Spawner::Default);
+		})))
 	}
 
 	/// Set the error handler.

--- a/crates/supervisor/src/job/state.rs
+++ b/crates/supervisor/src/job/state.rs
@@ -6,8 +6,10 @@ use process_wrap::tokio::CommandWrap;
 use tracing::trace;
 use watchexec_events::ProcessEnd;
 
+#[cfg(not(test))]
+use super::task::Spawner;
+use super::task::SpawnerSlot;
 use crate::command::Command;
-use super::task::SpawnFn;
 
 /// The state of the job's command / process.
 ///
@@ -73,11 +75,11 @@ impl CommandState {
 	}
 
 	#[cfg_attr(test, allow(unused_mut, unused_variables))]
-	pub(crate) fn spawn(
+	pub(super) fn spawn(
 		&mut self,
 		command: Arc<Command>,
 		mut spawnable: CommandWrap,
-		spawn_fn: Option<&SpawnFn>,
+		spawner: &SpawnerSlot,
 	) -> std::io::Result<bool> {
 		if let Self::Running { .. } = self {
 			trace!("command running, not spawning again");
@@ -90,10 +92,10 @@ impl CommandState {
 		let child = super::TestChild::new(command)?;
 
 		#[cfg(not(test))]
-		let child = if let Some(f) = spawn_fn {
-			spawnable.spawn_with(|cmd| f(cmd))?
-		} else {
-			spawnable.spawn()?
+		let child = match spawner.get() {
+			Spawner::Default => spawnable.spawn()?,
+			Spawner::Command(f) => spawnable.spawn_with(|cmd| f(cmd))?,
+			Spawner::Child(f) => f(spawnable)?,
 		};
 
 		*self = Self::Running {

--- a/crates/supervisor/src/job/task.rs
+++ b/crates/supervisor/src/job/task.rs
@@ -3,7 +3,7 @@ use std::{
 	mem::take,
 	sync::{
 		atomic::{AtomicBool, Ordering},
-		Arc,
+		Arc, Mutex,
 	},
 	time::Instant,
 };
@@ -44,6 +44,8 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 	let done = gone.clone();
 	let running = Arc::new(AtomicBool::new(false));
 	let running_flag = running.clone();
+	let spawner = Arc::new(SpawnerSlot::default());
+	let job_spawner = Arc::clone(&spawner);
 
 	(
 		Job {
@@ -51,11 +53,11 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 			control_queue: sender,
 			gone,
 			running,
+			spawner: job_spawner,
 		},
 		tokio::spawn(async move {
 			let mut error_handler = ErrorHandler::None;
 			let mut spawn_hook = SpawnHook::None;
-			let mut spawn_fn: Option<SpawnFn> = None;
 			let mut command_state = CommandState::Pending;
 			let mut previous_run = None;
 			let mut stop_timer = None;
@@ -101,7 +103,11 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 												},
 											)
 											.await;
-										if let Err(err) = command_state.spawn(command.clone(), spawnable, spawn_fn.as_ref()) {
+										if let Err(err) = command_state.spawn(
+											command.clone(),
+											spawnable,
+											&spawner,
+										) {
 											let fut = error_handler.call(sync_io_error(err));
 											fut.await;
 											return Loop::Skip;
@@ -166,7 +172,11 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 												},
 											)
 											.await;
-										try_with_handler!(command_state.spawn(command.clone(), spawnable, spawn_fn.as_ref()));
+										try_with_handler!(command_state.spawn(
+											command.clone(),
+											spawnable,
+											&spawner,
+										));
 									}
 								}
 								Control::Stop => {
@@ -232,7 +242,11 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 												},
 											)
 											.await;
-										try_with_handler!(command_state.spawn(command.clone(), spawnable, spawn_fn.as_ref()));
+										try_with_handler!(command_state.spawn(
+											command.clone(),
+											spawnable,
+											&spawner,
+										));
 									} else {
 										trace!("child isn't running, skip");
 									}
@@ -283,7 +297,11 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 											},
 										)
 										.await;
-									try_with_handler!(command_state.spawn(command.clone(), spawnable, spawn_fn.as_ref()));
+									try_with_handler!(command_state.spawn(
+										command.clone(),
+										spawnable,
+										&spawner,
+									));
 								}
 								Control::Signal(signal) => {
 									if let CommandState::Running { child, .. } = &mut command_state {
@@ -351,11 +369,11 @@ pub fn start_job(command: Arc<Command>) -> (Job, JoinHandle<()>) {
 								}
 								Control::SetSpawnFn(f) => {
 									trace!("setting spawn fn");
-									spawn_fn = Some(f);
+									spawner.set(Spawner::Command(f));
 								}
 								Control::ClearSpawnFn => {
 									trace!("clearing spawn fn");
-									spawn_fn = None;
+									spawner.set(Spawner::Default);
 								}
 							}
 
@@ -463,6 +481,60 @@ pub type SpawnFn = Arc<
 		+ Sync
 		+ 'static,
 >;
+
+/// A function that replaces the normal process spawn and returns a supervised child.
+///
+/// Unlike [`SpawnFn`], this receives ownership of the prepared [`CommandWrap`] and returns an
+/// arbitrary [`ChildWrapper`](process_wrap::tokio::ChildWrapper). This supports processes created
+/// by an external mechanism, such as a privileged launcher, which cannot return a
+/// [`tokio::process::Child`].
+///
+/// Spawn hooks have already run before this function is called. The function owns the
+/// `CommandWrap`, so it is also responsible for spawning it or otherwise handling its configured
+/// process-wrap layers.
+pub type SpawnChildFn = Arc<
+	dyn Fn(CommandWrap) -> std::io::Result<Box<dyn process_wrap::tokio::ChildWrapper>>
+		+ Send
+		+ Sync
+		+ 'static,
+>;
+
+#[derive(Clone)]
+#[cfg_attr(test, allow(dead_code))]
+pub(super) enum Spawner {
+	Default,
+	Command(SpawnFn),
+	Child(SpawnChildFn),
+}
+
+pub(super) struct SpawnerSlot(Mutex<Spawner>);
+
+impl SpawnerSlot {
+	pub(super) fn get(&self) -> Spawner {
+		self.0.lock().unwrap_or_else(|err| err.into_inner()).clone()
+	}
+
+	pub(super) fn set(&self, spawner: Spawner) {
+		*self.0.lock().unwrap_or_else(|err| err.into_inner()) = spawner;
+	}
+}
+
+impl Default for SpawnerSlot {
+	fn default() -> Self {
+		Self(Mutex::new(Spawner::Default))
+	}
+}
+
+impl std::fmt::Debug for SpawnerSlot {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		let name = match self.get() {
+			Spawner::Default => "default",
+			Spawner::Command(_) => "command",
+			Spawner::Child(_) => "child",
+		};
+		f.debug_tuple("SpawnerSlot").field(&name).finish()
+	}
+}
 
 sync_async_callbox!(SpawnHook, SyncSpawnHook, AsyncSpawnHook, (command: &mut CommandWrap, context: &JobTaskContext<'_>));
 

--- a/crates/supervisor/tests/programs.rs
+++ b/crates/supervisor/tests/programs.rs
@@ -1,10 +1,150 @@
+#[cfg(unix)]
+use std::{
+	future::Future,
+	pin::Pin,
+	process::ExitStatus,
+	sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 use std::{sync::Arc, time::Duration};
 
 use watchexec_supervisor::{
 	command::{Command, Program, Shell, SpawnOptions},
-	job::start_job,
+	job::{start_job, Job},
 	Signal,
 };
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct ExternalChild(tokio::process::Child);
+
+#[cfg(unix)]
+impl process_wrap::tokio::ChildWrapper for ExternalChild {
+	fn inner(&self) -> &dyn process_wrap::tokio::ChildWrapper {
+		panic!("external child has no wrapped Tokio child")
+	}
+
+	fn inner_mut(&mut self) -> &mut dyn process_wrap::tokio::ChildWrapper {
+		panic!("external child has no wrapped Tokio child")
+	}
+
+	fn into_inner(self: Box<Self>) -> Box<dyn process_wrap::tokio::ChildWrapper> {
+		panic!("external child has no wrapped Tokio child")
+	}
+
+	fn id(&self) -> Option<u32> {
+		self.0.id()
+	}
+
+	fn start_kill(&mut self) -> std::io::Result<()> {
+		self.0.start_kill()
+	}
+
+	fn try_wait(&mut self) -> std::io::Result<Option<ExitStatus>> {
+		self.0.try_wait()
+	}
+
+	fn wait(&mut self) -> Pin<Box<dyn Future<Output = std::io::Result<ExitStatus>> + Send + '_>> {
+		Box::pin(self.0.wait())
+	}
+}
+
+#[cfg(unix)]
+async fn wait_for_running(job: &Job, expected: bool) {
+	tokio::time::timeout(Duration::from_secs(1), async {
+		while job.is_running() != expected {
+			tokio::task::yield_now().await;
+		}
+	})
+	.await
+	.expect("job running state did not change in time");
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn custom_child_spawn_preserves_job_api() -> Result<(), std::io::Error> {
+	let command = Arc::new(Command {
+		program: Program::Exec {
+			prog: "/this/command/is/not/spawned".into(),
+			args: Vec::new(),
+		},
+		options: Default::default(),
+	});
+	let (job, task) = start_job(command);
+	let calls = Arc::new(AtomicUsize::new(0));
+	let replaced_spawn_called = Arc::new(AtomicBool::new(false));
+
+	job.set_spawn_fn({
+		let replaced_spawn_called = Arc::clone(&replaced_spawn_called);
+		move |command| {
+			replaced_spawn_called.store(true, Ordering::Relaxed);
+			command.spawn()
+		}
+	})
+	.await;
+	job.set_spawn_child_fn({
+		let calls = Arc::clone(&calls);
+		move |_command| {
+			calls.fetch_add(1, Ordering::Relaxed);
+			let mut external = tokio::process::Command::new("sleep");
+			Ok(Box::new(ExternalChild(external.arg("30").spawn()?))
+				as Box<dyn process_wrap::tokio::ChildWrapper>)
+		}
+	})
+	.await;
+	job.start().await;
+
+	wait_for_running(&job, true).await;
+	assert_eq!(calls.load(Ordering::Relaxed), 1);
+	assert!(!replaced_spawn_called.load(Ordering::Relaxed));
+
+	job.restart().await;
+	wait_for_running(&job, true).await;
+	assert_eq!(calls.load(Ordering::Relaxed), 2);
+
+	job.stop().await;
+	wait_for_running(&job, false).await;
+	task.abort();
+	Ok(())
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn existing_spawn_fn_remains_compatible() -> Result<(), std::io::Error> {
+	let command = Arc::new(Command {
+		program: Program::Exec {
+			prog: "sleep".into(),
+			args: vec!["30".into()],
+		},
+		options: Default::default(),
+	});
+	let (job, task) = start_job(command);
+	let called = Arc::new(AtomicBool::new(false));
+	let replaced_spawn_called = Arc::new(AtomicBool::new(false));
+
+	job.set_spawn_child_fn({
+		let replaced_spawn_called = Arc::clone(&replaced_spawn_called);
+		move |_command| {
+			replaced_spawn_called.store(true, Ordering::Relaxed);
+			panic!("replaced child spawn function ran")
+		}
+	})
+	.await;
+	job.set_spawn_fn({
+		let called = Arc::clone(&called);
+		move |command| {
+			called.store(true, Ordering::Relaxed);
+			command.spawn()
+		}
+	})
+	.await;
+	job.start().await;
+
+	assert!(called.load(Ordering::Relaxed));
+	assert!(!replaced_spawn_called.load(Ordering::Relaxed));
+	job.stop().await;
+	task.abort();
+	Ok(())
+}
 
 #[tokio::test]
 #[cfg(unix)]


### PR DESCRIPTION
supperseeds #1033 

## Summary

- add a public SpawnChildFn callback that takes ownership of the prepared CommandWrap and returns an arbitrary ChildWrapper
- add Job methods to install and remove the external-child spawner
- preserve the existing spawn function, lifecycle controls, and public Control enum
- verify start, running-state reporting, restart, and stop with an opaque externally spawned child

## Motivation

Some launchers create a process outside Tokio Command::spawn and therefore cannot return tokio::process::Child. One example is a privileged broker that grants a constrained set of Linux capabilities, drops back to the invoking user, and returns a handle implementing ChildWrapper.

Accepting a ChildWrapper lets these launchers retain watchexec-supervisor lifecycle management without requiring changes to process-wrap or exposing launcher-specific concepts in the supervisor API.

The existing set_spawn_fn API remains compatible. The two custom spawn modes replace one another, and clearing either restores the default CommandWrap::spawn behavior.

## Testing

- cargo test -p watchexec-supervisor: 40 tests passed
- downstream lifecycle validation in devenv: 148 process tests and 167 task tests passed

## AI assistance disclosure

This change was developed and reviewed with assistance from OpenAI Codex.